### PR TITLE
<Hyperlinks> prop null handling

### DIFF
--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -113,7 +113,7 @@ function Hyperlink({ hyperlink = Map() }) {
  * @param {List} props.hyperlinks
  */
 function Hyperlinks({ hyperlinks = List() }) {
-  if (hyperlinks.size === 0) return null;
+  if (!hyperlinks || hyperlinks.size === 0) return null;
 
   return (
     <section className="links">


### PR DESCRIPTION
# Root cause
API server would return `null` for `hyperlinks` field for some articles.

![2018-10-16 10 54 14](https://user-images.githubusercontent.com/108608/47025661-7ac79580-d196-11e8-91b0-4672d7c7e156.png)

# Proposed fix
Handle `null` in `<Hyperlinks>`

# Screenshot
Connect localhost to production API server, can open the page that errors in production:
![2018-10-16 10 51 51](https://user-images.githubusercontent.com/108608/47025552-4a7ff700-d196-11e8-8f5e-4b85ac447aa9.png)

