### PR TITLE
Fix level-up detection causing logout to fail

### DIFF
--- a/components/App/UserName.js
+++ b/components/App/UserName.js
@@ -197,6 +197,7 @@ class UserName extends PureComponent {
   componentDidUpdate(prevProps) {
     if (
       prevProps.user &&
+      this.props.user &&
       prevProps.user.get('level') !== this.props.user.get('level')
     ) {
       // show level up popup


### PR DESCRIPTION
As specified by #129 ,
Previously logging out may cause error (reproducible on [staging](https://cofacts.hacktabl.org/articles) now).

This PR fixes the issue by handling the case where the new `user` becomes null after logout.

After fix:
![logout](https://user-images.githubusercontent.com/108608/44600149-fea27880-a80a-11e8-8f46-28e91f8db321.gif)

