### PR TITLE
Better null handling for authors

### DIFF
--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -99,14 +99,15 @@ export default class ReplyConnection extends React.PureComponent {
   renderAuthor = () => {
     const { replyConnection } = this.props;
     const replyVersion = replyConnection.getIn(['reply', 'versions', 0]);
-    const connectionAuthor = replyConnection.get('user');
-    const replyAuthor = replyVersion.get('user');
+    const connectionAuthor = replyConnection.get('user') || Map();
+    const replyAuthor = replyVersion.get('user') || Map();
 
-    const connectionAuthorName = connectionAuthor
-      ? connectionAuthor.get('name')
-      : '有人';
+    const connectionAuthorName = connectionAuthor.get('name') || '有人';
 
-    if (replyAuthor && connectionAuthor.get('id') !== replyAuthor.get('id')) {
+    if (
+      replyAuthor.get('name') &&
+      connectionAuthor.get('id') !== replyAuthor.get('id')
+    ) {
       return (
         <span>
           {connectionAuthorName}


### PR DESCRIPTION
Currently, visiting this page will show 500:
https://cofacts.g0v.tw/article/AWF5zhDvhutQxxU6triN

The corresponding error log is:
```
site_1          | TypeError: Cannot read property 'get' of null
site_1          |     at ReplyConnection._this.renderAuthor (/srv/www/.next/dist/components/ReplyConnection.js:143:43)
site_1          |     at ReplyConnection.render (/srv/www/.next/dist/components/ReplyConnection.js:185:15)
site_1          |     at za (/srv/www/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:32:322)
site_1          |     at a.render (/srv/www/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:36:18)
site_1          |     at a.read (/srv/www/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:35:250)
site_1          |     at renderToString (/srv/www/node_modules/react-dom/cjs/react-dom-server.node.production.min.js:44:6)
site_1          |     at renderPage (/srv/www/node_modules/next/dist/server/render.js:174:26)
site_1          |     at Function.getInitialProps (/srv/www/node_modules/next/dist/server/document.js:83:25)
site_1          |     at _callee$ (/srv/www/node_modules/next/dist/lib/utils.js:36:30)
site_1          |     at tryCatch (/srv/www/node_modules/regenerator-runtime/runtime.js:65:40)
```

The page contains a reply connection whose author is a user in localhost site.
This will return null in production server.

This PR fixes this by handling the case that replyConnection's author may be null.