### PR TITLE
Add "copy to clipboard" button to each reply

### DIFF
--- a/components/CopyButton.js
+++ b/components/CopyButton.js
@@ -27,7 +27,8 @@ export default class CopyButton extends React.PureComponent {
           'data-balloon': '複製成功！',
           'data-balloon-visible': '',
           'data-balloon-pos': 'up',
-        }});
+        },
+      });
 
       setTimeout(function() {
         self.setState({ tooltipAttrs: {} });
@@ -36,13 +37,12 @@ export default class CopyButton extends React.PureComponent {
   }
 
   render() {
+    const { tooltipAttrs } = this.state;
     return (
       <button
         ref={this.copyBtnRef}
-        key="copy"
-        onClick={() => {}}
         className="btn-copy"
-        { ...this.state.tooltipAttrs }
+        {...tooltipAttrs}
       >
         複製到剪貼簿
         <style jsx>{`

--- a/components/CopyButton.js
+++ b/components/CopyButton.js
@@ -39,11 +39,7 @@ export default class CopyButton extends React.PureComponent {
   render() {
     const { tooltipAttrs } = this.state;
     return (
-      <button
-        ref={this.copyBtnRef}
-        className="btn-copy"
-        {...tooltipAttrs}
-      >
+      <button ref={this.copyBtnRef} className="btn-copy" {...tooltipAttrs}>
         複製到剪貼簿
         <style jsx>{`
           .btn-copy {

--- a/components/CopyButton.js
+++ b/components/CopyButton.js
@@ -6,7 +6,6 @@ export default class CopyButton extends React.PureComponent {
   constructor(props) {
     super(props);
     this.copyBtnRef = React.createRef();
-    this.clipboardRef = React.createRef();
   }
 
   static defaultProps = {
@@ -17,10 +16,10 @@ export default class CopyButton extends React.PureComponent {
   };
 
   componentDidMount() {
-    this.clipboardRef.current = new ClipboardJS(this.copyBtnRef.current, {
+    const clipboard = new ClipboardJS(this.copyBtnRef.current, {
       text: () => this.props.content,
     });
-    this.clipboardRef.current.on('success', () => {
+    clipboard.on('success', () => {
       const self = this;
       this.setState({
         tooltipAttrs: {

--- a/components/CopyButton.js
+++ b/components/CopyButton.js
@@ -25,7 +25,6 @@ export default class CopyButton extends React.PureComponent {
         key="copy"
         onClick={() => {}}
         className="btn-copy"
-        data-clipboard-target="#testCopyTarget"
       >
         複製到剪貼簿
         <style jsx>{`

--- a/components/CopyButton.js
+++ b/components/CopyButton.js
@@ -4,7 +4,7 @@ import ClipboardJS from 'clipboard';
 export default class CopyButton extends React.PureComponent {
   constructor(props) {
     super(props);
-    this.btnRef = React.createRef();
+    this.copyBtnRef = React.createRef();
     this.clipboardRef = React.createRef();
   }
 
@@ -13,7 +13,7 @@ export default class CopyButton extends React.PureComponent {
   };
 
   componentDidMount() {
-    this.clipboardRef.current = new ClipboardJS(this.btnRef.current, {
+    this.clipboardRef.current = new ClipboardJS(this.copyBtnRef.current, {
       text: () => this.props.content,
     });
   }
@@ -21,7 +21,7 @@ export default class CopyButton extends React.PureComponent {
   render() {
     return (
       <button
-        ref={this.btnRef}
+        ref={this.copyBtnRef}
         key="copy"
         onClick={() => {}}
         className="btn-copy"

--- a/components/CopyButton.js
+++ b/components/CopyButton.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import ClipboardJS from 'clipboard';
+
+export default class CopyButton extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.btnRef = React.createRef();
+  }
+
+  static defaultProps = {
+    content: '',
+  };
+
+  componentDidMount() {
+    console.log(this.btnRef.current);
+  }
+
+  render() {
+    return (
+      <button
+        ref={this.btnRef}
+        key="copy"
+        onClick={() => {}}
+        className="btn-copy"
+        data-clipboard-target="#testCopyTarget"
+      >
+        複製到剪貼簿
+        <style jsx>{`
+          .btn-copy {
+            margin-left: 10px;
+          }
+        `}</style>
+      </button>
+    );
+  }
+}

--- a/components/CopyButton.js
+++ b/components/CopyButton.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import ClipboardJS from 'clipboard';
 import 'balloon-css/balloon.css';
-import levelNames from "../constants/levelNames";
 
 export default class CopyButton extends React.PureComponent {
   constructor(props) {
@@ -13,23 +12,26 @@ export default class CopyButton extends React.PureComponent {
   static defaultProps = {
     content: '',
   };
+  state = {
+    btnAttributes: {},
+  };
 
   componentDidMount() {
-
     this.clipboardRef.current = new ClipboardJS(this.copyBtnRef.current, {
       text: () => this.props.content,
     });
     this.clipboardRef.current.on('success', () => {
-      // this.setState({ isSuccessMsgShow: true });
-      const copyBtnRef = this.copyBtnRef.current;
-      copyBtnRef.setAttribute('data-balloon', '複製成功！');
-      copyBtnRef.setAttribute('data-balloon-visible', '');
-      copyBtnRef.setAttribute('data-balloon-pos', 'up');
+      const self = this;
+      this.setState({
+        btnAttributes: {
+          'data-balloon': '複製成功！',
+          'data-balloon-visible': '',
+          'data-balloon-pos': 'up',
+        }});
+
       setTimeout(function() {
-        copyBtnRef.removeAttribute('data-balloon');
-        copyBtnRef.removeAttribute('data-balloon-visible');
-        copyBtnRef.removeAttribute('data-balloon-pos');
-      }, 3000);
+        self.setState({ btnAttributes: {} });
+      }, 1000);
     });
   }
 
@@ -40,6 +42,7 @@ export default class CopyButton extends React.PureComponent {
         key="copy"
         onClick={() => {}}
         className="btn-copy"
+        { ...this.state.btnAttributes }
       >
         複製到剪貼簿
         <style jsx>{`

--- a/components/CopyButton.js
+++ b/components/CopyButton.js
@@ -13,7 +13,7 @@ export default class CopyButton extends React.PureComponent {
     content: '',
   };
   state = {
-    btnAttributes: {},
+    tooltipAttrs: {},
   };
 
   componentDidMount() {
@@ -23,14 +23,14 @@ export default class CopyButton extends React.PureComponent {
     this.clipboardRef.current.on('success', () => {
       const self = this;
       this.setState({
-        btnAttributes: {
+        tooltipAttrs: {
           'data-balloon': '複製成功！',
           'data-balloon-visible': '',
           'data-balloon-pos': 'up',
         }});
 
       setTimeout(function() {
-        self.setState({ btnAttributes: {} });
+        self.setState({ tooltipAttrs: {} });
       }, 1000);
     });
   }
@@ -42,7 +42,7 @@ export default class CopyButton extends React.PureComponent {
         key="copy"
         onClick={() => {}}
         className="btn-copy"
-        { ...this.state.btnAttributes }
+        { ...this.state.tooltipAttrs }
       >
         複製到剪貼簿
         <style jsx>{`

--- a/components/CopyButton.js
+++ b/components/CopyButton.js
@@ -5,6 +5,7 @@ export default class CopyButton extends React.PureComponent {
   constructor(props) {
     super(props);
     this.btnRef = React.createRef();
+    this.clipboardRef = React.createRef();
   }
 
   static defaultProps = {
@@ -12,7 +13,9 @@ export default class CopyButton extends React.PureComponent {
   };
 
   componentDidMount() {
-    console.log(this.btnRef.current);
+    this.clipboardRef.current = new ClipboardJS(this.btnRef.current, {
+      text: () => this.props.content,
+    });
   }
 
   render() {

--- a/components/CopyButton.js
+++ b/components/CopyButton.js
@@ -1,5 +1,7 @@
 import React from 'react';
 import ClipboardJS from 'clipboard';
+import 'balloon-css/balloon.css';
+import levelNames from "../constants/levelNames";
 
 export default class CopyButton extends React.PureComponent {
   constructor(props) {
@@ -13,8 +15,21 @@ export default class CopyButton extends React.PureComponent {
   };
 
   componentDidMount() {
+
     this.clipboardRef.current = new ClipboardJS(this.copyBtnRef.current, {
       text: () => this.props.content,
+    });
+    this.clipboardRef.current.on('success', () => {
+      // this.setState({ isSuccessMsgShow: true });
+      const copyBtnRef = this.copyBtnRef.current;
+      copyBtnRef.setAttribute('data-balloon', '複製成功！');
+      copyBtnRef.setAttribute('data-balloon-visible', '');
+      copyBtnRef.setAttribute('data-balloon-pos', 'up');
+      setTimeout(function() {
+        copyBtnRef.removeAttribute('data-balloon');
+        copyBtnRef.removeAttribute('data-balloon-visible');
+        copyBtnRef.removeAttribute('data-balloon-pos');
+      }, 3000);
     });
   }
 

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from '../routes';
-import { List, Map } from 'immutable';
+import { Map } from 'immutable';
 import { TYPE_NAME, TYPE_DESC } from '../constants/replyType';
 import { USER_REFERENCE } from '../constants/urls';
 import moment from 'moment';

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -88,7 +88,15 @@ export default class ReplyConnection extends React.PureComponent {
               </button>,
             ]
           : ''}
+        <button key="copy" onClick={() => {}} className="btn-copy">
+          複製到剪貼簿
+        </button>
         <ReplyFeedback replyConnection={replyConnection} onVote={onVote} />
+        <style jsx>{`
+          .btn-copy {
+            margin-left: 10px;
+          }
+        `}</style>
       </footer>
     );
   };

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -68,11 +68,9 @@ export default class ReplyConnection extends React.PureComponent {
     const reply = replyConnection.get('reply');
     const copyText =
       typeof window !== 'undefined'
-        ? `${TYPE_NAME[reply.get('type')]}
-        【理由】${reply.get('text')} 
-        ↓詳細解釋↓
-        ${window.location.href}
-      `
+        ? `${TYPE_NAME[reply.get('type')]} \n【理由】${reply
+            .get('text')
+            .trim()}\n↓詳細解釋↓\n${window.location.href}`
         : '';
 
     return (

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -89,7 +89,7 @@ export default class ReplyConnection extends React.PureComponent {
               </button>,
             ]
           : ''}
-        <CopyButton />
+        <CopyButton content={`我從外面來`} />
         <p id="testCopyTarget">
           Lorem ipsum dolor sit amet, consectetur adipisicing elit. Facere,
           laborum.

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Link } from '../routes';
-import { Map } from 'immutable';
+import { List, Map } from 'immutable';
 import { TYPE_NAME, TYPE_DESC } from '../constants/replyType';
 import { USER_REFERENCE } from '../constants/urls';
 import moment from 'moment';
@@ -66,11 +66,19 @@ export default class ReplyConnection extends React.PureComponent {
     );
 
     const reply = replyConnection.get('reply');
+
+    const hyperlinks = replyConnection.getIn(['reply', 'hyperlinks']) || List();
+    const linksForPrint = hyperlinks
+      .map(item => item.get('url'))
+      .toJS()
+      .join('\n');
+    const reference = !hyperlinks.isEmpty() ? `\n↓出處↓\n${linksForPrint}` : '';
+
     const copyText =
       typeof window !== 'undefined'
         ? `${TYPE_NAME[reply.get('type')]} \n【理由】${reply
             .get('text')
-            .trim()}\n↓詳細解釋↓\n${window.location.href}`
+            .trim()}\n↓詳細解釋↓\n${window.location.href}${reference}`
         : '';
 
     return (

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -177,9 +177,7 @@ export default class ReplyConnection extends React.PureComponent {
         </header>
         <section className="section">
           <h3>理由</h3>
-          <ExpandableText id="foo">
-            {nl2br(linkify(reply.get('text')))}
-          </ExpandableText>
+          <ExpandableText>{nl2br(linkify(reply.get('text')))}</ExpandableText>
         </section>
 
         {this.renderReference()}

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -67,18 +67,24 @@ export default class ReplyConnection extends React.PureComponent {
 
     const reply = replyConnection.get('reply');
 
-    const hyperlinks = replyConnection.getIn(['reply', 'hyperlinks']) || List();
-    const linksForPrint = hyperlinks
-      .map(item => item.get('url'))
-      .toJS()
-      .join('\n');
-    const reference = !hyperlinks.isEmpty() ? `\n↓出處↓\n${linksForPrint}` : '';
+    const getReferenceText = () => {
+      const hyperlinks =
+        replyConnection.getIn(['reply', 'hyperlinks']) || List();
+      if (hyperlinks.isEmpty()) {
+        return '';
+      }
+      const linksStr = hyperlinks
+        .map(item => item.get('url'))
+        .toJS()
+        .join('\n');
+      return `\n↓出處↓\n${linksStr}`;
+    };
 
     const copyText =
       typeof window !== 'undefined'
         ? `${TYPE_NAME[reply.get('type')]} \n【理由】${reply
             .get('text')
-            .trim()}\n↓詳細解釋↓\n${window.location.href}${reference}`
+            .trim()}\n↓詳細解釋↓\n${window.location.href}${getReferenceText()}`
         : '';
 
     return (

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -66,11 +66,14 @@ export default class ReplyConnection extends React.PureComponent {
     );
 
     const reply = replyConnection.get('reply');
-    const copyText = `
-      以上圖片含有不實訊息
-      【理由】${nl2br(linkify(reply.get('text')))} 
-      ↓詳細解釋↓
-    `;
+    const copyText =
+      typeof window !== 'undefined'
+        ? `${TYPE_NAME[reply.get('type')]}
+        【理由】${reply.get('text')} 
+        ↓詳細解釋↓
+        ${window.location.href}
+      `
+        : '';
 
     return (
       <footer>

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -65,6 +65,13 @@ export default class ReplyConnection extends React.PureComponent {
       <span title={createdAt.format('lll')}>{createdAt.fromNow()}</span>
     );
 
+    const reply = replyConnection.get('reply');
+    const copyText = `
+      以上圖片含有不實訊息
+      【理由】${nl2br(linkify(reply.get('text')))} 
+      ↓詳細解釋↓
+    `;
+
     return (
       <footer>
         {linkToReply ? (
@@ -89,11 +96,7 @@ export default class ReplyConnection extends React.PureComponent {
               </button>,
             ]
           : ''}
-        <CopyButton content={`我從外面來`} />
-        <p id="testCopyTarget">
-          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Facere,
-          laborum.
-        </p>
+        <CopyButton content={copyText} />
         <ReplyFeedback replyConnection={replyConnection} onVote={onVote} />
       </footer>
     );

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -68,16 +68,8 @@ export default class ReplyConnection extends React.PureComponent {
     const reply = replyConnection.get('reply');
 
     const getReferenceText = () => {
-      const hyperlinks =
-        replyConnection.getIn(['reply', 'hyperlinks']) || List();
-      if (hyperlinks.isEmpty()) {
-        return '';
-      }
-      const linksStr = hyperlinks
-        .map(item => item.get('url'))
-        .toJS()
-        .join('\n');
-      return `\n↓出處↓\n${linksStr}`;
+      const hyperlinks = reply.get('reference');
+      return `\n↓出處↓\n${hyperlinks}`;
     };
 
     const copyText =

--- a/components/ReplyConnection.js
+++ b/components/ReplyConnection.js
@@ -10,6 +10,7 @@ import { sectionStyle } from './ReplyConnection.styles';
 import ReplyFeedback from './ReplyFeedback';
 import EditorName from './EditorName';
 import Hyperlinks from './Hyperlinks';
+import CopyButton from './CopyButton';
 
 export default class ReplyConnection extends React.PureComponent {
   static defaultProps = {
@@ -88,15 +89,12 @@ export default class ReplyConnection extends React.PureComponent {
               </button>,
             ]
           : ''}
-        <button key="copy" onClick={() => {}} className="btn-copy">
-          複製到剪貼簿
-        </button>
+        <CopyButton />
+        <p id="testCopyTarget">
+          Lorem ipsum dolor sit amet, consectetur adipisicing elit. Facere,
+          laborum.
+        </p>
         <ReplyFeedback replyConnection={replyConnection} onVote={onVote} />
-        <style jsx>{`
-          .btn-copy {
-            margin-left: 10px;
-          }
-        `}</style>
       </footer>
     );
   };
@@ -179,7 +177,9 @@ export default class ReplyConnection extends React.PureComponent {
         </header>
         <section className="section">
           <h3>理由</h3>
-          <ExpandableText>{nl2br(linkify(reply.get('text')))}</ExpandableText>
+          <ExpandableText id="foo">
+            {nl2br(linkify(reply.get('text')))}
+          </ExpandableText>
         </section>
 
         {this.renderReference()}

--- a/package-lock.json
+++ b/package-lock.json
@@ -2796,6 +2796,16 @@
       "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
       "dev": true
     },
+    "clipboard": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.4.tgz",
+      "integrity": "sha512-Vw26VSLRpJfBofiVaFb/I8PVfdI1OxKcYShe6fm0sP/DtmiWQNCjhM/okTvdCo0G+lMMm1rMYbk4IK4x1X+kgQ==",
+      "requires": {
+        "good-listener": "^1.2.2",
+        "select": "^1.1.2",
+        "tiny-emitter": "^2.0.0"
+      }
+    },
     "cliui": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
@@ -3373,6 +3383,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "delegate": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
+      "integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -5203,6 +5218,14 @@
           "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
         }
+      }
+    },
+    "good-listener": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
+      "integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
+      "requires": {
+        "delegate": "^3.1.2"
       }
     },
     "google-closure-compiler-js": {
@@ -11253,6 +11276,11 @@
         }
       }
     },
+    "select": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
+      "integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
+    },
     "semver": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
@@ -12410,6 +12438,11 @@
       "requires": {
         "setimmediate": "^1.0.4"
       }
+    },
+    "tiny-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
+      "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
     },
     "tmp": {
       "version": "0.0.33",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-eslint": "^10.0.0",
     "balloon-css": "^0.5.0",
     "classnames": "^2.2.5",
+    "clipboard": "^2.0.4",
     "dotenv": "^6.0.0",
     "immutable": "^3.8.2",
     "isomorphic-fetch": "^2.2.1",


### PR DESCRIPTION
## Add a "Copy to clipboard" button to each reply

### Feature
Allow users to copy reply contents of articles along with the page link to clipboard. Show tooltip beside the Copy button on success. Use template from [suggestion](https://www.facebook.com/photo.php?fbid=10213500185051777&set=pcb.2055948657970286&type=3&theater&ifg=1):
![facebook-template](https://user-images.githubusercontent.com/19681929/54082894-4b890f00-4357-11e9-9673-4b91d57c31ef.jpg)

### Reference
Issue https://github.com/cofacts/rumors-site/issues/62

### Screenshot
![cofacts_copy-to-clipboard](https://user-images.githubusercontent.com/19681929/54082855-83438700-4356-11e9-8c28-5c5dd0aeeb38.jpg)

![cofacts_copy-to-clipboard](https://user-images.githubusercontent.com/19681929/54082784-cb15de80-4355-11e9-8d23-90df245ec0cf.gif)

