### PR TITLE
Shrank url image preview and paddings to fit mobile

### DIFF
--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -65,7 +65,7 @@ function Hyperlink({ hyperlink = Map() }) {
 
         .preview__container {
           display: flex;
-          border-left: 3px solid rgba(0,0,0,0.2);
+          border-left: 3px solid rgba(0, 0, 0, 0.2);
           padding-left: 10px;
           padding-right: 15px;
           min-height: 40px;

--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -32,53 +32,63 @@ function Hyperlink({ hyperlink = Map() }) {
 
   return (
     <article className="link">
-      {topImageUrl && (
-        <figure
-          className="preview"
-          style={{ backgroundImage: `url(${topImageUrl})` }}
-        />
-      )}
-      <div className="info">
-        <h1 title={title}>{title}</h1>
-        <a
-          className="url"
-          href={hyperlink.get('url')}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {hyperlink.get('url')}
-        </a>
-        <p className="summary" title={summary}>
+      <h1 title={title}>{title}</h1>
+      <a
+        className="url"
+        href={hyperlink.get('url')}
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        {hyperlink.get('url')}
+      </a>
+      <div className="preview__container">
+        <p className="preview__summary" title={summary}>
           {summary}
         </p>
-        {error && <p className="error">{getErrorText(error)}</p>}
+        {topImageUrl && (
+          <figure
+            className="preview__img"
+            style={{ backgroundImage: `url(${topImageUrl})` }}
+          />
+        )}
       </div>
+
+      {error && <p className="error">{getErrorText(error)}</p>}
       <style jsx>{`
         .link {
-          display: flex;
           border: 1px solid rgba(0, 0, 0, 0.2);
+          padding: 12px 8px;
           margin: 0 8px 8px 0;
+          width: 100%;
+          overflow: hidden;
         }
 
-        .preview {
+        .preview__container {
+          display: flex;
+          border-left: 3px solid rgba(0,0,0,0.2);
+          padding-left: 10px;
+          padding-right: 15px;
+          min-height: 40px;
+          justify-content: space-between;
+        }
+
+        .preview__img {
           margin: 0;
-          width: 144px;
+          max-height: 60px;
+          min-width: 60px;
           border-right: 1px solid rgba(0, 0, 0, 0.2);
           background: #ccc center center no-repeat;
           background-size: cover;
-        }
-
-        .info {
-          padding: 16px;
-          max-width: 240px;
+          border-radius: 3px;
         }
 
         .link h1 {
           font-size: 14px;
-          white-space: nowrap;
           overflow: hidden;
           text-overflow: ellipsis;
+          white-space: nowrap;
           margin: 0;
+          max-width: inherit;
         }
 
         .url {
@@ -88,15 +98,17 @@ function Hyperlink({ hyperlink = Map() }) {
           overflow: hidden;
           text-overflow: ellipsis;
           color: #999;
-          margin: 8px 0;
+          margin-bottom: 8px;
         }
 
-        .summary {
+        .preview__summary {
           font-size: 12px;
           color: #333;
           max-height: 40px;
           overflow: hidden;
           margin: 0;
+          display: flex;
+          margin-right: 10px;
         }
 
         .error {
@@ -125,6 +137,7 @@ function Hyperlinks({ hyperlinks = List() }) {
           display: flex;
           flex-flow: row wrap;
           margin: 16px 0 8px;
+          max-width: 100%;
         }
       `}</style>
     </section>

--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -51,9 +51,9 @@ function Hyperlink({ hyperlink = Map() }) {
             style={{ backgroundImage: `url(${topImageUrl})` }}
           />
         )}
+        {error && <p className="error">{getErrorText(error)}</p>}
       </div>
 
-      {error && <p className="error">{getErrorText(error)}</p>}
       <style jsx>{`
         .link {
           border: 1px solid rgba(0, 0, 0, 0.2);


### PR DESCRIPTION
#144 

Before:
![47057407-1686ef00-d1f3-11e8-9a30-b48ddd868d34](https://user-images.githubusercontent.com/6004342/54066003-74c87300-4263-11e9-9962-0680d970a0f1.png)

After
<img width="421" alt="Screen Shot 2019-03-09 at 12 03 52 PM" src="https://user-images.githubusercontent.com/6004342/54066006-801b9e80-4263-11e9-89f4-2c4b6e713c97.png">
