### PR TITLE
201712 mappings refactor

### DIFF
--- a/components/CurrentReplies.js
+++ b/components/CurrentReplies.js
@@ -43,7 +43,7 @@ class DeletedItems extends React.Component {
         <ul className="items">
           {items.map(conn => (
             <ReplyConnection
-              key={conn.get('id')}
+              key={`${conn.get('articleId')}__${conn.get('replyId')}`}
               replyConnection={conn}
               onAction={this.handleRestore}
               disabled={disabled}
@@ -123,7 +123,7 @@ export default function CurrentReplies({
       {validConnections.map(conn => (
         <ReplyConnection
           authId={authId}
-          key={conn.get('id')}
+          key={`${conn.get('articleId')}__${conn.get('replyId')}`}
           replyConnection={conn}
           onAction={onDelete}
           onVote={onVote}

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -21,7 +21,7 @@ export default class ReplyConnection extends React.PureComponent {
 
   handleAction = () => {
     const { replyConnection, onAction } = this.props;
-    return onAction(replyConnection.get('id'));
+    return onAction(replyConnection);
   };
 
   renderHint = () => {

--- a/components/ReplyFeedback.js
+++ b/components/ReplyFeedback.js
@@ -25,12 +25,12 @@ export default class ReplyFeedback extends PureComponent {
 
   handleUpVote = () => {
     const { replyConnection, onVote } = this.props;
-    return onVote(replyConnection.get('id'), 'UPVOTE');
+    return onVote(replyConnection, 'UPVOTE');
   };
 
   handleDownVote = () => {
     const { replyConnection, onVote } = this.props;
-    return onVote(replyConnection.get('id'), 'DOWNVOTE');
+    return onVote(replyConnection, 'DOWNVOTE');
   };
 
   getFeedbackScore = () => {

--- a/ducks/__tests__/__snapshots__/articleDetail.js.snap
+++ b/ducks/__tests__/__snapshots__/articleDetail.js.snap
@@ -11,7 +11,8 @@ Immutable.Map {
   },
   "replyConnections": Immutable.List [
     Immutable.Map {
-      "id": "article1-reply1",
+      "articleId": "article1",
+      "replyId": "reply1",
       "canUpdateStatus": true,
       "status": "NORMAL",
       "reply": Immutable.Map {
@@ -75,7 +76,8 @@ Immutable.Map {
 exports[`reducer: articleDetail handles LOAD_AUTH 1`] = `
 Immutable.List [
   Immutable.Map {
-    "id": "article1-reply1",
+    "articleId": "article1",
+    "replyId": "reply1",
     "canUpdateStatus": true,
     "status": "NORMAL",
     "reply": Immutable.Map {

--- a/ducks/articleDetail.js
+++ b/ducks/articleDetail.js
@@ -203,19 +203,20 @@ export const submitReply = params => dispatch => {
   });
 };
 
-export const voteReply = (articleId, replyConnectionId, vote) => dispatch => {
+export const voteReply = (articleId, replyId, vote) => dispatch => {
   dispatch(setState({ key: 'isReplyLoading', value: true }));
   NProgress.start();
   return gql`
-    mutation($replyConnectionId: String!, $vote: FeedbackVote!) {
-      CreateOrUpdateReplyConnectionFeedback(
-        replyConnectionId: $replyConnectionId
+    mutation($articleId: String!, $replyId: String!, $vote: FeedbackVote!) {
+      CreateOrUpdateArticleReplyFeedback(
+        articleId: $articleId
+        replyId: $replyId
         vote: $vote
       ) {
         feedbackCount
       }
     }
-  `({ replyConnectionId, vote }).then(() => {
+  `({ articleId, replyId, vote }).then(() => {
     dispatch(reloadReply(articleId));
     NProgress.done();
   });

--- a/ducks/articleDetail.js
+++ b/ducks/articleDetail.js
@@ -169,7 +169,7 @@ export const updateArticleReplyStatus = (
         replyId: $replyId
         status: $status
       ) {
-        id
+        status
       }
     }
   `({ articleId, replyId, status }).then(() => {

--- a/ducks/articleDetail.js
+++ b/ducks/articleDetail.js
@@ -125,7 +125,7 @@ const reloadReply = articleId => dispatch =>
   gql`
     query($id: String!) {
       GetArticle(id: $id) {
-        replyConnections {
+        replyConnections: articleReplies {
           ...articleReplyFields
         }
       }
@@ -292,7 +292,7 @@ export const searchRepiedArticle = ({ q }) => dispatch => {
             text
             replyCount
             createdAt
-            replyConnections {
+            replyConnections: articleReplies {
               reply {
                 id
                 versions {

--- a/ducks/articleDetail.js
+++ b/ducks/articleDetail.js
@@ -366,7 +366,15 @@ export default createReducer(
               payload.remove('replyConnections').remove('relatedArticles')
             )
           )
-          .setIn(['data', 'replyConnections'], payload.get('replyConnections'))
+          .setIn(
+            ['data', 'replyConnections'],
+            payload
+              .get('replyConnections')
+              .sort(
+                (a, b) =>
+                  new Date(b.get('createdAt')) - new Date(a.get('createdAt'))
+              )
+          )
           .updateIn(
             ['data', 'relatedArticles'],
             articles =>

--- a/ducks/articleDetail.js
+++ b/ducks/articleDetail.js
@@ -142,7 +142,7 @@ export const connectReply = (articleId, replyId) => dispatch => {
   return gql`
     mutation($articleId: String!, $replyId: String!) {
       CreateArticleReply(articleId: $articleId, replyId: $replyId) {
-        id
+        articleId
       }
     }
   `({ articleId, replyId }).then(() => {

--- a/ducks/articleDetail.js
+++ b/ducks/articleDetail.js
@@ -141,7 +141,7 @@ export const connectReply = (articleId, replyId) => dispatch => {
   NProgress.start();
   return gql`
     mutation($articleId: String!, $replyId: String!) {
-      CreateReplyConnection(articleId: $articleId, replyId: $replyId) {
+      CreateArticleReply(articleId: $articleId, replyId: $replyId) {
         id
       }
     }

--- a/ducks/articleDetail.js
+++ b/ducks/articleDetail.js
@@ -31,13 +31,13 @@ const fragments = {
       }
     }
   `,
-  replyConnectionAndUserFields: `
+  articleReplyAndUserFields: `
     fragment userFields on User {
       id
       name
       avatarUrl
     }
-    fragment replyConnectionFields on ReplyConnection {
+    fragment articleReplyFields on ArticleReply {
       id
       canUpdateStatus
       status
@@ -74,14 +74,14 @@ export const load = id => dispatch => {
       GetArticle(id: $id) {
         ...articleFields
         user { ...userFields }
-        replyConnections { ...replyConnectionFields }
+        replyConnections: articleReplies { ...articleReplyFields }
         relatedArticles(filter: {replyCount: {GT: 0}}) {
           edges {
             node {
               ...articleFields
               user { ...userFields }
               replyCount
-              replyConnections { ...replyConnectionFields }
+              replyConnections: articleReplies { ...articleReplyFields }
             }
             score
           }
@@ -89,7 +89,7 @@ export const load = id => dispatch => {
       }
     }
     ${fragments.articleFields}
-    ${fragments.replyConnectionAndUserFields}
+    ${fragments.articleReplyAndUserFields}
   `({ id }).then(resp => {
     dispatch(loadData(resp.getIn(['data', 'GetArticle'])));
     dispatch(setState({ key: 'isLoading', value: false }));
@@ -103,7 +103,7 @@ export const loadAuth = id => dispatch => {
       gql`
         query($id: String!) {
           GetArticle(id: $id) {
-            replyConnections {
+            replyConnections: articleReplies {
               id
               canUpdateStatus
             }
@@ -124,11 +124,11 @@ const reloadReply = articleId => dispatch =>
     query($id: String!) {
       GetArticle(id: $id) {
         replyConnections {
-          ...replyConnectionFields
+          ...articleReplyFields
         }
       }
     }
-    ${fragments.replyConnectionAndUserFields}
+    ${fragments.articleReplyAndUserFields}
   `({ id: articleId }).then(resp => {
     dispatch(loadData(resp.getIn(['data', 'GetArticle'])));
     dispatch(setState({ key: 'isReplyLoading', value: false }));
@@ -236,7 +236,7 @@ export const searchReplies = ({ q }) => dispatch => {
               type
               createdAt
             }
-            replyConnections {
+            replyConnections: articleReplies {
               article {
                 id
                 text

--- a/ducks/fixtures/articleDetail.js
+++ b/ducks/fixtures/articleDetail.js
@@ -18,7 +18,8 @@ export const loadAction = {
             id: 'article1',
             replyConnections: [
               {
-                id: 'article1-relatedReply1',
+                articleId: 'article1',
+                replyId: 'relatedReply1',
                 canUpdateStatus: false,
                 reply: {
                   id: 'relatedReply1',
@@ -31,7 +32,8 @@ export const loadAction = {
                 },
               },
               {
-                id: 'article1-relatedReply2',
+                articleId: 'article1',
+                replyId: 'relatedReply2',
                 canUpdateStatus: false,
                 reply: {
                   id: 'relatedReply2',
@@ -44,7 +46,8 @@ export const loadAction = {
                 },
               },
               {
-                id: 'article1-reply1',
+                articleId: 'article1',
+                replyId: 'reply1',
                 canUpdateStatus: false,
                 reply: {
                   id: 'reply1', // Already added to article (exists in replyConnections)
@@ -67,7 +70,8 @@ export const loadAction = {
             text: '~~黎建南給退休軍公教人員的一封公開信~~',
             replyConnections: [
               {
-                id: 'article2-relatedReply1',
+                articleId: 'article2',
+                replyId: 'relatedReply1',
                 canUpdateStatus: false,
                 reply: {
                   // This is duplicated with related article 1
@@ -88,7 +92,8 @@ export const loadAction = {
     replyRequestCount: 1,
     replyConnections: [
       {
-        id: 'article1-reply1',
+        articleId: 'article1',
+        replyId: 'reply1',
         canUpdateStatus: true,
         status: 'NORMAL',
         reply: {
@@ -188,7 +193,8 @@ export const loadAuthAction = {
   payload: fromJS({
     replyConnections: [
       {
-        id: 'AV9mEFX2yCdS-nWhuiPu__AV9mJJ5qyCdS-nWhuiPz',
+        articleId: 'AV9mEFX2yCdS-nWhuiPu',
+        replyId: 'AV9mJJ5qyCdS-nWhuiPz',
         canUpdateStatus: true,
       },
     ],

--- a/ducks/replyDetail.js
+++ b/ducks/replyDetail.js
@@ -116,19 +116,20 @@ export const updateArticleReplyStatus = (
   });
 };
 
-export const voteReply = (replyId, replyConnectionId, vote) => dispatch => {
+export const voteReply = (articleId, replyId, vote) => dispatch => {
   dispatch(setState({ key: 'isReplyLoading', value: true }));
   NProgress.start();
   return gql`
-    mutation($replyConnectionId: String!, $vote: FeedbackVote!) {
-      CreateOrUpdateReplyConnectionFeedback(
-        replyConnectionId: $replyConnectionId
+    mutation($articleId: String!, $replyId: String!, $vote: FeedbackVote!) {
+      CreateOrUpdateArticleReplyFeedback(
+        articleId: $articleId
+        replyId: $replyId
         vote: $vote
       ) {
         feedbackCount
       }
     }
-  `({ replyConnectionId, vote }).then(() => {
+  `({ articleId, replyId, vote }).then(() => {
     dispatch(load(replyId)).then(() => {
       dispatch(setState({ key: 'isReplyLoading', value: false }));
     });

--- a/ducks/replyDetail.js
+++ b/ducks/replyDetail.js
@@ -32,7 +32,6 @@ export const load = id => dispatch => {
           createdAt
         }
         replyConnections: articleReplies {
-          id
           articleId
           article {
             id

--- a/ducks/replyDetail.js
+++ b/ducks/replyDetail.js
@@ -31,13 +31,15 @@ export const load = id => dispatch => {
           reference
           createdAt
         }
-        replyConnections {
+        replyConnections: articleReplies {
           id
+          articleId
           article {
             id
             text
             replyCount
           }
+          replyId
           user {
             name
           }
@@ -63,8 +65,10 @@ export const loadAuth = id => dispatch => {
       gql`
         query($id: String!) {
           GetReply(id: $id) {
-            replyConnections {
+            replyConnections: articleReplies {
               id
+              articleId
+              replyId
               canUpdateStatus
             }
           }
@@ -77,23 +81,28 @@ export const loadAuth = id => dispatch => {
     });
 };
 
-export const updateReplyConnectionStatus = (
+export const updateArticleReplyStatus = (
+  articleId,
   replyId,
-  replyConnectionId,
   status
 ) => dispatch => {
   dispatch(setState({ key: 'isReplyLoading', value: true }));
   NProgress.start();
   return gql`
-    mutation($replyConnectionId: String!, $status: ReplyConnectionStatusEnum!) {
-      UpdateReplyConnectionStatus(
-        replyConnectionId: $replyConnectionId
+    mutation(
+      $articleId: String!
+      $replyId: String!
+      $status: ArticleReplyStatusEnum!
+    ) {
+      UpdateArticleReplyStatus(
+        articleId: $articleId
+        replyId: $replyId
         status: $status
       ) {
         id
       }
     }
-  `({ replyConnectionId, status }).then(() => {
+  `({ articleId, replyId, status }).then(() => {
     // FIXME:
     // Immediate load(replyId) will not get updated reply connection status.
     // Super wierd.

--- a/ducks/replyDetail.js
+++ b/ducks/replyDetail.js
@@ -65,7 +65,6 @@ export const loadAuth = id => dispatch => {
         query($id: String!) {
           GetReply(id: $id) {
             replyConnections: articleReplies {
-              id
               articleId
               replyId
               canUpdateStatus
@@ -98,7 +97,7 @@ export const updateArticleReplyStatus = (
         replyId: $replyId
         status: $status
       ) {
-        id
+        status
       }
     }
   `({ articleId, replyId, status }).then(() => {

--- a/ducks/replyList.js
+++ b/ducks/replyList.js
@@ -69,7 +69,7 @@ export const load = ({
             type
             createdAt
           }
-          replyConnections(status: NORMAL) { id }
+          replyConnections: articleReplies(status: NORMAL) { replyId }
         }
         cursor
       }

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,6 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./src"
+  },
+  "exclude": ["node_modules"]
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "baseUrl": "./src"
+    "baseUrl": "./"
   },
   "exclude": ["node_modules"]
 }

--- a/pages/article.js
+++ b/pages/article.js
@@ -85,9 +85,9 @@ class ArticlePage extends React.Component {
     ).then(this.scrollToReplySection);
   };
 
-  handleReplyConnectionVote = (replyConnectionId, vote) => {
+  handleReplyConnectionVote = (conn, vote) => {
     const { dispatch, query: { id } } = this.props;
-    return dispatch(voteReply(id, replyConnectionId, vote));
+    return dispatch(voteReply(id, conn.get('replyId'), vote));
   };
 
   handleTabChange = tab => () => {

--- a/pages/article.js
+++ b/pages/article.js
@@ -20,7 +20,7 @@ import {
   connectReply,
   searchReplies,
   searchRepiedArticle,
-  updateReplyConnectionStatus,
+  updateArticleReplyStatus,
   voteReply,
   reset,
 } from 'ducks/articleDetail';
@@ -71,17 +71,17 @@ class ArticlePage extends React.Component {
     );
   };
 
-  handleReplyConnectionDelete = replyConnectionId => {
+  handleReplyConnectionDelete = conn => {
     const { dispatch, query: { id } } = this.props;
     return dispatch(
-      updateReplyConnectionStatus(id, replyConnectionId, 'DELETED')
+      updateArticleReplyStatus(id, conn.get('replyId'), 'DELETED')
     );
   };
 
-  handleReplyConnectionRestore = replyConnectionId => {
+  handleReplyConnectionRestore = conn => {
     const { dispatch, query: { id } } = this.props;
     return dispatch(
-      updateReplyConnectionStatus(id, replyConnectionId, 'NORMAL')
+      updateArticleReplyStatus(id, conn.get('replyId'), 'NORMAL')
     ).then(this.scrollToReplySection);
   };
 

--- a/pages/reply.js
+++ b/pages/reply.js
@@ -6,7 +6,7 @@ import { compose } from 'redux';
 import {
   load,
   loadAuth,
-  updateReplyConnectionStatus,
+  updateArticleReplyStatus,
   voteReply,
 } from '../ducks/replyDetail';
 import Head from 'next/head';
@@ -49,9 +49,9 @@ class ReplyPage extends React.Component {
   handleReplyConnectionDelete = () => {
     const { dispatch, originalReplyConnection, query: { id } } = this.props;
     return dispatch(
-      updateReplyConnectionStatus(
+      updateArticleReplyStatus(
+        originalReplyConnection.get('articleId'),
         id,
-        originalReplyConnection.get('id'),
         'DELETED'
       )
     );
@@ -60,9 +60,9 @@ class ReplyPage extends React.Component {
   handleReplyConnectionRestore = () => {
     const { dispatch, originalReplyConnection, query: { id } } = this.props;
     return dispatch(
-      updateReplyConnectionStatus(
+      updateArticleReplyStatus(
+        originalReplyConnection.get('articleId'),
         id,
-        originalReplyConnection.get('id'),
         'NORMAL'
       )
     );

--- a/pages/reply.js
+++ b/pages/reply.js
@@ -84,9 +84,9 @@ class ReplyPage extends React.Component {
     );
   };
 
-  handleReplyConnectionVote = (replyConnectionId, vote) => {
+  handleReplyConnectionVote = (conn, vote) => {
     const { dispatch, query: { id } } = this.props;
-    return dispatch(voteReply(id, replyConnectionId, vote));
+    return dispatch(voteReply(conn.get('articleId'), id, vote));
   };
 
   renderReply = () => {


### PR DESCRIPTION
Make necessary changes to make the UI compatible with API after [201712-mappings-refactor](https://github.com/cofacts/rumors-api/pull/62).

Since we are having low test coverage in this repository, I am doing minimal changes to support the new API.

Please refer to [staging API site](https://cofacts-api.hacktabl.org) for the new API.

Future improvements should follow these steps:
1. We are having the new UI
2. Implement the new UI
3. Write tests on the new UI

Currently we are not plan to rename concepts/names like 'ReplyConnections' to new names (like "ArticleReplies") thoroughly from rumros-site codebase yet.

We will put that off until we have a new UI, then we will switch to the new name when we are doing UI revamp.
