### PR TITLE
Scroll to current reply section after new replies are added

### DIFF
--- a/pages/article.js
+++ b/pages/article.js
@@ -51,12 +51,14 @@ function RelatedArticleItem({ article }) {
 class ArticlePage extends React.Component {
   handleConnect = ({ target: { value: replyId } }) => {
     const { dispatch, query: { id } } = this.props;
-    return dispatch(connectReply(id, replyId));
+    return dispatch(connectReply(id, replyId)).then(this.scrollToReplySection);
   };
 
   handleSubmit = reply => {
     const { dispatch, query: { id } } = this.props;
-    return dispatch(submitReply({ ...reply, articleId: id }));
+    return dispatch(submitReply({ ...reply, articleId: id })).then(
+      this.scrollToReplySection
+    );
   };
 
   handleReplyConnectionDelete = replyConnectionId => {
@@ -70,7 +72,12 @@ class ArticlePage extends React.Component {
     const { dispatch, query: { id } } = this.props;
     return dispatch(
       updateReplyConnectionStatus(id, replyConnectionId, 'NORMAL')
-    );
+    ).then(this.scrollToReplySection);
+  };
+
+  scrollToReplySection = () => {
+    if (!this._replySectionEl) return;
+    this._replySectionEl.scrollIntoView({ behavior: 'smooth' });
   };
 
   getStructuredData = () => {
@@ -150,7 +157,11 @@ class ArticlePage extends React.Component {
           <div className="message">{nl2br(article.get('text'))}</div>
         </section>
 
-        <section className="section">
+        <section
+          id="current-replies"
+          className="section"
+          ref={replySectionEl => (this._replySectionEl = replySectionEl)}
+        >
           <h2>現有回應</h2>
           <CurrentReplies
             replyConnections={replyConnections}


### PR DESCRIPTION
Fixes #29 .

In the end, we does sorting in API server ( see https://github.com/cofacts/rumors-api/pull/46 ), so we only handles automatic scrolling here:

![auto-jump](https://user-images.githubusercontent.com/108608/29202545-ca7deab0-7e9b-11e7-8356-ceaecddad2ac.gif)
