### PR TITLE
Implement a create-article page for editors

### DIFF
--- a/pages/create.js
+++ b/pages/create.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import gql from '../util/gql';
+import Head from 'next/head';
+import Router from 'next/router';
+
+import app from 'components/App';
+
+class CreateArticlePage extends React.Component {
+  state = {
+    isSubmitting: false,
+  };
+
+  handleSubmit = e => {
+    e.preventDefault();
+    this.setState({ isSubmitting: true });
+
+    const text = e.target.text.value.trim();
+    const reason = e.target.reason.value.trim();
+    const reference = e.target.references.value.trim();
+
+    gql`
+      mutation(
+        $text: String!
+        $reference: ArticleReferenceInput!
+        $reason: String
+      ) {
+        CreateArticle(text: $text, reference: $reference, reason: $reason) {
+          id
+        }
+      }
+    `({
+      text,
+      reason,
+      reference: {
+        type: 'URL',
+        permalink: reference,
+      },
+    }).then(resp => {
+      this.setState({ isSubmitting: false });
+
+      if (resp.get('errors')) {
+        console.error(resp.get('errors'));
+        return;
+      }
+
+      const id = resp.getIn(['data', 'CreateArticle', 'id']);
+
+      Router.push(`/article/${id}`);
+    });
+  };
+
+  render() {
+    const { isSubmitting } = this.state;
+
+    return (
+      <div className="root">
+        <Head>
+          <title>送出新訊息到資料庫 | Cofacts 真的假的</title>
+        </Head>
+        <form onSubmit={this.handleSubmit}>
+          <h2>訊息原文</h2>
+          <textarea name="text" rows="6" />
+          <h2>理由</h2>
+          <textarea name="reason" row="2" />
+          <h2>訊息來源網址</h2>
+          <input type="text" name="references" />
+
+          <hr />
+
+          <button type="submit" disabled={isSubmitting}>
+            送出新訊息
+          </button>
+        </form>
+        <style jsx>{`
+          .root {
+            padding: 0 40px 40px;
+          }
+
+          textarea,
+          input {
+            width: 100%;
+          }
+        `}</style>
+      </div>
+    );
+  }
+}
+
+export default app()(CreateArticlePage);


### PR DESCRIPTION
A place for editors to input rumors they saw elsewhere.

Currently the page `/create` is not shown publicly.

![submit](https://user-images.githubusercontent.com/108608/47875422-787d6080-de51-11e8-8739-42151905beb9.gif)
