### PR TITLE
New reply tabs

### DIFF
--- a/pages/article.js
+++ b/pages/article.js
@@ -138,12 +138,12 @@ class ArticlePage extends React.Component {
         >
           使用相關回應 <span className="badge">{relatedReplyCount}</span>
         </li>
-        <li
+        {/*<li
           onClick={this.handleTabChange('search')}
           className={`tab ${tab === 'search' ? 'active' : ''}`}
         >
           搜尋
-        </li>
+        </li>*/}
         <li className="empty" />
 
         <style jsx>{`

--- a/pages/article.js
+++ b/pages/article.js
@@ -130,13 +130,19 @@ class ArticlePage extends React.Component {
           onClick={this.handleTabChange('new')}
           className={`tab ${tab === 'new' ? 'active' : ''}`}
         >
-          撰寫新回應
+          撰寫回應
         </li>
         <li
           onClick={this.handleTabChange('related')}
-          className={`tab ${tab === 'related' ? 'active' : ''}`}
+          className={`tab ${tab === 'related'
+            ? 'active'
+            : ''} ${relatedReplyCount === 0 ? 'disabled' : ''}`}
         >
-          使用相關回應 <span className="badge">{relatedReplyCount}</span>
+          {relatedReplyCount === 0
+            ? '無相關回應'
+            : <span>
+                使用相關回應 <span className="badge">{relatedReplyCount}</span>
+              </span>}
         </li>
         {/*<li
           onClick={this.handleTabChange('search')}
@@ -246,6 +252,7 @@ class ArticlePage extends React.Component {
         </section>
 
         <section className="section">
+          <h2>增加新回應</h2>
           {this.renderTabMenu()}
           <div className="tab-content">
             {this.renderNewReplyTab()}
@@ -266,7 +273,7 @@ class ArticlePage extends React.Component {
         <style jsx>{detailStyle}</style>
         <style jsx>{`
           .tab-content {
-            padding: 24px;
+            padding: 20px;
             border: 1px solid #ccc;
             border-top: 0;
           }

--- a/pages/article.js
+++ b/pages/article.js
@@ -120,7 +120,10 @@ class ArticlePage extends React.Component {
   };
 
   renderTabMenu = () => {
+    const { data } = this.props;
     const { tab } = this.state;
+    const relatedReplyCount = data.get('relatedReplies').size;
+
     return (
       <ul className="tabs">
         <li
@@ -133,7 +136,7 @@ class ArticlePage extends React.Component {
           onClick={this.handleTabChange('related')}
           className={`tab ${tab === 'related' ? 'active' : ''}`}
         >
-          使用相關回應
+          使用相關回應 <span className="badge">{relatedReplyCount}</span>
         </li>
         <li
           onClick={this.handleTabChange('search')}
@@ -158,6 +161,8 @@ class ArticlePage extends React.Component {
             padding: 16px 24px;
             border: 1px solid #ccc;
             background: #eee;
+            display: flex;
+            align-items: center;
           }
           .tab:hover {
             background: #f8f8f8;
@@ -168,6 +173,14 @@ class ArticlePage extends React.Component {
           .tab.active {
             border-bottom-color: transparent;
             background: #fff;
+          }
+          .badge {
+            background: #999;
+            color: #fff;
+            padding: 2px 8px;
+            border-radius: 100%;
+            font-size: 0.75em;
+            margin-left: 8px;
           }
           .empty {
             flex: 1;

--- a/pages/article.js
+++ b/pages/article.js
@@ -20,7 +20,7 @@ import {
   updateReplyConnectionStatus,
 } from '../redux/articleDetail';
 
-import { detailStyle } from './article.styles';
+import { detailStyle, tabMenuStyle } from './article.styles';
 
 function getRatingString(replyConnections) {
   const resultStrings = [];
@@ -146,47 +146,7 @@ class ArticlePage extends React.Component {
         </li>*/}
         <li className="empty" />
 
-        <style jsx>{`
-          .tabs {
-            display: flex;
-            font-size: 18px;
-            font-weight: 500;
-            margin: 0;
-            padding: 0;
-          }
-          .tabs li {
-            list-style: none;
-          }
-          .tab {
-            padding: 16px 24px;
-            border: 1px solid #ccc;
-            background: #eee;
-            display: flex;
-            align-items: center;
-          }
-          .tab:hover {
-            background: #f8f8f8;
-          }
-          .tab + .tab {
-            border-left: 0;
-          }
-          .tab.active {
-            border-bottom-color: transparent;
-            background: #fff;
-          }
-          .badge {
-            background: #999;
-            color: #fff;
-            padding: 2px 8px;
-            border-radius: 100%;
-            font-size: 0.75em;
-            margin-left: 8px;
-          }
-          .empty {
-            flex: 1;
-            border-bottom: 1px solid #ccc;
-          }
-        `}</style>
+        <style jsx>{tabMenuStyle}</style>
       </ul>
     );
   };

--- a/pages/article.styles.js
+++ b/pages/article.styles.js
@@ -67,4 +67,4 @@ export const tabMenuStyle = `
     flex: 1;
     border-bottom: 1px solid #ccc;
   }
-`
+`;

--- a/pages/article.styles.js
+++ b/pages/article.styles.js
@@ -30,7 +30,7 @@ export const detailStyle = `
 export const tabMenuStyle = `
   .tabs {
     display: flex;
-    font-size: 18px;
+    font-size: 16px;
     font-weight: 500;
     margin: 0;
     padding: 0;
@@ -39,7 +39,7 @@ export const tabMenuStyle = `
     list-style: none;
   }
   .tab {
-    padding: 16px 24px;
+    padding: 16px 20px;
     border: 1px solid #ccc;
     background: #eee;
     display: flex;
@@ -55,11 +55,15 @@ export const tabMenuStyle = `
     border-bottom-color: transparent;
     background: #fff;
   }
+  .tab.disabled {
+    color: #bbb;
+    pointer-events: none;
+  }
   .badge {
     background: #999;
     color: #fff;
     padding: 2px 8px;
-    border-radius: 100%;
+    border-radius: 20px;
     font-size: 0.75em;
     margin-left: 8px;
   }

--- a/pages/article.styles.js
+++ b/pages/article.styles.js
@@ -26,3 +26,45 @@ export const detailStyle = `
     padding-left: 0;
   }
 `;
+
+export const tabMenuStyle = `
+  .tabs {
+    display: flex;
+    font-size: 18px;
+    font-weight: 500;
+    margin: 0;
+    padding: 0;
+  }
+  .tabs li {
+    list-style: none;
+  }
+  .tab {
+    padding: 16px 24px;
+    border: 1px solid #ccc;
+    background: #eee;
+    display: flex;
+    align-items: center;
+  }
+  .tab:hover {
+    background: #f8f8f8;
+  }
+  .tab + .tab {
+    border-left: 0;
+  }
+  .tab.active {
+    border-bottom-color: transparent;
+    background: #fff;
+  }
+  .badge {
+    background: #999;
+    color: #fff;
+    padding: 2px 8px;
+    border-radius: 100%;
+    font-size: 0.75em;
+    margin-left: 8px;
+  }
+  .empty {
+    flex: 1;
+    border-bottom: 1px solid #ccc;
+  }
+`


### PR DESCRIPTION
Related to #46.
"Search" tab is not included yet.

## "New reply" tab
<img width="686" alt="2017-10-24 9 47 35" src="https://user-images.githubusercontent.com/108608/31946725-2ebed8c8-b898-11e7-90e2-ed9556703330.png">


## "Use existing replies" tab
<img width="684" alt="2017-10-24 9 47 41" src="https://user-images.githubusercontent.com/108608/31946729-3485ae9e-b898-11e7-8cdb-6e0d5760d4c1.png">

## "Use existing replies" tab grayed out if no related replies
<img width="683" alt="2017-10-24 9 47 51" src="https://user-images.githubusercontent.com/108608/31946752-46916d08-b898-11e7-9b5c-bc91606d73be.png">
