### PR TITLE
New filter / sorting defaults for article list

### DIFF
--- a/components/ListPage.js
+++ b/components/ListPage.js
@@ -37,7 +37,9 @@ export default class ListPage extends React.Component {
   };
 
   handleKeywordChange = e => {
+    const { q = '' } = this.props.query;
     const { value } = e.target;
+    if (q === value) return;
     this.goToQuery({
       q: value,
     });

--- a/components/ListPage.js
+++ b/components/ListPage.js
@@ -45,7 +45,7 @@ export default class ListPage extends React.Component {
 
   handleKeywordKeyup = e => {
     if (e.which === 13) {
-      return this.handleKeywordChange(e);
+      e.target.blur(); // Triggers onBlur
     }
   };
 }

--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -11,24 +11,24 @@ export default function Pagination({
 }) {
   return (
     <p>
-      {firstCursor === firstCursorOfPage
-        ? ''
-        : <Link
+      {firstCursor && firstCursor !== firstCursorOfPage
+        ? <Link
             href={url.format({
               query: { ...query, before: firstCursorOfPage, after: undefined },
             })}
           >
             <a>Prev</a>
-          </Link>}
-      {lastCursor === lastCursorOfPage
-        ? ''
-        : <Link
+          </Link>
+        : ''}
+      {lastCursor && lastCursor !== lastCursorOfPage
+        ? <Link
             href={url.format({
               query: { ...query, after: lastCursorOfPage, before: undefined },
             })}
           >
             <a>Next</a>
-          </Link>}
+          </Link>
+        : ''}
       <style jsx>{`
         a {
           padding: 8px;

--- a/pages/index.js
+++ b/pages/index.js
@@ -46,11 +46,10 @@ class Index extends ListPage {
     return (
       <select
         onChange={this.handleOrderByChange}
-        value={orderBy || 'replyRequestCount'}
+        value={orderBy || 'createdAt'}
       >
-        <option value="replyRequestCount">Most asked</option>
         <option value="createdAt">Most recently asked</option>
-        <option value="updatedAt">Latest updated</option>
+        <option value="replyRequestCount">Most asked</option>
       </select>
     );
   };
@@ -60,12 +59,12 @@ class Index extends ListPage {
     return (
       <RadioGroup
         onChange={this.handleFilterChange}
-        selectedValue={filter || 'all'}
+        selectedValue={filter || 'unsolved'}
         Component="ul"
       >
-        <li><label><Radio value="all" />All</label></li>
         <li><label><Radio value="unsolved" />Not replied yet</label></li>
         <li><label><Radio value="solved" />Replied</label></li>
+        <li><label><Radio value="all" />All</label></li>
       </RadioGroup>
     );
   };

--- a/redux/articleList.js
+++ b/redux/articleList.js
@@ -28,8 +28,8 @@ export const load = ({
   before,
   after,
 }) => dispatch => {
-  filter = getFilterObject(filter, q);
-  const stringifiedFilter = JSON.stringify(filter);
+  const filterObject = getFilterObject(filter, q);
+  const stringifiedFilter = JSON.stringify(filterObject);
 
   if (lastStringifiedFilter !== stringifiedFilter) {
     // Invalidate costy field cache when filter changes
@@ -82,7 +82,7 @@ export const load = ({
         `}
     }
   }`({
-    filter,
+    filter: filterObject,
     orderBy: orderByArray,
     before,
     after,

--- a/redux/articleList.js
+++ b/redux/articleList.js
@@ -23,8 +23,8 @@ let isInCooldown = false;
 let lastStringifiedFilter;
 export const load = ({
   q,
-  filter = 'all',
-  orderBy = 'replyRequestCount',
+  filter = 'unsolved',
+  orderBy = 'createdAt',
   before,
   after,
 }) => dispatch => {

--- a/redux/articleList.js
+++ b/redux/articleList.js
@@ -164,15 +164,21 @@ export default createReducer(
         .set('edges', payload.get('edges'))
         .set(
           'firstCursor',
-          payload.getIn(['pageInfo', 'firstCursor']) || state.get('firstCursor')
+          payload.getIn(['pageInfo', 'firstCursor']) === undefined
+            ? state.get('firstCursor')
+            : payload.getIn(['pageInfo', 'firstCursor'])
         )
         .set(
           'lastCursor',
-          payload.getIn(['pageInfo', 'lastCursor']) || state.get('lastCursor')
+          payload.getIn(['pageInfo', 'lastCursor']) === undefined
+            ? state.get('lastCursor')
+            : payload.getIn(['pageInfo', 'lastCursor'])
         )
         .set(
           'totalCount',
-          payload.get('totalCount') || state.get('totalCount')
+          payload.get('totalCount') === undefined
+            ? state.get('totalCount')
+            : payload.get('totalCount')
         ),
     [LOAD_AUTH_FIELDS]: (state, { payload }) =>
       state.set(


### PR DESCRIPTION
Changes:
1. Remove "Latest updated" sorting. It's basically equivalent to "Most recently asked", because `updatedAt` field in BE API never updates.
2. Make "Most recently asked" the default sorting mechanism. Reasons:
    * It makes our homepage (article list) looks different upon every visit, making the site visitors aware of new articles & feel that this site is updated often.
    * Veteran editors rely on "Most recently asked" sorting very much, so we can just make it default
    * If an article is "Most asked" but is not answered yet, it must be so difficult that it scares new editors away. Sticking with "Most recently asked" makes their lives easier.
3. Make "Not replied yet" the default filter. Reasons:
    * We used "all" as default filter several months ago because at that time, there are too few "replied" articles, so "all" and "not replied yet" are almost equivalent back then. With almost 8000 replied articles, this is no longer the case.
    * Most visitors to the article page are editors, they look for "Not replied yet" articles most of the time.

![2017-09-03 11 42 41](https://user-images.githubusercontent.com/108608/30004434-abac5f5e-9101-11e7-9475-5aa5b11c42fc.png)

This PR also fixes several bugs regarding pagination & filtering, please see individual commits for bugfix details