### PR TITLE
Fix not-in-range info style scoping issue

### DIFF
--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -31,20 +31,20 @@ export default class ReplyConnection extends React.PureComponent {
     if (replyType !== 'NOT_ARTICLE') return null;
 
     return (
-      <span>
+      <aside className="not-in-range-info">
         ／ 查證範圍請參考
         <a href={USER_REFERENCE} target="_blank" rel="noopener noreferrer">
           《使用者指南》
         </a>。
         <style jsx>{`
-          span {
+          .not-in-range-info {
             display: inline-block; /* line-break as a whole in small screen */
             margin-left: 0.5em;
             font-size: 12px;
             opacity: 0.75;
           }
         `}</style>
-      </span>
+      </aside>
     );
   };
 


### PR DESCRIPTION
## Before

<img width="713" alt="2018-02-10 12 36 21" src="https://user-images.githubusercontent.com/108608/36038460-c2f20cc4-0dfa-11e8-9721-f634146b0728.png">

## After
<img width="638" alt="2018-02-10 12 35 58" src="https://user-images.githubusercontent.com/108608/36038466-ca01151e-0dfa-11e8-90eb-e2fc03ded95c.png">

## Note

Seems that `<style jsx>` is not scoped to each render function, but scoped to something larger instead. (React component I guess?)

This may lead to some confusion though. Styled-components would not have such issue, maybe we should consider that when applying the actual website theme.