### PR TITLE
Make url preview less wide

### DIFF
--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -60,6 +60,7 @@ function Hyperlink({ hyperlink = Map() }) {
           padding: 12px 8px;
           margin: 0 8px 8px 0;
           width: 100%;
+          max-width: 450px;
           overflow: hidden;
         }
 


### PR DESCRIPTION
Make it less wide by setting max-width css on `link` class.

**Before**
<img width="1107" alt="Screen Shot 2019-03-13 at 7 26 47 PM" src="https://user-images.githubusercontent.com/6004342/54275639-1f26fa00-45c6-11e9-9bf7-0b107c14c756.png">

**After**
<img width="1514" alt="Screen Shot 2019-03-13 at 7 25 39 PM" src="https://user-images.githubusercontent.com/6004342/54275638-1f26fa00-45c6-11e9-8c4b-4ccb3302ddeb.png">
