### PR TITLE
Refactor article detail

### DIFF
--- a/components/RelatedReplies.js
+++ b/components/RelatedReplies.js
@@ -88,7 +88,6 @@ function RelatedReplyItem({
 
 export default function RelatedReplies({
   relatedReplies,
-  relatedArticles,
   getArticleSimilarity,
   onConnect,
 }) {
@@ -99,15 +98,14 @@ export default function RelatedReplies({
   return (
     <ul className="items">
       {relatedReplies.map(reply => {
-        const articleText = relatedArticles
-          .find(article => article.get('id') === reply.get('articleId'))
-          .get('text', '');
+        const articleId = reply.getIn(['article', 'id']);
+        const articleText = reply.getIn(['article', 'text']);
         const similarity = getArticleSimilarity(articleText);
         return (
           <RelatedReplyItem
-            key={`${reply.get('id')}-${reply.get('articleId')}`}
+            key={`${reply.get('id')}-${articleId}`}
             reply={reply}
-            articleId={reply.get('articleId')}
+            articleId={articleId}
             articleText={articleText}
             similarity={similarity}
             onConnect={onConnect}

--- a/components/RelatedReplies.js
+++ b/components/RelatedReplies.js
@@ -6,13 +6,9 @@ import { linkify, nl2br } from '../util/text';
 import { Link } from '../routes';
 import { sectionStyle } from './ReplyConnection.styles';
 
-function RelatedReplyItem({
-  reply,
-  articleId,
-  articleText,
-  similarity,
-  onConnect,
-}) {
+function RelatedReplyItem({ reply, similarity, onConnect }) {
+  const articleId = reply.getIn(['article', 'id']);
+  const articleText = reply.getIn(['article', 'text']);
   const replyVersion = reply.getIn(['versions', 0]);
   const createdAt = moment(replyVersion.get('createdAt'));
   const similarityPercentage = Math.round(similarity * 100);
@@ -98,15 +94,13 @@ export default function RelatedReplies({
   return (
     <ul className="items">
       {relatedReplies.map(reply => {
-        const articleId = reply.getIn(['article', 'id']);
-        const articleText = reply.getIn(['article', 'text']);
-        const similarity = getArticleSimilarity(articleText);
+        const similarity = getArticleSimilarity(
+          reply.getIn(['article', 'text'])
+        );
         return (
           <RelatedReplyItem
-            key={`${reply.get('id')}-${articleId}`}
+            key={`${reply.get('id')}`}
             reply={reply}
-            articleId={articleId}
-            articleText={articleText}
             similarity={similarity}
             onConnect={onConnect}
           />

--- a/pages/article.js
+++ b/pages/article.js
@@ -162,7 +162,6 @@ class ArticlePage extends React.Component {
     const { tab } = this.state;
 
     const article = data.get('article');
-    const relatedArticles = data.get('relatedArticles');
     const relatedReplies = data.get('relatedReplies');
 
     const articleText = article.get('text', '');
@@ -180,7 +179,6 @@ class ArticlePage extends React.Component {
           <RelatedReplies
             onConnect={this.handleConnect}
             relatedReplies={relatedReplies}
-            relatedArticles={relatedArticles}
             getArticleSimilarity={getArticleSimilarity}
           />
         );

--- a/redux/__tests__/__snapshots__/articleDetail.js.snap
+++ b/redux/__tests__/__snapshots__/articleDetail.js.snap
@@ -66,19 +66,6 @@ Immutable.Map {
         "id": "article1",
       },
     },
-    Immutable.Map {
-      "id": "relatedReply1",
-      "versions": Immutable.List [
-        Immutable.Map {
-          "type": "RUMOR",
-          "text": "醫師聽聞後都斥為無稽之談",
-        },
-      ],
-      "article": Immutable.Map {
-        "id": "article2",
-        "text": "~~黎建南給退休軍公教人員的一封公開信~~",
-      },
-    },
   ],
 }
 `;
@@ -216,19 +203,6 @@ Immutable.Map {
       ],
       "article": Immutable.Map {
         "id": "article1",
-      },
-    },
-    Immutable.Map {
-      "id": "relatedReply1",
-      "versions": Immutable.List [
-        Immutable.Map {
-          "type": "RUMOR",
-          "text": "醫師聽聞後都斥為無稽之談",
-        },
-      ],
-      "article": Immutable.Map {
-        "id": "article2",
-        "text": "~~黎建南給退休軍公教人員的一封公開信~~",
       },
     },
   ],

--- a/redux/__tests__/__snapshots__/articleDetail.js.snap
+++ b/redux/__tests__/__snapshots__/articleDetail.js.snap
@@ -1,0 +1,322 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`reducer: articleDetail handles LOAD 1`] = `
+Immutable.Map {
+  "article": Immutable.Map {
+    "replyRequestCount": 1,
+    "user": null,
+    "text": "請問這偏文章是正確嗎？",
+    "id": "AV9mEFX2yCdS-nWhuiPu",
+    "createdAt": "2017-10-29T02:57:47.509Z",
+  },
+  "replyConnections": Immutable.List [
+    Immutable.Map {
+      "id": "AV9mEFX2yCdS-nWhuiPu__AV9mJJ5qyCdS-nWhuiPz",
+      "canUpdateStatus": true,
+      "status": "NORMAL",
+      "reply": Immutable.Map {
+        "id": "AV9mJJ5qyCdS-nWhuiPz",
+        "versions": Immutable.List [
+          Immutable.Map {
+            "user": Immutable.Map {
+              "id": "AVqVwjqQyrDaTqlmmp_a",
+              "name": null,
+              "avatarUrl": null,
+            },
+            "type": "NOT_ARTICLE",
+            "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
+            "reference": "",
+            "createdAt": "2017-10-29T03:19:56.776Z",
+          },
+        ],
+      },
+      "feedbacks": Immutable.List [],
+      "user": Immutable.Map {
+        "id": "AVqVwjqQyrDaTqlmmp_a",
+        "name": null,
+        "avatarUrl": null,
+      },
+      "createdAt": "2017-10-29T03:19:56.782Z",
+    },
+  ],
+  "relatedArticles": Immutable.List [
+    Immutable.Map {
+      "id": "article1",
+      "replyConnections": Immutable.List [
+        Immutable.Map {
+          "id": "article1-reply1",
+          "canUpdateStatus": false,
+          "reply": Immutable.Map {
+            "id": "reply1",
+            "versions": Immutable.List [
+              Immutable.Map {
+                "type": "RUMOR",
+                "text": "醫師聽聞後都斥為無稽之談",
+              },
+            ],
+          },
+        },
+        Immutable.Map {
+          "id": "article1-reply2",
+          "canUpdateStatus": false,
+          "reply": Immutable.Map {
+            "id": "reply2",
+            "versions": Immutable.List [
+              Immutable.Map {
+                "type": "RUMOR",
+                "text": "喝冰水跟罹癌根本是兩回事",
+              },
+            ],
+          },
+        },
+      ],
+    },
+    Immutable.Map {
+      "id": "article2",
+      "text": "~~黎建南給退休軍公教人員的一封公開信~~",
+      "replyConnections": Immutable.List [
+        Immutable.Map {
+          "id": "article2-reply1",
+          "canUpdateStatus": false,
+          "reply": Immutable.Map {
+            "id": "reply1",
+            "versions": Immutable.List [
+              Immutable.Map {
+                "type": "RUMOR",
+                "text": "醫師聽聞後都斥為無稽之談",
+              },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+  "relatedReplies": Immutable.List [
+    Immutable.Map {
+      "id": "reply1",
+      "versions": Immutable.List [
+        Immutable.Map {
+          "type": "RUMOR",
+          "text": "醫師聽聞後都斥為無稽之談",
+        },
+      ],
+      "articleId": "article1",
+    },
+    Immutable.Map {
+      "id": "reply2",
+      "versions": Immutable.List [
+        Immutable.Map {
+          "type": "RUMOR",
+          "text": "喝冰水跟罹癌根本是兩回事",
+        },
+      ],
+      "articleId": "article1",
+    },
+    Immutable.Map {
+      "id": "reply1",
+      "versions": Immutable.List [
+        Immutable.Map {
+          "type": "RUMOR",
+          "text": "醫師聽聞後都斥為無稽之談",
+        },
+      ],
+      "articleId": "article2",
+    },
+  ],
+}
+`;
+
+exports[`reducer: articleDetail handles LOAD_AUTH 1`] = `
+Immutable.List [
+  Immutable.Map {
+    "id": "AV9mEFX2yCdS-nWhuiPu__AV9mJJ5qyCdS-nWhuiPz",
+    "canUpdateStatus": true,
+    "status": "NORMAL",
+    "reply": Immutable.Map {
+      "id": "AV9mJJ5qyCdS-nWhuiPz",
+      "versions": Immutable.List [
+        Immutable.Map {
+          "user": Immutable.Map {
+            "id": "AVqVwjqQyrDaTqlmmp_a",
+            "name": null,
+            "avatarUrl": null,
+          },
+          "type": "NOT_ARTICLE",
+          "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
+          "reference": "",
+          "createdAt": "2017-10-29T03:19:56.776Z",
+        },
+      ],
+    },
+    "feedbacks": Immutable.List [],
+    "user": Immutable.Map {
+      "id": "AVqVwjqQyrDaTqlmmp_a",
+      "name": null,
+      "avatarUrl": null,
+    },
+    "createdAt": "2017-10-29T03:19:56.782Z",
+  },
+]
+`;
+
+exports[`reducer: articleDetail handles SET_STATE 1`] = `
+Immutable.Map {
+  "isLoading": true,
+  "isAuthLoading": false,
+  "isReplyLoading": false,
+}
+`;
+
+exports[`reducer: articleDetail handles partial LOAD 1`] = `
+Immutable.Map {
+  "article": Immutable.Map {
+    "replyRequestCount": 1,
+    "user": null,
+    "text": "請問這偏文章是正確嗎？",
+    "id": "AV9mEFX2yCdS-nWhuiPu",
+    "createdAt": "2017-10-29T02:57:47.509Z",
+  },
+  "replyConnections": Immutable.List [
+    Immutable.Map {
+      "id": "AV9mEFX2yCdS-nWhuiPu__AV9mN3dDyCdS-nWhuiP3",
+      "canUpdateStatus": true,
+      "status": "NORMAL",
+      "reply": Immutable.Map {
+        "id": "AV9mN3dDyCdS-nWhuiP3",
+        "versions": Immutable.List [
+          Immutable.Map {
+            "user": Immutable.Map {
+              "id": "AVqVwjqQyrDaTqlmmp_a",
+              "name": null,
+              "avatarUrl": null,
+            },
+            "type": "NOT_ARTICLE",
+            "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
+            "reference": "",
+            "createdAt": "2017-10-29T03:40:31.938Z",
+          },
+        ],
+      },
+      "feedbacks": Immutable.List [],
+      "user": Immutable.Map {
+        "id": "AVqVwjqQyrDaTqlmmp_a",
+        "name": null,
+        "avatarUrl": null,
+      },
+      "createdAt": "2017-10-29T03:40:31.942Z",
+    },
+    Immutable.Map {
+      "id": "AV9mEFX2yCdS-nWhuiPu__AV9mJJ5qyCdS-nWhuiPz",
+      "canUpdateStatus": true,
+      "status": "NORMAL",
+      "reply": Immutable.Map {
+        "id": "AV9mJJ5qyCdS-nWhuiPz",
+        "versions": Immutable.List [
+          Immutable.Map {
+            "user": Immutable.Map {
+              "id": "AVqVwjqQyrDaTqlmmp_a",
+              "name": null,
+              "avatarUrl": null,
+            },
+            "type": "NOT_ARTICLE",
+            "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
+            "reference": "",
+            "createdAt": "2017-10-29T03:19:56.776Z",
+          },
+        ],
+      },
+      "feedbacks": Immutable.List [],
+      "user": Immutable.Map {
+        "id": "AVqVwjqQyrDaTqlmmp_a",
+        "name": null,
+        "avatarUrl": null,
+      },
+      "createdAt": "2017-10-29T03:19:56.782Z",
+    },
+  ],
+  "relatedArticles": Immutable.List [
+    Immutable.Map {
+      "id": "article1",
+      "replyConnections": Immutable.List [
+        Immutable.Map {
+          "id": "article1-reply1",
+          "canUpdateStatus": false,
+          "reply": Immutable.Map {
+            "id": "reply1",
+            "versions": Immutable.List [
+              Immutable.Map {
+                "type": "RUMOR",
+                "text": "醫師聽聞後都斥為無稽之談",
+              },
+            ],
+          },
+        },
+        Immutable.Map {
+          "id": "article1-reply2",
+          "canUpdateStatus": false,
+          "reply": Immutable.Map {
+            "id": "reply2",
+            "versions": Immutable.List [
+              Immutable.Map {
+                "type": "RUMOR",
+                "text": "喝冰水跟罹癌根本是兩回事",
+              },
+            ],
+          },
+        },
+      ],
+    },
+    Immutable.Map {
+      "id": "article2",
+      "text": "~~黎建南給退休軍公教人員的一封公開信~~",
+      "replyConnections": Immutable.List [
+        Immutable.Map {
+          "id": "article2-reply1",
+          "canUpdateStatus": false,
+          "reply": Immutable.Map {
+            "id": "reply1",
+            "versions": Immutable.List [
+              Immutable.Map {
+                "type": "RUMOR",
+                "text": "醫師聽聞後都斥為無稽之談",
+              },
+            ],
+          },
+        },
+      ],
+    },
+  ],
+  "relatedReplies": Immutable.List [
+    Immutable.Map {
+      "id": "reply1",
+      "versions": Immutable.List [
+        Immutable.Map {
+          "type": "RUMOR",
+          "text": "醫師聽聞後都斥為無稽之談",
+        },
+      ],
+      "articleId": "article1",
+    },
+    Immutable.Map {
+      "id": "reply2",
+      "versions": Immutable.List [
+        Immutable.Map {
+          "type": "RUMOR",
+          "text": "喝冰水跟罹癌根本是兩回事",
+        },
+      ],
+      "articleId": "article1",
+    },
+    Immutable.Map {
+      "id": "reply1",
+      "versions": Immutable.List [
+        Immutable.Map {
+          "type": "RUMOR",
+          "text": "醫師聽聞後都斥為無稽之談",
+        },
+      ],
+      "articleId": "article2",
+    },
+  ],
+}
+`;

--- a/redux/__tests__/__snapshots__/articleDetail.js.snap
+++ b/redux/__tests__/__snapshots__/articleDetail.js.snap
@@ -11,22 +11,15 @@ Immutable.Map {
   },
   "replyConnections": Immutable.List [
     Immutable.Map {
-      "id": "AV9mEFX2yCdS-nWhuiPu__AV9mJJ5qyCdS-nWhuiPz",
+      "id": "article1-reply1",
       "canUpdateStatus": true,
       "status": "NORMAL",
       "reply": Immutable.Map {
-        "id": "AV9mJJ5qyCdS-nWhuiPz",
+        "id": "reply1",
         "versions": Immutable.List [
           Immutable.Map {
-            "user": Immutable.Map {
-              "id": "AVqVwjqQyrDaTqlmmp_a",
-              "name": null,
-              "avatarUrl": null,
-            },
             "type": "NOT_ARTICLE",
             "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
-            "reference": "",
-            "createdAt": "2017-10-29T03:19:56.776Z",
           },
         ],
       },
@@ -44,10 +37,10 @@ Immutable.Map {
       "id": "article1",
       "replyConnections": Immutable.List [
         Immutable.Map {
-          "id": "article1-reply1",
+          "id": "article1-relatedReply1",
           "canUpdateStatus": false,
           "reply": Immutable.Map {
-            "id": "reply1",
+            "id": "relatedReply1",
             "versions": Immutable.List [
               Immutable.Map {
                 "type": "RUMOR",
@@ -57,14 +50,27 @@ Immutable.Map {
           },
         },
         Immutable.Map {
-          "id": "article1-reply2",
+          "id": "article1-relatedReply2",
           "canUpdateStatus": false,
           "reply": Immutable.Map {
-            "id": "reply2",
+            "id": "relatedReply2",
             "versions": Immutable.List [
               Immutable.Map {
                 "type": "RUMOR",
                 "text": "喝冰水跟罹癌根本是兩回事",
+              },
+            ],
+          },
+        },
+        Immutable.Map {
+          "id": "article1-reply1",
+          "canUpdateStatus": false,
+          "reply": Immutable.Map {
+            "id": "reply1",
+            "versions": Immutable.List [
+              Immutable.Map {
+                "type": "NOT_ARTICLE",
+                "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
               },
             ],
           },
@@ -76,10 +82,10 @@ Immutable.Map {
       "text": "~~黎建南給退休軍公教人員的一封公開信~~",
       "replyConnections": Immutable.List [
         Immutable.Map {
-          "id": "article2-reply1",
+          "id": "article2-relatedReply1",
           "canUpdateStatus": false,
           "reply": Immutable.Map {
-            "id": "reply1",
+            "id": "relatedReply1",
             "versions": Immutable.List [
               Immutable.Map {
                 "type": "RUMOR",
@@ -93,7 +99,7 @@ Immutable.Map {
   ],
   "relatedReplies": Immutable.List [
     Immutable.Map {
-      "id": "reply1",
+      "id": "relatedReply1",
       "versions": Immutable.List [
         Immutable.Map {
           "type": "RUMOR",
@@ -103,7 +109,7 @@ Immutable.Map {
       "articleId": "article1",
     },
     Immutable.Map {
-      "id": "reply2",
+      "id": "relatedReply2",
       "versions": Immutable.List [
         Immutable.Map {
           "type": "RUMOR",
@@ -113,7 +119,7 @@ Immutable.Map {
       "articleId": "article1",
     },
     Immutable.Map {
-      "id": "reply1",
+      "id": "relatedReply1",
       "versions": Immutable.List [
         Immutable.Map {
           "type": "RUMOR",
@@ -129,22 +135,15 @@ Immutable.Map {
 exports[`reducer: articleDetail handles LOAD_AUTH 1`] = `
 Immutable.List [
   Immutable.Map {
-    "id": "AV9mEFX2yCdS-nWhuiPu__AV9mJJ5qyCdS-nWhuiPz",
+    "id": "article1-reply1",
     "canUpdateStatus": true,
     "status": "NORMAL",
     "reply": Immutable.Map {
-      "id": "AV9mJJ5qyCdS-nWhuiPz",
+      "id": "reply1",
       "versions": Immutable.List [
         Immutable.Map {
-          "user": Immutable.Map {
-            "id": "AVqVwjqQyrDaTqlmmp_a",
-            "name": null,
-            "avatarUrl": null,
-          },
           "type": "NOT_ARTICLE",
           "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
-          "reference": "",
-          "createdAt": "2017-10-29T03:19:56.776Z",
         },
       ],
     },
@@ -178,7 +177,7 @@ Immutable.Map {
   },
   "replyConnections": Immutable.List [
     Immutable.Map {
-      "id": "AV9mEFX2yCdS-nWhuiPu__AV9mN3dDyCdS-nWhuiP3",
+      "id": "reply1",
       "canUpdateStatus": true,
       "status": "NORMAL",
       "reply": Immutable.Map {
@@ -206,7 +205,7 @@ Immutable.Map {
       "createdAt": "2017-10-29T03:40:31.942Z",
     },
     Immutable.Map {
-      "id": "AV9mEFX2yCdS-nWhuiPu__AV9mJJ5qyCdS-nWhuiPz",
+      "id": "reply2",
       "canUpdateStatus": true,
       "status": "NORMAL",
       "reply": Immutable.Map {
@@ -239,10 +238,10 @@ Immutable.Map {
       "id": "article1",
       "replyConnections": Immutable.List [
         Immutable.Map {
-          "id": "article1-reply1",
+          "id": "article1-relatedReply1",
           "canUpdateStatus": false,
           "reply": Immutable.Map {
-            "id": "reply1",
+            "id": "relatedReply1",
             "versions": Immutable.List [
               Immutable.Map {
                 "type": "RUMOR",
@@ -252,14 +251,27 @@ Immutable.Map {
           },
         },
         Immutable.Map {
-          "id": "article1-reply2",
+          "id": "article1-relatedReply2",
           "canUpdateStatus": false,
           "reply": Immutable.Map {
-            "id": "reply2",
+            "id": "relatedReply2",
             "versions": Immutable.List [
               Immutable.Map {
                 "type": "RUMOR",
                 "text": "喝冰水跟罹癌根本是兩回事",
+              },
+            ],
+          },
+        },
+        Immutable.Map {
+          "id": "article1-reply1",
+          "canUpdateStatus": false,
+          "reply": Immutable.Map {
+            "id": "reply1",
+            "versions": Immutable.List [
+              Immutable.Map {
+                "type": "NOT_ARTICLE",
+                "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
               },
             ],
           },
@@ -271,10 +283,10 @@ Immutable.Map {
       "text": "~~黎建南給退休軍公教人員的一封公開信~~",
       "replyConnections": Immutable.List [
         Immutable.Map {
-          "id": "article2-reply1",
+          "id": "article2-relatedReply1",
           "canUpdateStatus": false,
           "reply": Immutable.Map {
-            "id": "reply1",
+            "id": "relatedReply1",
             "versions": Immutable.List [
               Immutable.Map {
                 "type": "RUMOR",
@@ -288,7 +300,7 @@ Immutable.Map {
   ],
   "relatedReplies": Immutable.List [
     Immutable.Map {
-      "id": "reply1",
+      "id": "relatedReply1",
       "versions": Immutable.List [
         Immutable.Map {
           "type": "RUMOR",
@@ -298,7 +310,7 @@ Immutable.Map {
       "articleId": "article1",
     },
     Immutable.Map {
-      "id": "reply2",
+      "id": "relatedReply2",
       "versions": Immutable.List [
         Immutable.Map {
           "type": "RUMOR",
@@ -308,7 +320,7 @@ Immutable.Map {
       "articleId": "article1",
     },
     Immutable.Map {
-      "id": "reply1",
+      "id": "relatedReply1",
       "versions": Immutable.List [
         Immutable.Map {
           "type": "RUMOR",

--- a/redux/__tests__/__snapshots__/articleDetail.js.snap
+++ b/redux/__tests__/__snapshots__/articleDetail.js.snap
@@ -3,11 +3,11 @@
 exports[`reducer: articleDetail handles LOAD 1`] = `
 Immutable.Map {
   "article": Immutable.Map {
+    "id": "AV9mEFX2yCdS-nWhuiPu",
     "replyRequestCount": 1,
+    "createdAt": "2017-10-29T02:57:47.509Z",
     "user": null,
     "text": "請問這偏文章是正確嗎？",
-    "id": "AV9mEFX2yCdS-nWhuiPu",
-    "createdAt": "2017-10-29T02:57:47.509Z",
   },
   "replyConnections": Immutable.List [
     Immutable.Map {
@@ -35,66 +35,10 @@ Immutable.Map {
   "relatedArticles": Immutable.List [
     Immutable.Map {
       "id": "article1",
-      "replyConnections": Immutable.List [
-        Immutable.Map {
-          "id": "article1-relatedReply1",
-          "canUpdateStatus": false,
-          "reply": Immutable.Map {
-            "id": "relatedReply1",
-            "versions": Immutable.List [
-              Immutable.Map {
-                "type": "RUMOR",
-                "text": "醫師聽聞後都斥為無稽之談",
-              },
-            ],
-          },
-        },
-        Immutable.Map {
-          "id": "article1-relatedReply2",
-          "canUpdateStatus": false,
-          "reply": Immutable.Map {
-            "id": "relatedReply2",
-            "versions": Immutable.List [
-              Immutable.Map {
-                "type": "RUMOR",
-                "text": "喝冰水跟罹癌根本是兩回事",
-              },
-            ],
-          },
-        },
-        Immutable.Map {
-          "id": "article1-reply1",
-          "canUpdateStatus": false,
-          "reply": Immutable.Map {
-            "id": "reply1",
-            "versions": Immutable.List [
-              Immutable.Map {
-                "type": "NOT_ARTICLE",
-                "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
-              },
-            ],
-          },
-        },
-      ],
     },
     Immutable.Map {
       "id": "article2",
       "text": "~~黎建南給退休軍公教人員的一封公開信~~",
-      "replyConnections": Immutable.List [
-        Immutable.Map {
-          "id": "article2-relatedReply1",
-          "canUpdateStatus": false,
-          "reply": Immutable.Map {
-            "id": "relatedReply1",
-            "versions": Immutable.List [
-              Immutable.Map {
-                "type": "RUMOR",
-                "text": "醫師聽聞後都斥為無稽之談",
-              },
-            ],
-          },
-        },
-      ],
     },
   ],
   "relatedReplies": Immutable.List [
@@ -106,7 +50,9 @@ Immutable.Map {
           "text": "醫師聽聞後都斥為無稽之談",
         },
       ],
-      "articleId": "article1",
+      "article": Immutable.Map {
+        "id": "article1",
+      },
     },
     Immutable.Map {
       "id": "relatedReply2",
@@ -116,7 +62,9 @@ Immutable.Map {
           "text": "喝冰水跟罹癌根本是兩回事",
         },
       ],
-      "articleId": "article1",
+      "article": Immutable.Map {
+        "id": "article1",
+      },
     },
     Immutable.Map {
       "id": "relatedReply1",
@@ -126,7 +74,10 @@ Immutable.Map {
           "text": "醫師聽聞後都斥為無稽之談",
         },
       ],
-      "articleId": "article2",
+      "article": Immutable.Map {
+        "id": "article2",
+        "text": "~~黎建南給退休軍公教人員的一封公開信~~",
+      },
     },
   ],
 }
@@ -169,11 +120,11 @@ Immutable.Map {
 exports[`reducer: articleDetail handles partial LOAD 1`] = `
 Immutable.Map {
   "article": Immutable.Map {
+    "id": "AV9mEFX2yCdS-nWhuiPu",
     "replyRequestCount": 1,
+    "createdAt": "2017-10-29T02:57:47.509Z",
     "user": null,
     "text": "請問這偏文章是正確嗎？",
-    "id": "AV9mEFX2yCdS-nWhuiPu",
-    "createdAt": "2017-10-29T02:57:47.509Z",
   },
   "replyConnections": Immutable.List [
     Immutable.Map {
@@ -236,66 +187,10 @@ Immutable.Map {
   "relatedArticles": Immutable.List [
     Immutable.Map {
       "id": "article1",
-      "replyConnections": Immutable.List [
-        Immutable.Map {
-          "id": "article1-relatedReply1",
-          "canUpdateStatus": false,
-          "reply": Immutable.Map {
-            "id": "relatedReply1",
-            "versions": Immutable.List [
-              Immutable.Map {
-                "type": "RUMOR",
-                "text": "醫師聽聞後都斥為無稽之談",
-              },
-            ],
-          },
-        },
-        Immutable.Map {
-          "id": "article1-relatedReply2",
-          "canUpdateStatus": false,
-          "reply": Immutable.Map {
-            "id": "relatedReply2",
-            "versions": Immutable.List [
-              Immutable.Map {
-                "type": "RUMOR",
-                "text": "喝冰水跟罹癌根本是兩回事",
-              },
-            ],
-          },
-        },
-        Immutable.Map {
-          "id": "article1-reply1",
-          "canUpdateStatus": false,
-          "reply": Immutable.Map {
-            "id": "reply1",
-            "versions": Immutable.List [
-              Immutable.Map {
-                "type": "NOT_ARTICLE",
-                "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
-              },
-            ],
-          },
-        },
-      ],
     },
     Immutable.Map {
       "id": "article2",
       "text": "~~黎建南給退休軍公教人員的一封公開信~~",
-      "replyConnections": Immutable.List [
-        Immutable.Map {
-          "id": "article2-relatedReply1",
-          "canUpdateStatus": false,
-          "reply": Immutable.Map {
-            "id": "relatedReply1",
-            "versions": Immutable.List [
-              Immutable.Map {
-                "type": "RUMOR",
-                "text": "醫師聽聞後都斥為無稽之談",
-              },
-            ],
-          },
-        },
-      ],
     },
   ],
   "relatedReplies": Immutable.List [
@@ -307,7 +202,9 @@ Immutable.Map {
           "text": "醫師聽聞後都斥為無稽之談",
         },
       ],
-      "articleId": "article1",
+      "article": Immutable.Map {
+        "id": "article1",
+      },
     },
     Immutable.Map {
       "id": "relatedReply2",
@@ -317,7 +214,9 @@ Immutable.Map {
           "text": "喝冰水跟罹癌根本是兩回事",
         },
       ],
-      "articleId": "article1",
+      "article": Immutable.Map {
+        "id": "article1",
+      },
     },
     Immutable.Map {
       "id": "relatedReply1",
@@ -327,7 +226,10 @@ Immutable.Map {
           "text": "醫師聽聞後都斥為無稽之談",
         },
       ],
-      "articleId": "article2",
+      "article": Immutable.Map {
+        "id": "article2",
+        "text": "~~黎建南給退休軍公教人員的一封公開信~~",
+      },
     },
   ],
 }

--- a/redux/__tests__/articleDetail.js
+++ b/redux/__tests__/articleDetail.js
@@ -1,0 +1,38 @@
+import articleDetail, { initialState } from '../articleDetail';
+import {
+  setStateAction,
+  loadAction,
+  reloadRepliesAction,
+  loadAuthAction,
+} from '../fixtures/articleDetail';
+
+describe('reducer: articleDetail', () => {
+  it('handles SET_STATE', () => {
+    expect(
+      articleDetail(initialState, setStateAction).get('state')
+    ).toMatchSnapshot();
+  });
+
+  it('handles LOAD', () => {
+    expect(
+      articleDetail(initialState, loadAction).get('data')
+    ).toMatchSnapshot();
+  });
+
+  it('handles partial LOAD', () => {
+    const stateAfterLoad = articleDetail(initialState, loadAction);
+    expect(
+      articleDetail(stateAfterLoad, reloadRepliesAction).get('data')
+    ).toMatchSnapshot();
+  });
+
+  it('handles LOAD_AUTH', () => {
+    const stateAfterLoad = articleDetail(initialState, loadAction);
+    expect(
+      articleDetail(stateAfterLoad, loadAuthAction).getIn([
+        'data',
+        'replyConnections',
+      ])
+    ).toMatchSnapshot();
+  });
+});

--- a/redux/articleDetail.js
+++ b/redux/articleDetail.js
@@ -184,7 +184,7 @@ export const submitReply = params => dispatch => {
 // Reducer
 //
 
-const initialState = fromJS({
+export const initialState = fromJS({
   state: { isLoading: false, isAuthLoading: false, isReplyLoading: false },
   data: {
     // data from server

--- a/redux/articleDetail.js
+++ b/redux/articleDetail.js
@@ -1,5 +1,5 @@
 import { createDuck } from 'redux-duck';
-import { fromJS, Map, List, OrderedMap, Set } from 'immutable';
+import { fromJS, Map, List, Set } from 'immutable';
 import { waitForAuth } from './auth';
 import gql from '../util/gql';
 import NProgress from 'nprogress';
@@ -201,19 +201,8 @@ export default createReducer(
       state.setIn(['state', key], value),
 
     [LOAD]: (state, { payload }) => {
-      const articleEdges =
+      const relatedArticleEdges =
         payload.getIn(['relatedArticles', 'edges']) || List();
-      const replyConnections = OrderedMap(
-        articleEdges
-          .flatMap(edge =>
-            (edge.getIn(['node', 'replyConnections']) || List()).map(conn =>
-              // we need to encode articleId into each replyConnection,
-              // so that we can show link to the article in the related reply item.
-              conn.set('articleId', edge.getIn(['node', 'id']))
-            )
-          )
-          .map(conn => [conn.get('id'), conn])
-      ).toList();
 
       const replyIds = Set(
         (payload.get('replyConnections') || List())
@@ -225,34 +214,40 @@ export default createReducer(
           .updateIn(['data', 'article'], article =>
             (article || Map())
               .merge(
-                payload.filterNot(
-                  (v, key) =>
-                    key === 'replyConnections' || key === 'relatedArticles'
-                )
+                payload.remove('replyConnections').remove('relatedArticles')
               )
           )
           .setIn(['data', 'replyConnections'], payload.get('replyConnections'))
           .updateIn(
             ['data', 'relatedArticles'],
             articles =>
-              !articleEdges.size
+              !relatedArticleEdges.size
                 ? articles
-                : articleEdges.map(edge => edge.get('node'))
+                : relatedArticleEdges.map(edge =>
+                    edge.get('node').remove('replyConnections')
+                  )
           )
           .updateIn(
             ['data', 'relatedReplies'],
             replies =>
-              !replyConnections.size
+              !relatedArticleEdges.size
                 ? replies
-                : replyConnections
-                    .map(conn =>
-                      // get reply and articleId
-                      conn.get('reply').set('articleId', conn.get('articleId'))
-                    )
-                    .filter(reply => {
-                      // Filter-out replies that is already re-used.
-                      return !replyIds.contains(reply.get('id'));
-                    })
+                : relatedArticleEdges.flatMap(edge =>
+                    edge
+                      .getIn(['node', 'replyConnections'])
+                      .map(conn =>
+                        conn
+                          .get('reply')
+                          .set(
+                            'article',
+                            edge.get('node').remove('replyConnections')
+                          )
+                      )
+                      .filter(reply => {
+                        // Filter-out replies that is already re-used.
+                        return reply && !replyIds.contains(reply.get('id'));
+                      })
+                  )
           )
       );
     },

--- a/redux/fixtures/articleDetail.js
+++ b/redux/fixtures/articleDetail.js
@@ -1,0 +1,186 @@
+import { fromJS } from 'immutable';
+
+export const setStateAction = {
+  type: 'articleDetail/SET_STATE',
+  payload: {
+    key: 'isLoading',
+    value: true,
+  },
+};
+
+export const loadAction = {
+  type: 'articleDetail/LOAD',
+  payload: fromJS({
+    relatedArticles: {
+      edges: [
+        {
+          node: {
+            id: 'article1',
+            replyConnections: [
+              {
+                id: 'article1-reply1',
+                canUpdateStatus: false,
+                reply: {
+                  id: 'reply1',
+                  versions: [
+                    {
+                      type: 'RUMOR',
+                      text: '醫師聽聞後都斥為無稽之談',
+                    },
+                  ],
+                },
+              },
+              {
+                id: 'article1-reply2',
+                canUpdateStatus: false,
+                reply: {
+                  id: 'reply2',
+                  versions: [
+                    {
+                      type: 'RUMOR',
+                      text: '喝冰水跟罹癌根本是兩回事',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          score: 3.4705038,
+        },
+        {
+          node: {
+            id: 'article2',
+            text: '~~黎建南給退休軍公教人員的一封公開信~~',
+            replyConnections: [
+              {
+                id: 'article2-reply1',
+                canUpdateStatus: false,
+                reply: {
+                  // This is duplicated with related article 1
+                  id: 'reply1',
+                  versions: [
+                    {
+                      type: 'RUMOR',
+                      text: '醫師聽聞後都斥為無稽之談',
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+        },
+      ],
+    },
+    replyRequestCount: 1,
+    replyConnections: [
+      {
+        id: 'AV9mEFX2yCdS-nWhuiPu__AV9mJJ5qyCdS-nWhuiPz',
+        canUpdateStatus: true,
+        status: 'NORMAL',
+        reply: {
+          id: 'AV9mJJ5qyCdS-nWhuiPz',
+          versions: [
+            {
+              user: {
+                id: 'AVqVwjqQyrDaTqlmmp_a',
+                name: null,
+                avatarUrl: null,
+              },
+              type: 'NOT_ARTICLE',
+              text: '文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。',
+              reference: '',
+              createdAt: '2017-10-29T03:19:56.776Z',
+            },
+          ],
+        },
+        feedbacks: [],
+        user: {
+          id: 'AVqVwjqQyrDaTqlmmp_a',
+          name: null,
+          avatarUrl: null,
+        },
+        createdAt: '2017-10-29T03:19:56.782Z',
+      },
+    ],
+    user: null,
+    text: '請問這偏文章是正確嗎？',
+    id: 'AV9mEFX2yCdS-nWhuiPu',
+    createdAt: '2017-10-29T02:57:47.509Z',
+  }),
+};
+
+export const reloadRepliesAction = {
+  type: 'articleDetail/LOAD',
+  payload: fromJS({
+    replyConnections: [
+      {
+        id: 'AV9mEFX2yCdS-nWhuiPu__AV9mN3dDyCdS-nWhuiP3',
+        canUpdateStatus: true,
+        status: 'NORMAL',
+        reply: {
+          id: 'AV9mN3dDyCdS-nWhuiP3',
+          versions: [
+            {
+              user: {
+                id: 'AVqVwjqQyrDaTqlmmp_a',
+                name: null,
+                avatarUrl: null,
+              },
+              type: 'NOT_ARTICLE',
+              text: '文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。',
+              reference: '',
+              createdAt: '2017-10-29T03:40:31.938Z',
+            },
+          ],
+        },
+        feedbacks: [],
+        user: {
+          id: 'AVqVwjqQyrDaTqlmmp_a',
+          name: null,
+          avatarUrl: null,
+        },
+        createdAt: '2017-10-29T03:40:31.942Z',
+      },
+      {
+        id: 'AV9mEFX2yCdS-nWhuiPu__AV9mJJ5qyCdS-nWhuiPz',
+        canUpdateStatus: true,
+        status: 'NORMAL',
+        reply: {
+          id: 'AV9mJJ5qyCdS-nWhuiPz',
+          versions: [
+            {
+              user: {
+                id: 'AVqVwjqQyrDaTqlmmp_a',
+                name: null,
+                avatarUrl: null,
+              },
+              type: 'NOT_ARTICLE',
+              text: '文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。',
+              reference: '',
+              createdAt: '2017-10-29T03:19:56.776Z',
+            },
+          ],
+        },
+        feedbacks: [],
+        user: {
+          id: 'AVqVwjqQyrDaTqlmmp_a',
+          name: null,
+          avatarUrl: null,
+        },
+        createdAt: '2017-10-29T03:19:56.782Z',
+      },
+    ],
+  }),
+};
+
+export const loadAuthAction = {
+  type: 'articleDetail/LOAD_AUTH',
+  payload: fromJS({
+    replyConnections: [
+      {
+        id: 'AV9mEFX2yCdS-nWhuiPu__AV9mJJ5qyCdS-nWhuiPz',
+        canUpdateStatus: true,
+      },
+    ],
+  }),
+};

--- a/redux/fixtures/articleDetail.js
+++ b/redux/fixtures/articleDetail.js
@@ -18,10 +18,10 @@ export const loadAction = {
             id: 'article1',
             replyConnections: [
               {
-                id: 'article1-reply1',
+                id: 'article1-relatedReply1',
                 canUpdateStatus: false,
                 reply: {
-                  id: 'reply1',
+                  id: 'relatedReply1',
                   versions: [
                     {
                       type: 'RUMOR',
@@ -31,14 +31,27 @@ export const loadAction = {
                 },
               },
               {
-                id: 'article1-reply2',
+                id: 'article1-relatedReply2',
                 canUpdateStatus: false,
                 reply: {
-                  id: 'reply2',
+                  id: 'relatedReply2',
                   versions: [
                     {
                       type: 'RUMOR',
                       text: '喝冰水跟罹癌根本是兩回事',
+                    },
+                  ],
+                },
+              },
+              {
+                id: 'article1-reply1',
+                canUpdateStatus: false,
+                reply: {
+                  id: 'reply1', // Already added to article (exists in replyConnections)
+                  versions: [
+                    {
+                      type: 'NOT_ARTICLE',
+                      text: '文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。',
                     },
                   ],
                 },
@@ -53,11 +66,11 @@ export const loadAction = {
             text: '~~黎建南給退休軍公教人員的一封公開信~~',
             replyConnections: [
               {
-                id: 'article2-reply1',
+                id: 'article2-relatedReply1',
                 canUpdateStatus: false,
                 reply: {
                   // This is duplicated with related article 1
-                  id: 'reply1',
+                  id: 'relatedReply1',
                   versions: [
                     {
                       type: 'RUMOR',
@@ -74,22 +87,15 @@ export const loadAction = {
     replyRequestCount: 1,
     replyConnections: [
       {
-        id: 'AV9mEFX2yCdS-nWhuiPu__AV9mJJ5qyCdS-nWhuiPz',
+        id: 'article1-reply1',
         canUpdateStatus: true,
         status: 'NORMAL',
         reply: {
-          id: 'AV9mJJ5qyCdS-nWhuiPz',
+          id: 'reply1',
           versions: [
             {
-              user: {
-                id: 'AVqVwjqQyrDaTqlmmp_a',
-                name: null,
-                avatarUrl: null,
-              },
               type: 'NOT_ARTICLE',
               text: '文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。',
-              reference: '',
-              createdAt: '2017-10-29T03:19:56.776Z',
             },
           ],
         },
@@ -114,7 +120,7 @@ export const reloadRepliesAction = {
   payload: fromJS({
     replyConnections: [
       {
-        id: 'AV9mEFX2yCdS-nWhuiPu__AV9mN3dDyCdS-nWhuiP3',
+        id: 'reply1',
         canUpdateStatus: true,
         status: 'NORMAL',
         reply: {
@@ -142,7 +148,7 @@ export const reloadRepliesAction = {
         createdAt: '2017-10-29T03:40:31.942Z',
       },
       {
-        id: 'AV9mEFX2yCdS-nWhuiPu__AV9mJJ5qyCdS-nWhuiPz',
+        id: 'reply2',
         canUpdateStatus: true,
         status: 'NORMAL',
         reply: {


### PR DESCRIPTION
Logic revamp:

1. Adding snapshot testing for `articleDetail` reducers. See snapshot files to check how the reducer work!
2. Simplify the logic of processing `relatedReplies`. Previously it inserts `articleId` twice and looking up article in `render()` functions. Now it is more straightforward, with `article` directly embedded.
3. Change related UI components. Removes unused props.

No UI change for this PR.