### PR TITLE
Remove reply version from all logic

### DIFF
--- a/components/Modal/RepliesModal.js
+++ b/components/Modal/RepliesModal.js
@@ -13,17 +13,18 @@ export default function RepliesModal({ replies, onConnect, onModalClose }) {
       <ul className="items">
         {replies.map(reply => {
           const replyId = reply.getIn(['reply', 'id']);
+          const replyType = reply.getIn(['reply', 'type']);
           const createdAt = moment(reply.get('createdAt'));
           return (
             <li key={replyId} className="root">
               <header className="section">
-                被標示為：<strong title={TYPE_DESC[reply.get('type')]}>
-                  {TYPE_NAME[reply.get('type')]}
+                被標示為：<strong title={TYPE_DESC[replyType]}>
+                  {TYPE_NAME[replyType]}
                 </strong>
               </header>
               <section className="section">
                 <ExpandableText wordCount={40}>
-                  {nl2br(linkify(reply.get('text')))}
+                  {nl2br(linkify(reply.getIn(['reply', 'text'])))}
                 </ExpandableText>
               </section>
               <footer>

--- a/components/Modal/RepliesModal.js
+++ b/components/Modal/RepliesModal.js
@@ -13,20 +13,17 @@ export default function RepliesModal({ replies, onConnect, onModalClose }) {
       <ul className="items">
         {replies.map(reply => {
           const replyId = reply.getIn(['reply', 'id']);
-          const replyLastVersion = reply.getIn(['reply', 'versions', '0']);
-          const createdAt = moment(replyLastVersion.get('createdAt'));
+          const createdAt = moment(reply.get('createdAt'));
           return (
             <li key={replyId} className="root">
               <header className="section">
-                被標示為：<strong
-                  title={TYPE_DESC[replyLastVersion.get('type')]}
-                >
-                  {TYPE_NAME[replyLastVersion.get('type')]}
+                被標示為：<strong title={TYPE_DESC[reply.get('type')]}>
+                  {TYPE_NAME[reply.get('type')]}
                 </strong>
               </header>
               <section className="section">
                 <ExpandableText wordCount={40}>
-                  {nl2br(linkify(replyLastVersion.get('text')))}
+                  {nl2br(linkify(reply.get('text')))}
                 </ExpandableText>
               </section>
               <footer>

--- a/components/RelatedReplies.js
+++ b/components/RelatedReplies.js
@@ -9,16 +9,15 @@ import { sectionStyle } from './ReplyConnection.styles';
 function RelatedReplyItem({ reply, similarity, onConnect }) {
   const articleId = reply.getIn(['article', 'id']);
   const articleText = reply.getIn(['article', 'text']);
-  const replyVersion = reply.getIn(['versions', 0]);
-  const createdAt = moment(replyVersion.get('createdAt'));
+  const createdAt = moment(reply.get('createdAt'));
   const similarityPercentage = Math.round(similarity * 100);
   return (
     <li className="root">
       <header className="section">
         <Link route="article" params={{ id: articleId }}>
           <a>相關訊息</a>
-        </Link>被標示為：<strong title={TYPE_DESC[replyVersion.get('type')]}>
-          {TYPE_NAME[replyVersion.get('type')]}
+        </Link>被標示為：<strong title={TYPE_DESC[reply.get('type')]}>
+          {TYPE_NAME[reply.get('type')]}
         </strong>
       </header>
       <section className="section">
@@ -39,9 +38,7 @@ function RelatedReplyItem({ reply, similarity, onConnect }) {
       </section>
       <section className="section">
         <h3>回應</h3>
-        <ExpandableText>
-          {nl2br(linkify(replyVersion.get('text')))}
-        </ExpandableText>
+        <ExpandableText>{nl2br(linkify(reply.get('text')))}</ExpandableText>
       </section>
       <footer>
         <Link route="reply" params={{ id: reply.get('id') }}>

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -26,7 +26,7 @@ export default class ReplyConnection extends React.PureComponent {
 
   renderHint = () => {
     const { replyConnection } = this.props;
-    const replyType = replyConnection.getIn(['reply', 'versions', 0, 'type']);
+    const replyType = replyConnection.getIn(['reply', 'type']);
 
     if (replyType !== 'NOT_ARTICLE') return null;
 
@@ -98,9 +98,9 @@ export default class ReplyConnection extends React.PureComponent {
 
   renderAuthor = () => {
     const { replyConnection } = this.props;
-    const replyVersion = replyConnection.getIn(['reply', 'versions', 0]);
+    const reply = replyConnection.get('reply');
     const connectionAuthor = replyConnection.get('user') || Map();
-    const replyAuthor = replyVersion.get('user') || Map();
+    const replyAuthor = reply.get('user') || Map();
 
     const connectionAuthorName = connectionAuthor.get('name') || '有人';
 
@@ -127,15 +127,10 @@ export default class ReplyConnection extends React.PureComponent {
 
   renderReference = () => {
     const { replyConnection } = this.props;
-    const replyType = replyConnection.getIn(['reply', 'versions', 0, 'type']);
+    const replyType = replyConnection.getIn(['reply', 'type']);
     if (replyType === 'NOT_ARTICLE') return null;
 
-    const reference = replyConnection.getIn([
-      'reply',
-      'versions',
-      0,
-      'reference',
-    ]);
+    const reference = replyConnection.getIn(['reply', 'reference']);
     return (
       <section className="section">
         <h3>{replyType === 'OPINIONATED' ? '不同意見' : '出處'}</h3>
@@ -149,8 +144,8 @@ export default class ReplyConnection extends React.PureComponent {
 
   render() {
     const { replyConnection } = this.props;
-    const replyVersion = replyConnection.getIn(['reply', 'versions', 0]);
-    const replyType = replyVersion.get('type');
+    const reply = replyConnection.get('reply');
+    const replyType = reply.get('type');
 
     return (
       <li className="root">
@@ -163,9 +158,7 @@ export default class ReplyConnection extends React.PureComponent {
         </header>
         <section className="section">
           <h3>理由</h3>
-          <ExpandableText>
-            {nl2br(linkify(replyVersion.get('text')))}
-          </ExpandableText>
+          <ExpandableText>{nl2br(linkify(reply.get('text')))}</ExpandableText>
         </section>
 
         {this.renderReference()}

--- a/components/ReplyItem.js
+++ b/components/ReplyItem.js
@@ -5,9 +5,8 @@ import { listItemStyle } from './ListItem.styles';
 import { TYPE_ICON, TYPE_NAME } from '../constants/replyType';
 
 export default function ReplyItem({ reply, showUser = true }) {
-  const currentVersion = reply.getIn(['versions', 0]);
-  const replyType = currentVersion.get('type');
-  const createdAt = moment(currentVersion.get('createdAt'));
+  const replyType = reply.get('type');
+  const createdAt = moment(reply.get('createdAt'));
 
   return (
     <Link route="reply" params={{ id: reply.get('id') }}>
@@ -15,10 +14,8 @@ export default function ReplyItem({ reply, showUser = true }) {
         <div title={TYPE_NAME[replyType]}>{TYPE_ICON[replyType]}</div>
         <div className="item-content">
           <div className="item-text">
-            {showUser
-              ? `${currentVersion.getIn(['user', 'name'], '有人')}：`
-              : ''}
-            {currentVersion.get('text')}
+            {showUser ? `${reply.getIn(['user', 'name'], '有人')}：` : ''}
+            {reply.get('text')}
           </div>
           <div className="item-info">
             使用於 {reply.get('replyConnectionCount')} 篇

--- a/ducks/__tests__/__snapshots__/articleDetail.js.snap
+++ b/ducks/__tests__/__snapshots__/articleDetail.js.snap
@@ -17,12 +17,8 @@ Immutable.Map {
       "status": "NORMAL",
       "reply": Immutable.Map {
         "id": "reply1",
-        "versions": Immutable.List [
-          Immutable.Map {
-            "type": "NOT_ARTICLE",
-            "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
-          },
-        ],
+        "type": "NOT_ARTICLE",
+        "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
       },
       "feedbacks": Immutable.List [],
       "user": Immutable.Map {
@@ -45,24 +41,16 @@ Immutable.Map {
   "relatedReplies": Immutable.List [
     Immutable.Map {
       "id": "relatedReply1",
-      "versions": Immutable.List [
-        Immutable.Map {
-          "type": "RUMOR",
-          "text": "醫師聽聞後都斥為無稽之談",
-        },
-      ],
+      "type": "RUMOR",
+      "text": "醫師聽聞後都斥為無稽之談",
       "article": Immutable.Map {
         "id": "article1",
       },
     },
     Immutable.Map {
       "id": "relatedReply2",
-      "versions": Immutable.List [
-        Immutable.Map {
-          "type": "RUMOR",
-          "text": "喝冰水跟罹癌根本是兩回事",
-        },
-      ],
+      "type": "RUMOR",
+      "text": "喝冰水跟罹癌根本是兩回事",
       "article": Immutable.Map {
         "id": "article1",
       },
@@ -82,12 +70,8 @@ Immutable.List [
     "status": "NORMAL",
     "reply": Immutable.Map {
       "id": "reply1",
-      "versions": Immutable.List [
-        Immutable.Map {
-          "type": "NOT_ARTICLE",
-          "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
-        },
-      ],
+      "type": "NOT_ARTICLE",
+      "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
     },
     "feedbacks": Immutable.List [],
     "user": Immutable.Map {
@@ -124,19 +108,15 @@ Immutable.Map {
       "status": "NORMAL",
       "reply": Immutable.Map {
         "id": "AV9mN3dDyCdS-nWhuiP3",
-        "versions": Immutable.List [
-          Immutable.Map {
-            "user": Immutable.Map {
-              "id": "AVqVwjqQyrDaTqlmmp_a",
-              "name": null,
-              "avatarUrl": null,
-            },
-            "type": "NOT_ARTICLE",
-            "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
-            "reference": "",
-            "createdAt": "2017-10-29T03:40:31.938Z",
-          },
-        ],
+        "user": Immutable.Map {
+          "id": "AVqVwjqQyrDaTqlmmp_a",
+          "name": null,
+          "avatarUrl": null,
+        },
+        "type": "NOT_ARTICLE",
+        "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
+        "reference": "",
+        "createdAt": "2017-10-29T03:40:31.938Z",
       },
       "feedbacks": Immutable.List [],
       "user": Immutable.Map {
@@ -152,19 +132,15 @@ Immutable.Map {
       "status": "NORMAL",
       "reply": Immutable.Map {
         "id": "AV9mJJ5qyCdS-nWhuiPz",
-        "versions": Immutable.List [
-          Immutable.Map {
-            "user": Immutable.Map {
-              "id": "AVqVwjqQyrDaTqlmmp_a",
-              "name": null,
-              "avatarUrl": null,
-            },
-            "type": "NOT_ARTICLE",
-            "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
-            "reference": "",
-            "createdAt": "2017-10-29T03:19:56.776Z",
-          },
-        ],
+        "user": Immutable.Map {
+          "id": "AVqVwjqQyrDaTqlmmp_a",
+          "name": null,
+          "avatarUrl": null,
+        },
+        "type": "NOT_ARTICLE",
+        "text": "文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。",
+        "reference": "",
+        "createdAt": "2017-10-29T03:19:56.776Z",
       },
       "feedbacks": Immutable.List [],
       "user": Immutable.Map {
@@ -187,24 +163,16 @@ Immutable.Map {
   "relatedReplies": Immutable.List [
     Immutable.Map {
       "id": "relatedReply1",
-      "versions": Immutable.List [
-        Immutable.Map {
-          "type": "RUMOR",
-          "text": "醫師聽聞後都斥為無稽之談",
-        },
-      ],
+      "type": "RUMOR",
+      "text": "醫師聽聞後都斥為無稽之談",
       "article": Immutable.Map {
         "id": "article1",
       },
     },
     Immutable.Map {
       "id": "relatedReply2",
-      "versions": Immutable.List [
-        Immutable.Map {
-          "type": "RUMOR",
-          "text": "喝冰水跟罹癌根本是兩回事",
-        },
-      ],
+      "type": "RUMOR",
+      "text": "喝冰水跟罹癌根本是兩回事",
       "article": Immutable.Map {
         "id": "article1",
       },

--- a/ducks/articleDetail.js
+++ b/ducks/articleDetail.js
@@ -44,14 +44,12 @@ const fragments = {
       replyId
       reply {
         id
-        versions(limit: 1) {
-          user {
-            ...userFields
-          }
-          type
-          text
-          reference
+        user {
+          ...userFields
         }
+        type
+        text
+        reference
       }
       feedbacks {
         user{
@@ -239,11 +237,9 @@ export const searchReplies = ({ q }) => dispatch => {
           cursor
           node {
             id
-            versions {
-              text
-              type
-              createdAt
-            }
+            text
+            type
+            createdAt
             replyConnections: articleReplies {
               article {
                 id
@@ -296,11 +292,9 @@ export const searchRepiedArticle = ({ q }) => dispatch => {
             replyConnections: articleReplies {
               reply {
                 id
-                versions {
-                  text
-                  createdAt
-                  type
-                }
+                text
+                createdAt
+                type
               }
             }
           }
@@ -431,7 +425,7 @@ export default createReducer(
         return Map({
           id: reply.getIn(['node', 'id']),
           article: reply.getIn(['node', 'replyConnections', 0, 'article']),
-          versions: reply.getIn(['node', 'versions']),
+          reply: reply,
         });
       });
       return state.setIn(

--- a/ducks/fixtures/articleDetail.js
+++ b/ducks/fixtures/articleDetail.js
@@ -23,12 +23,8 @@ export const loadAction = {
                 canUpdateStatus: false,
                 reply: {
                   id: 'relatedReply1',
-                  versions: [
-                    {
-                      type: 'RUMOR',
-                      text: '醫師聽聞後都斥為無稽之談',
-                    },
-                  ],
+                  type: 'RUMOR',
+                  text: '醫師聽聞後都斥為無稽之談',
                 },
               },
               {
@@ -37,12 +33,8 @@ export const loadAction = {
                 canUpdateStatus: false,
                 reply: {
                   id: 'relatedReply2',
-                  versions: [
-                    {
-                      type: 'RUMOR',
-                      text: '喝冰水跟罹癌根本是兩回事',
-                    },
-                  ],
+                  type: 'RUMOR',
+                  text: '喝冰水跟罹癌根本是兩回事',
                 },
               },
               {
@@ -51,13 +43,9 @@ export const loadAction = {
                 canUpdateStatus: false,
                 reply: {
                   id: 'reply1', // Already added to article (exists in replyConnections)
-                  versions: [
-                    {
-                      type: 'NOT_ARTICLE',
-                      text:
-                        '文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。',
-                    },
-                  ],
+                  type: 'NOT_ARTICLE',
+                  text:
+                    '文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。',
                 },
               },
             ],
@@ -76,12 +64,8 @@ export const loadAction = {
                 reply: {
                   // This is duplicated with related article 1
                   id: 'relatedReply1',
-                  versions: [
-                    {
-                      type: 'RUMOR',
-                      text: '醫師聽聞後都斥為無稽之談',
-                    },
-                  ],
+                  type: 'RUMOR',
+                  text: '醫師聽聞後都斥為無稽之談',
                 },
               },
             ],
@@ -98,13 +82,8 @@ export const loadAction = {
         status: 'NORMAL',
         reply: {
           id: 'reply1',
-          versions: [
-            {
-              type: 'NOT_ARTICLE',
-              text:
-                '文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。',
-            },
-          ],
+          type: 'NOT_ARTICLE',
+          text: '文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。',
         },
         feedbacks: [],
         user: {
@@ -132,20 +111,15 @@ export const reloadRepliesAction = {
         status: 'NORMAL',
         reply: {
           id: 'AV9mN3dDyCdS-nWhuiP3',
-          versions: [
-            {
-              user: {
-                id: 'AVqVwjqQyrDaTqlmmp_a',
-                name: null,
-                avatarUrl: null,
-              },
-              type: 'NOT_ARTICLE',
-              text:
-                '文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。',
-              reference: '',
-              createdAt: '2017-10-29T03:40:31.938Z',
-            },
-          ],
+          user: {
+            id: 'AVqVwjqQyrDaTqlmmp_a',
+            name: null,
+            avatarUrl: null,
+          },
+          type: 'NOT_ARTICLE',
+          text: '文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。',
+          reference: '',
+          createdAt: '2017-10-29T03:40:31.938Z',
         },
         feedbacks: [],
         user: {
@@ -161,20 +135,15 @@ export const reloadRepliesAction = {
         status: 'NORMAL',
         reply: {
           id: 'AV9mJJ5qyCdS-nWhuiPz',
-          versions: [
-            {
-              user: {
-                id: 'AVqVwjqQyrDaTqlmmp_a',
-                name: null,
-                avatarUrl: null,
-              },
-              type: 'NOT_ARTICLE',
-              text:
-                '文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。',
-              reference: '',
-              createdAt: '2017-10-29T03:19:56.776Z',
-            },
-          ],
+          user: {
+            id: 'AVqVwjqQyrDaTqlmmp_a',
+            name: null,
+            avatarUrl: null,
+          },
+          type: 'NOT_ARTICLE',
+          text: '文字長度太短，疑似為使用者手動輸入之查詢語句，不像轉傳文章。',
+          reference: '',
+          createdAt: '2017-10-29T03:19:56.776Z',
         },
         feedbacks: [],
         user: {

--- a/ducks/replyDetail.js
+++ b/ducks/replyDetail.js
@@ -25,12 +25,10 @@ export const load = id => dispatch => {
   return gql`
     query($id: String!) {
       GetReply(id: $id) {
-        versions(limit: 1) {
-          type
-          text
-          reference
-          createdAt
-        }
+        type
+        text
+        reference
+        createdAt
         replyConnections: articleReplies {
           articleId
           article {

--- a/ducks/replyList.js
+++ b/ducks/replyList.js
@@ -62,13 +62,11 @@ export const load = ({
       edges {
         node {
           id
-          versions(limit: 1) {
-            user { name }
-            reference
-            text
-            type
-            createdAt
-          }
+          user { name }
+          reference
+          text
+          type
+          createdAt
           replyConnections: articleReplies(status: NORMAL) { replyId }
         }
         cursor

--- a/pages/reply.js
+++ b/pages/reply.js
@@ -154,21 +154,20 @@ class ReplyPage extends React.Component {
 
   render() {
     const { isLoading, reply, originalReplyConnection } = this.props;
-    const currentVersion = reply.getIn(['versions', 0]);
     const originalArticle = originalReplyConnection.get('article');
 
-    if (isLoading && currentVersion === null) {
+    if (isLoading && reply === null) {
       return <div>Loading...</div>;
     }
 
-    if (currentVersion === null) {
+    if (reply === null) {
       return <div>Reply not found.</div>;
     }
 
     return (
       <div className="root">
         <Head>
-          <title>{currentVersion.get('text').slice(0, 15)}⋯⋯ - 回應</title>
+          <title>{reply.get('text').slice(0, 15)}⋯⋯ - 回應</title>
         </Head>
 
         <section className="section">


### PR DESCRIPTION
This PR removes all deprecated `replies.versions`.

After this we can finally remove the deprecated fields in rumors-api.
