### PR TITLE
Barebone for reply list

### DIFF
--- a/components/ListPage.js
+++ b/components/ListPage.js
@@ -5,44 +5,42 @@ import url from 'url';
 // Super class for list pages
 //
 export default class ListPage extends React.Component {
-  handleOrderByChange = e => {
+  goToQuery = (newQuery, resetPage = true) => {
+    const resetObj = resetPage
+      ? {
+          before: undefined,
+          after: undefined,
+        }
+      : {};
+
     Router.push(
       `${location.pathname}${url.format({
         query: {
           ...this.props.query,
-          orderBy: e.target.value,
-          before: undefined,
-          after: undefined,
+          ...resetObj,
+          ...newQuery,
         },
       })}`
     );
   };
 
+  handleOrderByChange = e => {
+    this.goToQuery({
+      orderBy: e.target.value,
+    });
+  };
+
   handleFilterChange = value => {
-    Router.push(
-      `${location.pathname}${url.format({
-        query: {
-          ...this.props.query,
-          filter: value,
-          before: undefined,
-          after: undefined,
-        },
-      })}`
-    );
+    this.goToQuery({
+      filter: value,
+    });
   };
 
   handleKeywordChange = e => {
     const { value } = e.target;
-    Router.push(
-      `${location.pathname}${url.format({
-        query: {
-          ...this.props.query,
-          q: value,
-          before: undefined,
-          after: undefined,
-        },
-      })}`
-    );
+    this.goToQuery({
+      q: value,
+    });
   };
 
   handleKeywordKeyup = e => {

--- a/components/ListPage.js
+++ b/components/ListPage.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import Router from 'next/router';
+import url from 'url';
+
+// Super class for list pages
+//
+export default class ListPage extends React.Component {
+  handleOrderByChange = e => {
+    Router.push(
+      `${location.pathname}${url.format({
+        query: {
+          ...this.props.query,
+          orderBy: e.target.value,
+          before: undefined,
+          after: undefined,
+        },
+      })}`
+    );
+  };
+
+  handleFilterChange = value => {
+    Router.push(
+      `${location.pathname}${url.format({
+        query: {
+          ...this.props.query,
+          filter: value,
+          before: undefined,
+          after: undefined,
+        },
+      })}`
+    );
+  };
+
+  handleKeywordChange = e => {
+    const { value } = e.target;
+    Router.push(
+      `${location.pathname}${url.format({
+        query: {
+          ...this.props.query,
+          q: value,
+          before: undefined,
+          after: undefined,
+        },
+      })}`
+    );
+  };
+
+  handleKeywordKeyup = e => {
+    if (e.which === 13) {
+      return this.handleKeywordChange(e);
+    }
+  };
+}

--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -3,7 +3,7 @@ import { connect } from 'react-redux';
 import Link from 'next/link';
 import url from 'url';
 
-function Pagination({
+export default function Pagination({
   query = {}, // URL params
   firstCursor,
   lastCursor,
@@ -38,14 +38,3 @@ function Pagination({
     </p>
   );
 }
-
-function mapStateToProps({ articleList }) {
-  return {
-    firstCursor: articleList.get('firstCursor'),
-    lastCursor: articleList.get('lastCursor'),
-    firstCursorOfPage: articleList.getIn(['edges', 0, 'cursor']),
-    lastCursorOfPage: articleList.getIn(['edges', -1, 'cursor']),
-  };
-}
-
-export default connect(mapStateToProps)(Pagination);

--- a/pages/index.js
+++ b/pages/index.js
@@ -66,11 +66,30 @@ class Index extends ListPage {
     );
   };
 
+  renderPagination = () => {
+    const {
+      query = {}, // URL params
+      firstCursor,
+      lastCursor,
+      firstCursorOfPage,
+      lastCursorOfPage,
+    } = this.props;
+
+    return (
+      <Pagination
+        query={query}
+        firstCursor={firstCursor}
+        lastCursor={lastCursor}
+        firstCursorOfPage={firstCursorOfPage}
+        lastCursorOfPage={lastCursorOfPage}
+      />
+    );
+  };
+
   render() {
     const {
       isLoading = false,
       articles = null,
-      query,
       totalCount,
       authFields,
     } = this.props;
@@ -93,7 +112,7 @@ class Index extends ListPage {
         {this.renderFilter()}
 
         <p>{totalCount} articles</p>
-        <Pagination query={query} />
+        {this.renderPagination()}
         <div className="article-list">
           {articles.map(article =>
             <ArticleItem
@@ -104,7 +123,7 @@ class Index extends ListPage {
           )}
         </div>
         {isLoading ? <p>Loading in background...</p> : ''}
-        <Pagination query={query} />
+        {this.renderPagination()}
 
         <style jsx>{mainStyle}</style>
         <style jsx>{`
@@ -124,6 +143,10 @@ function mapStateToProps({ articleList }) {
       .map(edge => edge.get('node')),
     authFields: articleList.get('authFields'),
     totalCount: articleList.get('totalCount'),
+    firstCursor: articleList.get('firstCursor'),
+    lastCursor: articleList.get('lastCursor'),
+    firstCursorOfPage: articleList.getIn(['edges', 0, 'cursor']),
+    lastCursorOfPage: articleList.getIn(['edges', -1, 'cursor']),
   };
 }
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,67 +1,69 @@
+/* eslint-disable react/display-name */
+// https://github.com/yannickcr/eslint-plugin-react/issues/1200
+
 import React from 'react';
 import { connect } from 'react-redux';
 import { compose } from 'redux';
 import Head from 'next/head';
-import Router from 'next/router';
 import { List } from 'immutable';
-import url from 'url';
 import { RadioGroup, Radio } from 'react-radio-group';
 
 import app from '../components/App';
+import ListPage from '../components/ListPage';
 import Pagination from '../components/Pagination';
 import ArticleItem from '../components/ArticleItem';
 import { load, loadAuthFields } from '../redux/articleList';
 
-class Index extends React.Component {
+import { mainStyle } from './index.styles';
+
+class Index extends ListPage {
   componentDidMount() {
     // Browser-only
     this.props.dispatch(loadAuthFields(this.props.query));
   }
 
-  handleOrderByChange = e => {
-    Router.push(
-      `/${url.format({
-        query: {
-          ...this.props.query,
-          orderBy: e.target.value,
-          before: undefined,
-          after: undefined,
-        },
-      })}`
+  renderSearch = () => {
+    const { query: { q } } = this.props;
+    return (
+      <label>
+        Search For:
+        <input
+          type="search"
+          onBlur={this.handleKeywordChange}
+          onKeyUp={this.handleKeywordKeyup}
+          defaultValue={q}
+        />
+      </label>
     );
   };
 
-  handleFilterChange = value => {
-    Router.push(
-      `/${url.format({
-        query: {
-          ...this.props.query,
-          filter: value,
-          before: undefined,
-          after: undefined,
-        },
-      })}`
+  renderOrderBy = () => {
+    const { query: { orderBy } } = this.props;
+    return (
+      <select
+        onChange={this.handleOrderByChange}
+        value={orderBy || 'replyRequestCount'}
+      >
+        <option value="replyRequestCount">Most asked</option>
+        <option value="createdAt">Most recently asked</option>
+        <option value="updatedAt">Latest updated</option>
+      </select>
     );
   };
 
-  handleKeywordChange = e => {
-    const { value } = e.target;
-    Router.push(
-      `/${url.format({
-        query: {
-          ...this.props.query,
-          q: value,
-          before: undefined,
-          after: undefined,
-        },
-      })}`
+  renderFilter = () => {
+    const { query: { filter } } = this.props;
+    return (
+      <RadioGroup
+        onChange={this.handleFilterChange}
+        selectedValue={filter || 'all'}
+        Component="ul"
+      >
+        <li><label><Radio value="all" />All</label></li>
+        <li><label><Radio value="unsolved" />Not replied yet</label></li>
+        <li><label><Radio value="solved" />Replied</label></li>
+      </RadioGroup>
     );
-  };
-
-  handleKeywordKeyup = e => {
-    if (e.which === 13) {
-      return this.handleKeywordChange(e);
-    }
   };
 
   render() {
@@ -83,36 +85,12 @@ class Index extends React.Component {
           <title>文章列表</title>
         </Head>
 
-        <label>
-          Search For:
-          <input
-            type="search"
-            onBlur={this.handleKeywordChange}
-            onKeyUp={this.handleKeywordKeyup}
-            defaultValue={query.q}
-          />
-        </label>
+        {this.renderSearch()}
         <br />
 
         Order By:
-        <select
-          onChange={this.handleOrderByChange}
-          value={query.orderBy || 'replyRequestCount'}
-        >
-          <option value="replyRequestCount">Most asked</option>
-          <option value="createdAt">Most recently asked</option>
-          <option value="updatedAt">Latest updated</option>
-        </select>
-
-        <RadioGroup
-          onChange={this.handleFilterChange}
-          selectedValue={query.filter || 'all'}
-          Component="ul"
-        >
-          <li><label><Radio value="all" />All</label></li>
-          <li><label><Radio value="unsolved" />Not replied yet</label></li>
-          <li><label><Radio value="solved" />Replied</label></li>
-        </RadioGroup>
+        {this.renderOrderBy()}
+        {this.renderFilter()}
 
         <p>{totalCount} articles</p>
         <Pagination query={query} />
@@ -128,15 +106,8 @@ class Index extends React.Component {
         {isLoading ? <p>Loading in background...</p> : ''}
         <Pagination query={query} />
 
+        <style jsx>{mainStyle}</style>
         <style jsx>{`
-          main {
-            padding: 24px;
-          }
-          @media screen and (min-width: 768px) {
-            main {
-              padding: 40px;
-            }
-          }
           .article-list {
             padding: 0;
           }

--- a/pages/index.js
+++ b/pages/index.js
@@ -86,17 +86,37 @@ class Index extends ListPage {
     );
   };
 
-  render() {
+  renderList = () => {
     const {
-      isLoading = false,
       articles = null,
       totalCount,
       authFields,
     } = this.props;
+    return (
+      <div>
+        <p>{totalCount} articles</p>
+        {this.renderPagination()}
+        <div className="article-list">
+          {articles.map(article =>
+            <ArticleItem
+              key={article.get('id')}
+              article={article}
+              requestedForReply={authFields.get(article.get('id'))}
+            />
+          )}
+        </div>
+        {this.renderPagination()}
+        <style jsx>{`
+          .article-list {
+            padding: 0;
+          }
+        `}</style>
+      </div>
+    );
+  };
 
-    if (isLoading && articles === null) {
-      return <div>Loading...</div>;
-    }
+  render() {
+    const { isLoading = false } = this.props;
 
     return (
       <main>
@@ -111,26 +131,10 @@ class Index extends ListPage {
         {this.renderOrderBy()}
         {this.renderFilter()}
 
-        <p>{totalCount} articles</p>
-        {this.renderPagination()}
-        <div className="article-list">
-          {articles.map(article =>
-            <ArticleItem
-              key={article.get('id')}
-              article={article}
-              requestedForReply={authFields.get(article.get('id'))}
-            />
-          )}
-        </div>
-        {isLoading ? <p>Loading in background...</p> : ''}
-        {this.renderPagination()}
+        {isLoading ? <p>Loading...</p> : this.renderList()}
 
         <style jsx>{mainStyle}</style>
-        <style jsx>{`
-          .article-list {
-            padding: 0;
-          }
-        `}</style>
+
       </main>
     );
   }

--- a/pages/index.styles.js
+++ b/pages/index.styles.js
@@ -1,0 +1,10 @@
+export const mainStyle = `
+  main {
+    padding: 24px;
+  }
+  @media screen and (min-width: 768px) {
+    main {
+      padding: 40px;
+    }
+  }
+`;

--- a/pages/replies.js
+++ b/pages/replies.js
@@ -1,0 +1,167 @@
+/* eslint-disable react/display-name */
+// https://github.com/yannickcr/eslint-plugin-react/issues/1200
+
+import React from 'react';
+import { connect } from 'react-redux';
+import { compose } from 'redux';
+import Head from 'next/head';
+import { List } from 'immutable';
+import { RadioGroup, Radio } from 'react-radio-group';
+import { load } from '../redux/replyList';
+
+import { TYPE_NAME, TYPE_DESC } from '../constants/replyType';
+
+import app from '../components/App';
+import ListPage from '../components/ListPage';
+import Pagination from '../components/Pagination';
+
+import { mainStyle } from './index.styles';
+
+class ReplyList extends ListPage {
+  handleMyReplyOnlyCheck = e => {
+    this.goToQuery({
+      mine: e.target.checked ? 1 : undefined,
+    });
+  };
+
+  renderSearch = () => {
+    const { query: { q } } = this.props;
+    return (
+      <label>
+        Search For:
+        <input
+          type="search"
+          onBlur={this.handleKeywordChange}
+          onKeyUp={this.handleKeywordKeyup}
+          defaultValue={q}
+        />
+      </label>
+    );
+  };
+
+  renderOrderBy = () => {
+    const { query: { orderBy } } = this.props;
+
+    return (
+      <select
+        onChange={this.handleOrderByChange}
+        value={orderBy || 'createdAt_DESC'}
+      >
+        <option value="createdAt_DESC">Most recently written</option>
+        <option value="createdAt_ASC">Least recently written</option>
+      </select>
+    );
+  };
+
+  renderMyReplyOnlyCheckbox() {
+    const { isLoggedIn } = this.props;
+    if (!isLoggedIn) return null;
+
+    return (
+      <label>
+        <input type="checkbox" onChange={this.handleMyReplyOnlyCheck} />
+        只顯示我寫的
+      </label>
+    );
+  }
+
+  renderFilter = () => {
+    const { query: { filter } } = this.props;
+    return (
+      <RadioGroup
+        onChange={this.handleFilterChange}
+        selectedValue={filter || 'all'}
+        Component="ul"
+      >
+        <li><label><Radio value="all" />All</label></li>
+        {['NOT_ARTICLE', 'OPINIONATED', 'NOT_RUMOR', 'RUMOR'].map(type =>
+          <li key={type}>
+            <label>
+              <Radio value={type} title={TYPE_DESC[type]} />
+              {TYPE_NAME[type]}
+            </label>
+          </li>
+        )}
+      </RadioGroup>
+    );
+  };
+
+  renderPagination = () => {
+    const {
+      query = {}, // URL params
+      firstCursor,
+      lastCursor,
+      firstCursorOfPage,
+      lastCursorOfPage,
+    } = this.props;
+
+    return (
+      <Pagination
+        query={query}
+        firstCursor={firstCursor}
+        lastCursor={lastCursor}
+        firstCursorOfPage={firstCursorOfPage}
+        lastCursorOfPage={lastCursorOfPage}
+      />
+    );
+  };
+
+  render() {
+    const { isLoading = false, replies = null, totalCount } = this.props;
+
+    if (isLoading && replies === null) {
+      return <div>Loading...</div>;
+    }
+
+    return (
+      <main>
+        <Head>
+          <title>回應列表</title>
+        </Head>
+
+        {this.renderSearch()}
+        <br />
+
+        Order By:
+        {this.renderOrderBy()}
+        {this.renderFilter()}
+        {this.renderMyReplyOnlyCheckbox()}
+
+        <p>{totalCount} replies</p>
+        {this.renderPagination()}
+        <div>
+          <pre>
+            {JSON.stringify(replies, null, '  ')}
+          </pre>
+
+        </div>
+        {this.renderPagination()}
+
+        <style jsx>{mainStyle}</style>
+        <style jsx>{`
+          .article-list {
+            padding: 0;
+          }
+        `}</style>
+      </main>
+    );
+  }
+}
+
+function mapStateToProps({ replyList, auth }) {
+  return {
+    isLoggedIn: !!auth.get('user'),
+    isLoading: replyList.getIn(['state', 'isLoading']),
+    replies: (replyList.get('edges') || List()).map(edge => edge.get('node')),
+    totalCount: replyList.get('totalCount'),
+    firstCursor: replyList.get('firstCursor'),
+    lastCursor: replyList.get('lastCursor'),
+    firstCursorOfPage: replyList.getIn(['edges', 0, 'cursor']),
+    lastCursorOfPage: replyList.getIn(['edges', -1, 'cursor']),
+  };
+}
+
+export default compose(
+  app((dispatch, { query }) => dispatch(load(query))),
+  connect(mapStateToProps)
+)(ReplyList);

--- a/pages/replies.js
+++ b/pages/replies.js
@@ -167,7 +167,19 @@ function mapStateToProps({ replyList, auth }) {
   };
 }
 
-export default compose(
-  app((dispatch, { query }) => dispatch(load(query))),
-  connect(mapStateToProps)
-)(ReplyList);
+function initFn(dispatch, { query }) {
+  // Load on server-side render only when query.mine is not set.
+  // This makes sure that reply list can be crawled by search engines too, and it can load fast
+  if (query.mine && typeof window === 'undefined') return;
+  return dispatch(load(query));
+}
+
+function bootstrapFn(dispatch, { query }) {
+  // Pick up initial data loading when server-side render skips
+  if (!query.mine) return;
+  return dispatch(load(query));
+}
+
+export default compose(app(initFn, bootstrapFn), connect(mapStateToProps))(
+  ReplyList
+);

--- a/pages/replies.js
+++ b/pages/replies.js
@@ -106,12 +106,26 @@ class ReplyList extends ListPage {
     );
   };
 
-  render() {
-    const { isLoading = false, replies = null, totalCount } = this.props;
+  renderList = () => {
+    const { replies = null, totalCount } = this.props;
+    return (
+      <div>
+        <p>{totalCount} replies</p>
+        {this.renderPagination()}
+        <div>
+          <pre>
+            {JSON.stringify(replies, null, '  ')}
+          </pre>
 
-    if (isLoading && replies === null) {
-      return <div>Loading...</div>;
-    }
+        </div>
+        {this.renderPagination()}
+
+      </div>
+    );
+  };
+
+  render() {
+    const { isLoading = false } = this.props;
 
     return (
       <main>
@@ -127,15 +141,7 @@ class ReplyList extends ListPage {
         {this.renderFilter()}
         {this.renderMyReplyOnlyCheckbox()}
 
-        <p>{totalCount} replies</p>
-        {this.renderPagination()}
-        <div>
-          <pre>
-            {JSON.stringify(replies, null, '  ')}
-          </pre>
-
-        </div>
-        {this.renderPagination()}
+        {isLoading ? <p>Loading...</p> : this.renderList()}
 
         <style jsx>{mainStyle}</style>
         <style jsx>{`

--- a/pages/replies.js
+++ b/pages/replies.js
@@ -54,12 +54,16 @@ class ReplyList extends ListPage {
   };
 
   renderMyReplyOnlyCheckbox() {
-    const { isLoggedIn } = this.props;
+    const { isLoggedIn, query: { mine } } = this.props;
     if (!isLoggedIn) return null;
 
     return (
       <label>
-        <input type="checkbox" onChange={this.handleMyReplyOnlyCheck} />
+        <input
+          type="checkbox"
+          onChange={this.handleMyReplyOnlyCheck}
+          checked={!!mine}
+        />
         只顯示我寫的
       </label>
     );

--- a/redux/articleDetail.js
+++ b/redux/articleDetail.js
@@ -1,5 +1,6 @@
 import { createDuck } from 'redux-duck';
 import { fromJS, Map, List, OrderedMap, Set } from 'immutable';
+import { waitForAuth } from './auth';
 import gql from '../util/gql';
 import NProgress from 'nprogress';
 
@@ -92,19 +93,23 @@ export const load = id => dispatch => {
 
 export const loadAuth = id => dispatch => {
   dispatch(setState({ key: 'isAuthLoading', value: true }));
-  return gql`
-    query($id: String!) {
-      GetArticle(id: $id) {
-        replyConnections {
-          id
-          canUpdateStatus
+  return waitForAuth
+    .then(() =>
+      gql`
+        query($id: String!) {
+          GetArticle(id: $id) {
+            replyConnections {
+              id
+              canUpdateStatus
+            }
+          }
         }
-      }
-    }
-  `({ id }).then(resp => {
-    dispatch(createAction(LOAD_AUTH)(resp.getIn(['data', 'GetArticle'])));
-    dispatch(setState({ key: 'isAuthLoading', value: false }));
-  });
+      `({ id })
+    )
+    .then(resp => {
+      dispatch(createAction(LOAD_AUTH)(resp.getIn(['data', 'GetArticle'])));
+      dispatch(setState({ key: 'isAuthLoading', value: false }));
+    });
 };
 
 export const reset = () => createAction(RESET);

--- a/redux/auth.js
+++ b/redux/auth.js
@@ -4,6 +4,7 @@ import { createDuck } from 'redux-duck';
 import { fromJS } from 'immutable';
 import fetchAPI from '../util/fetchAPI';
 import gql from '../util/gql';
+import { commonSetState } from '../util/reducer';
 
 const { defineType, createAction, createReducer } = createDuck('auth');
 
@@ -67,8 +68,7 @@ const initialState = fromJS({
 
 const reducer = createReducer(
   {
-    [SET_STATE]: (state, { payload: { key, value } }) =>
-      state.setIn(['state', key], value),
+    [SET_STATE]: commonSetState,
     [LOAD]: (state, { payload }) => state.set('user', payload),
     [RESET]: state => state.set('user', initialState.get('user')),
   },

--- a/redux/index.js
+++ b/redux/index.js
@@ -4,11 +4,13 @@ import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 import thunk from 'redux-thunk';
 
 import articleList from './articleList';
+import replyList from './replyList';
 import articleDetail from './articleDetail';
 import auth from './auth';
 
 const reducers = combineReducers({
   articleList,
+  replyList,
   articleDetail,
   auth,
 });

--- a/redux/replyList.js
+++ b/redux/replyList.js
@@ -120,7 +120,12 @@ export default createReducer(
         .set(
           'edges',
           (payload.get('edges') || List())
-            .map(edge => edge.setIn(['node', 'replyConnectionCount']))
+            .map(edge =>
+              edge.setIn(
+                ['node', 'replyConnectionCount'],
+                (edge.getIn(['node', 'replyConnections']) || List()).size
+              )
+            )
         )
         .set(
           'firstCursor',

--- a/redux/replyList.js
+++ b/redux/replyList.js
@@ -1,0 +1,161 @@
+import { createDuck } from 'redux-duck';
+import { fromJS, List } from 'immutable';
+import gql from '../util/gql';
+
+const COSTY_FIELD_COOLDOWN = 60 * 1000; // in seconds. query costy fields only 1 time within 60 seconds
+
+const { defineType, createReducer, createAction } = createDuck('replyList');
+
+// Action Types
+//
+
+const LOAD = defineType('LOAD');
+
+// Action creators
+//
+
+let isInCooldown = false;
+let lastStringifiedFilter;
+export const load = ({
+  q,
+  filter = 'all',
+  orderBy = 'createdAt_DESC',
+  mine,
+  before,
+  after,
+}) => dispatch => {
+  filter = getFilterObject(filter, q, mine);
+  const stringifiedFilter = JSON.stringify(filter);
+
+  if (lastStringifiedFilter !== stringifiedFilter) {
+    // Invalidate costy field cache when filter changes
+    isInCooldown = false;
+  }
+
+  lastStringifiedFilter = stringifiedFilter;
+
+  // If there is query text, sort by _score first
+
+  const [orderByField, orderByDirection] = orderBy.split('_');
+
+  const orderByArray = q
+    ? [{ _score: 'DESC' }, { [orderByField]: orderByDirection }]
+    : [{ [orderByField]: orderByDirection }];
+
+  return gql`query(
+    $filter: ListReplyFilter,
+    $orderBy: [ListReplyOrderBy],
+    $before: String,
+    $after: String,
+  ) {
+    ListReplies(
+      filter: $filter
+      orderBy: $orderBy
+      before: $before
+      after: $after
+      first: 25
+    ) {
+      edges {
+        node {
+          id
+          versions(limit: 1) {
+            user { name }
+            reference
+            text
+            type
+            createdAt
+          }
+          replyConnections { id }
+        }
+        cursor
+      }
+
+      ${isInCooldown
+        ? ''
+        : /* costy fields */ `
+          pageInfo {
+            firstCursor
+            lastCursor
+          }
+          totalCount
+        `}
+    }
+  }`({
+    filter,
+    orderBy: orderByArray,
+    before,
+    after,
+  }).then(resp => {
+    // only ignore costy fields on browser.
+    //
+    if (typeof window !== 'undefined' && !isInCooldown) {
+      isInCooldown = true;
+      setTimeout(resetCooldown, COSTY_FIELD_COOLDOWN);
+    }
+    dispatch(createAction(LOAD)(resp.getIn(['data', 'ListReplies'], List())));
+  });
+};
+
+// Reducer
+//
+
+const initialState = fromJS({
+  state: { isLoading: false },
+  edges: null,
+  firstCursor: null,
+  lastCursor: null,
+  totalCount: null,
+});
+
+export default createReducer(
+  {
+    [LOAD]: (state, { payload }) =>
+      state
+        .set(
+          'edges',
+          (payload.get('edges') || List())
+            .map(edge => edge.setIn(['node', 'replyConnectionCount']))
+        )
+        .set(
+          'firstCursor',
+          payload.getIn(['pageInfo', 'firstCursor']) || state.get('firstCursor')
+        )
+        .set(
+          'lastCursor',
+          payload.getIn(['pageInfo', 'lastCursor']) || state.get('lastCursor')
+        )
+        .set(
+          'totalCount',
+          payload.get('totalCount') || state.get('totalCount')
+        ),
+  },
+  initialState
+);
+
+// Util
+//
+
+function resetCooldown() {
+  isInCooldown = false;
+}
+
+function getFilterObject(filter, q, mine) {
+  const filterObj = {};
+  if (q) {
+    filterObj.moreLikeThis = { like: q, minimumShouldMatch: '0' };
+  }
+
+  if (filter !== 'all') {
+    filterObj.type = filter;
+  }
+
+  if (mine) {
+    filterObj.selfOnly = true;
+  }
+
+  // Return filterObj only when it is populated.
+  if (!Object.keys(filterObj).length) {
+    return undefined;
+  }
+  return filterObj;
+}

--- a/util/reducer.js
+++ b/util/reducer.js
@@ -1,0 +1,2 @@
+export const commonSetState = (state, { payload: { key, value } }) =>
+  state.setIn(['state', key], value);


### PR DESCRIPTION
Related to #32.

**Reply list**

![normal-reply-list](https://user-images.githubusercontent.com/108608/29496366-a6268f0e-8603-11e7-8c72-fc7fe0f22509.gif)

- - -

**Mine-only reply list for logged-in people**

![mine-only](https://user-images.githubusercontent.com/108608/29496415-bd3f5b70-8604-11e7-992c-57f4f3f3f87e.gif)


- - -

# Implements
- Barebone for reply list component
- Reply list data-loading logic

# Refactors
- Article list and reply list both inherits from `ListPage`, which implements all change handlers for filter / sorting.
- Move styles shared by Article list and reply list to `index.styles.js`
- Refactor render functions in article list to match reply list's implementation
- Remove `connect` on `<Pagination />` so that it can be also used in reply list
- Set / Read "isLoading" state for article list and reply list
