### PR TITLE
Url preview for aritcles and replies

### DIFF
--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -6,11 +6,20 @@ import { List, Map } from 'immutable';
  * @param {Map} props.hyperlink -
  */
 function Hyperlink({ hyperlink = Map() }) {
+  const title = hyperlink.get('title');
   const summary = (hyperlink.get('summary') || '').slice(0, 200);
+
   return (
     <article className="link">
-      <h1>{hyperlink.get('title')}</h1>
-      <p className="url">{hyperlink.get('url')}</p>
+      <h1 title={title}>{title}</h1>
+      <a
+        className="url"
+        href={hyperlink.get('url')}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {hyperlink.get('url')}
+      </a>
       <p className="summary" title={summary}>
         {summary}
       </p>
@@ -31,6 +40,7 @@ function Hyperlink({ hyperlink = Map() }) {
         }
 
         .url {
+          display: block;
           font-size: 12px;
           white-space: nowrap;
           overflow: hidden;

--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -1,0 +1,76 @@
+import React from 'react';
+import { List, Map } from 'immutable';
+
+/**
+ *
+ * @param {Map} props.hyperlink -
+ */
+function Hyperlink({ hyperlink = Map() }) {
+  const summary = (hyperlink.get('summary') || '').slice(0, 200);
+  return (
+    <article className="link">
+      <h1>{hyperlink.get('title')}</h1>
+      <p className="url">{hyperlink.get('url')}</p>
+      <p className="summary" title={summary}>
+        {summary}
+      </p>
+      <style jsx>{`
+        .link {
+          max-width: 240px;
+          padding: 16px;
+          border: 1px solid rgba(0, 0, 0, 0.2);
+          margin: 0 8px 8px 0;
+        }
+
+        .link h1 {
+          font-size: 14px;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          margin: 0;
+        }
+
+        .url {
+          font-size: 12px;
+          white-space: nowrap;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          color: #999;
+          margin: 8px 0;
+        }
+
+        .summary {
+          font-size: 12px;
+          color: #333;
+          max-height: 40px;
+          overflow: hidden;
+          margin: 0;
+        }
+      `}</style>
+    </article>
+  );
+}
+
+/**
+ * @param {List} props.hyperlinks
+ */
+function Hyperlinks({ hyperlinks = List() }) {
+  if (hyperlinks.size === 0) return null;
+
+  return (
+    <section className="links">
+      {hyperlinks
+        .map((hyperlink, idx) => <Hyperlink key={idx} hyperlink={hyperlink} />)
+        .toArray()}
+      <style jsx>{`
+        .links {
+          display: flex;
+          flex-flow: row wrap;
+          margin: 16px 0 8px;
+        }
+      `}</style>
+    </section>
+  );
+}
+
+export default Hyperlinks;

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -9,6 +9,8 @@ import { nl2br, linkify } from '../util/text';
 import { sectionStyle } from './ReplyConnection.styles';
 import ReplyFeedback from './ReplyFeedback';
 import EditorName from './EditorName';
+import Hyperlinks from './Hyperlinks';
+
 export default class ReplyConnection extends React.PureComponent {
   static defaultProps = {
     replyConnection: Map(),
@@ -144,6 +146,10 @@ export default class ReplyConnection extends React.PureComponent {
         {reference
           ? nl2br(linkify(reference))
           : '⚠️️ 此回應沒有出處，請自行斟酌回應真實性。'}
+
+        <Hyperlinks
+          hyperlinks={replyConnection.getIn(['reply', 'hyperlinks'])}
+        />
         <style jsx>{sectionStyle}</style>
       </section>
     );

--- a/ducks/articleDetail.js
+++ b/ducks/articleDetail.js
@@ -30,6 +30,9 @@ const fragments = {
       references {
         type
       }
+      hyperlinks {
+        ...hyperlinkFields
+      }
     }
   `,
   replyRequestsFields: `
@@ -60,6 +63,9 @@ const fragments = {
         type
         text
         reference
+        hyperlinks {
+          ...hyperlinkFields
+        }
       }
       feedbacks {
         user{
@@ -69,6 +75,13 @@ const fragments = {
       }
       user { ...userFields }
       createdAt
+    }
+  `,
+  hyperlinkFields: `
+    fragment hyperlinkFields on Hyperlink {
+      title
+      url
+      summary
     }
   `,
 };
@@ -111,6 +124,7 @@ export const load = id => dispatch => {
     ${fragments.articleFields}
     ${fragments.replyRequestsFields}
     ${fragments.articleReplyAndUserFields}
+    ${fragments.hyperlinkFields}
   `({ id }).then(resp => {
     dispatch(loadData(resp.getIn(['data', 'GetArticle'])));
     dispatch(setState({ key: 'isLoading', value: false }));
@@ -151,6 +165,7 @@ const reloadReply = articleId => dispatch =>
       }
     }
     ${fragments.articleReplyAndUserFields}
+    ${fragments.hyperlinkFields}
   `({ id: articleId }).then(resp => {
     dispatch(loadData(resp.getIn(['data', 'GetArticle'])));
     dispatch(setState({ key: 'isReplyLoading', value: false }));

--- a/ducks/replyDetail.js
+++ b/ducks/replyDetail.js
@@ -29,12 +29,18 @@ export const load = id => dispatch => {
         text
         reference
         createdAt
+        hyperlinks {
+          ...hyperlinkFields
+        }
         replyConnections: articleReplies {
           articleId
           article {
             id
             text
             replyCount
+            hyperlinks {
+              ...hyperlinkFields
+            }
           }
           replyId
           user {
@@ -53,6 +59,11 @@ export const load = id => dispatch => {
           createdAt
         }
       }
+    }
+    fragment hyperlinkFields on Hyperlink {
+      title
+      url
+      summary
     }
   `({ id }).then(resp => {
     dispatch(loadData(resp.getIn(['data', 'GetReply'])));

--- a/pages/article.js
+++ b/pages/article.js
@@ -13,6 +13,7 @@ import RelatedReplies from 'components/RelatedReplies';
 import ReplySearch from 'components/ReplySearch/ReplySearch.js';
 import ReplyForm from 'components/ReplyForm';
 import ReplyRequestReason from 'components/ReplyRequestReason';
+import Hyperlinks from 'components/Hyperlinks';
 import {
   load,
   loadAuth,
@@ -242,6 +243,7 @@ class ArticlePage extends React.Component {
                 },
               })
             )}
+            <Hyperlinks hyperlinks={article.get('hyperlinks')} />
           </article>
           <footer>
             {article.get('replyRequests').map((replyRequest, index) => {

--- a/pages/reply.js
+++ b/pages/reply.js
@@ -15,6 +15,7 @@ import { nl2br, linkify } from '../util/text';
 import app from 'components/App';
 import ReplyConnection from 'components/ReplyConnection';
 import EditorName from 'components/EditorName';
+import Hyperlinks from 'components/Hyperlinks';
 
 import { detailStyle } from './article.styles';
 import { listItemStyle } from 'components/ListItem.styles';
@@ -197,6 +198,7 @@ class ReplyPage extends React.Component {
                 props: { target: '_blank' },
               })
             )}
+            <Hyperlinks hyperlinks={originalArticle.get('hyperlinks')} />
           </div>
         </section>
 


### PR DESCRIPTION
Shows URL title & summary for article & reply.

Fixes #102 

# Screenshots

## Article page, article
<img width="735" alt="2018-10-10 6 13 52" src="https://user-images.githubusercontent.com/108608/46729756-d1296580-ccb8-11e8-8ddc-6b401473eea8.png">

## Article page, reply
With one broken link (page not accessible)
<img width="668" alt="2018-10-10 6 13 43" src="https://user-images.githubusercontent.com/108608/46729771-db4b6400-ccb8-11e8-8b89-d8b1084b2be2.png">

## Reply page, article
<img width="558" alt="2018-10-10 6 19 36" src="https://user-images.githubusercontent.com/108608/46729899-3715ed00-ccb9-11e8-9f32-fe31f5055411.png">
