### PR TITLE
Refactor <ExpandableText>

### DIFF
--- a/components/ExpandableText.js
+++ b/components/ExpandableText.js
@@ -1,48 +1,29 @@
 import React from 'react';
-import { nl2br, linkify } from '../util/text';
+import { truncate } from '../util/text';
 
 export default class ExpandableText extends React.Component {
   static defaultProps = {
     children: '',
-    lines: 3,
+    wordCount: 140,
   };
 
-  constructor({ children }) {
-    super();
-
-    if (typeof children !== 'string') {
-      throw new Error('<ExpandableText> only accepts string children.');
-    }
-
-    this.state = {
-      isExpanded: false,
-    };
-  }
+  state = {
+    isExpanded: false,
+  };
 
   toggleExapnd = () => {
-    this.setState({ isExpanded: !this.state.isExpanded });
+    this.setState(({ isExpanded }) => ({ isExpanded: !isExpanded }));
   };
 
-  render() {
-    const { children, lines } = this.props;
+  renderToggleButton = () => {
     const { isExpanded } = this.state;
-    const sentences = nl2br(linkify(children));
-
-    if (sentences.length <= lines) {
-      return (
-        <div>
-          {sentences}
-        </div>
-      );
-    }
-
     return (
-      <div>
-        {isExpanded ? sentences : sentences.slice(0, lines)}
-
-        <button className="more" onClick={this.toggleExapnd}>
-          {isExpanded ? '隱藏全文' : '閱讀更多'}
-        </button>
+      <button
+        key="expandable-text-more-button"
+        className="more"
+        onClick={this.toggleExapnd}
+      >
+        {isExpanded ? '隱藏全文' : '閱讀更多'}
         <style jsx>{`
           .more {
             border: 0;
@@ -50,6 +31,31 @@ export default class ExpandableText extends React.Component {
             text-decoration: underline;
           }
         `}</style>
+      </button>
+    );
+  };
+
+  render() {
+    const { children, wordCount } = this.props;
+    const { isExpanded } = this.state;
+
+    // Note: if "children" is short enough, this.state.isExpanded should never be true.
+    //
+    if (isExpanded) {
+      return (
+        <div>
+          {children}
+          {this.renderToggleButton()}
+        </div>
+      );
+    }
+
+    return (
+      <div>
+        {truncate(children, {
+          wordCount,
+          moreElem: this.renderToggleButton(),
+        })}
       </div>
     );
   }

--- a/components/RelatedReplies.js
+++ b/components/RelatedReplies.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { TYPE_NAME, TYPE_DESC } from '../constants/replyType';
 import moment from 'moment';
 import ExpandableText from './ExpandableText';
+import { linkify, nl2br } from '../util/text';
 import { Link } from '../routes';
 
 function RelatedReplyItem({
@@ -34,7 +35,9 @@ function RelatedReplyItem({
         ：<i>{similarityPercentage}%</i>）
       </header>
       <section className="section">
-        <ExpandableText>{replyVersion.get('text')}</ExpandableText>
+        <ExpandableText>
+          {nl2br(linkify(replyVersion.get('text')))}
+        </ExpandableText>
       </section>
       <footer>
         <Link route="reply" params={{ id: reply.get('id') }}>

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -151,7 +151,9 @@ export default class ReplyConnection extends React.PureComponent {
         </header>
         <section className="section">
           <h3>理由</h3>
-          <ExpandableText>{replyVersion.get('text')}</ExpandableText>
+          <ExpandableText>
+            {nl2br(linkify(replyVersion.get('text')))}
+          </ExpandableText>
         </section>
 
         {this.renderReference()}

--- a/util/__tests__/__snapshots__/text.js.snap
+++ b/util/__tests__/__snapshots__/text.js.snap
@@ -139,3 +139,87 @@ Array [
   ],
 ]
 `;
+
+exports[`text truncate truncates nested DOM 1`] = `
+Array [
+  <div>
+    12
+    <p>
+      3
+      <a
+        href=""
+      />
+    </p>
+  </div>,
+  <button>
+    ...more
+  </button>,
+]
+`;
+
+exports[`text truncate truncates nested DOM 2`] = `
+Array [
+  <div>
+    12
+    <p>
+      34
+      <a
+        href=""
+      >
+        5
+      </a>
+    </p>
+  </div>,
+  <button>
+    ...more
+  </button>,
+]
+`;
+
+exports[`text truncate truncates nested DOM 3`] = `
+Array [
+  <div>
+    12
+    <p>
+      34
+      <a
+        href=""
+      >
+        56
+      </a>
+      7
+      <a
+        href=""
+      />
+    </p>
+  </div>,
+  <button>
+    ...more
+  </button>,
+]
+`;
+
+exports[`text truncate truncates nested DOM 4`] = `
+Array [
+  <div>
+    12
+    <p>
+      34
+      <a
+        href=""
+      >
+        56
+      </a>
+      78
+      <a
+        href=""
+      >
+        9
+      </a>
+    </p>
+  </div>,
+  <button>
+    ...more
+  </button>,
+]
+`;

--- a/util/__tests__/text.js
+++ b/util/__tests__/text.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { linkify, nl2br } from '../text';
+import { linkify, nl2br, truncate } from '../text';
 
 describe('text', () => {
   describe('linkify', () => {
@@ -116,6 +116,46 @@ describe('text', () => {
           '\n15少年集體性侵驢子　全染上狂犬病',
         ])
       ).toMatchSnapshot();
+    });
+  });
+
+  describe('truncate', () => {
+    it('does nothing if wordCount is infinity', () => {
+      expect(truncate('12345')).toBe('12345');
+
+      const singleLevelElem = <p>This is not truncated</p>;
+      expect(singleLevelElem).toBe(singleLevelElem);
+    });
+
+    it('truncates strings', () => {
+      const moreElem = <button key="btn">...more</button>;
+
+      expect(truncate('12345', { moreElem, wordCount: 3 })).toEqual([
+        '123',
+        moreElem,
+      ]);
+    });
+
+    it('truncates nested DOM', () => {
+      const moreElem = <button key="btn">...more</button>;
+      const inputElem = (
+        <div>
+          12
+          <p>
+            34
+            <a href="">56</a>
+            78
+            <a href="">90</a>
+            12
+          </p>
+          34
+        </div>
+      );
+
+      expect(truncate(inputElem, { moreElem, wordCount: 3 })).toMatchSnapshot();
+      expect(truncate(inputElem, { moreElem, wordCount: 5 })).toMatchSnapshot();
+      expect(truncate(inputElem, { moreElem, wordCount: 7 })).toMatchSnapshot();
+      expect(truncate(inputElem, { moreElem, wordCount: 9 })).toMatchSnapshot();
     });
   });
 });

--- a/util/text.js
+++ b/util/text.js
@@ -1,5 +1,25 @@
 import React from 'react';
 
+const BREAK = { $$BREAK: true };
+
+/**
+ * Invokes traverseForStrings for each item in elems.
+ * When `BREAK` is received, break traversal immediately.
+ *
+ * @param {*} elem Array of elements to traverse
+ * @param {Function} callback passed to traverseForStrings()
+ */
+function traverseElems(elems, callback) {
+  const result = [];
+  for (let i = 0; i < elems.length; i += 1) {
+    const returnValue = traverseForStrings(elems[i], callback);
+    if (returnValue === BREAK) break;
+    result.push(returnValue);
+  }
+
+  return result;
+}
+
 /**
  * Traverses elem tree for strings, returns callback(string)
  * @param {*} elem
@@ -9,14 +29,13 @@ function traverseForStrings(elem, callback) {
   switch (true) {
     case typeof elem === 'string':
       return callback(elem);
-    case elem instanceof Array: {
-      return elem.map(el => traverseForStrings(el, callback));
-    }
+
+    case elem instanceof Array:
+      return traverseElems(elem, callback);
+
     case React.isValidElement(elem): {
       const children = React.Children.toArray(elem.props.children);
-      const newChildren = children.map(childElem =>
-        traverseForStrings(childElem, callback)
-      );
+      const newChildren = traverseElems(children, callback);
 
       // No need to clone element if new children is identical with the original
       //
@@ -104,4 +123,37 @@ export function nl2br(elem) {
     //
     return flatternPureStrings(tokenized);
   });
+}
+
+/**
+ * Truncates the given elem to the specified wordCount.
+ * When truncated, appends moreElem to the end of the string.
+ *
+ * @param {*} elem React element, string, array of string & react elements
+ * @param {<wordCount: Number, moreElem: ReactElement>} options
+ */
+export function truncate(elem, { wordCount = Infinity, moreElem = null } = {}) {
+  let currentWordCount = 0;
+  const result = traverseForStrings(elem, str => {
+    if (currentWordCount >= wordCount) return BREAK;
+
+    currentWordCount += str.length;
+    const exceededCount = currentWordCount - wordCount;
+
+    return exceededCount <= 0 ? str : str.slice(0, -exceededCount);
+  });
+
+  switch (true) {
+    // Not exceeding wordCount, just return the original element
+    case currentWordCount <= wordCount:
+      return elem;
+
+    // If the result is an array, append moreElem
+    case result instanceof Array:
+      return result.concat(moreElem);
+
+    // Others, including result being a string or React Element.
+    default:
+      return [result, moreElem];
+  }
 }


### PR DESCRIPTION
1. Make `traverseForStrings()` in `util/text` support `BREAK`
2. Implements `truncate()`, which truncates strings by length, and appends `moreElem` when truncation happens. This is the core of `<ExpandableText>`. (See `util/__tests__/__snapshots__/text.js.snap`)
3. Rewrite `<ExpandableText>` to leverage `truncate()`. Move `linkify()` and `nl2br()` to outside of `<ExpandableText>` implementation.