### PR TITLE
Add 30-day LINE bot search trendline to article page

### DIFF
--- a/components/Trendline.js
+++ b/components/Trendline.js
@@ -3,15 +3,35 @@ import React from 'react';
 /**
  * @param {string} props.id - String ID of article
  */
-function Trendline({ id, ...iframeProps }) {
+function Trendline({ id }) {
   return (
-    <iframe
-      width="200"
-      height="50"
-      src={`https://datastudio.google.com/embed/reporting/1t6Qx0P_3lsQilD1PPNf0jIfXsJ1Id7uC/page/q0iq?config=%7B%22df1%22:%22include%25EE%2580%25800%25EE%2580%2580IN%25EE%2580%2580${id}%22%7D`}
-      {...iframeProps}
-      style={{ border: 0, ...(iframeProps.style || {}) }}
-    />
+    <a
+      className="root"
+      href={`https://datastudio.google.com/u/0/reporting/18J8jZYumsoaCPBk9bdRd97GKvi_W5v-r/page/NrUQ?config=%7B%22df7%22:%22include%25EE%2580%25800%25EE%2580%2580IN%25EE%2580%2580${id}%22%7D`}
+      target="_blank"
+      rel="noopener noreferrer"
+    >
+      <iframe
+        width="200"
+        height="50"
+        src={`https://datastudio.google.com/embed/reporting/1t6Qx0P_3lsQilD1PPNf0jIfXsJ1Id7uC/page/q0iq?config=%7B%22df1%22:%22include%25EE%2580%25800%25EE%2580%2580IN%25EE%2580%2580${id}%22%7D`}
+        style={{ border: 0 }}
+      />
+      <style jsx>{`
+        .root {
+          display: block;
+          position: relative;
+        }
+        .root::before {
+          content: '';
+          position: absolute;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+        }
+      `}</style>
+    </a>
   );
 }
 

--- a/components/Trendline.js
+++ b/components/Trendline.js
@@ -1,0 +1,18 @@
+import React from 'react';
+
+/**
+ * @param {string} props.id - String ID of article
+ */
+function Trendline({ id, ...iframeProps }) {
+  return (
+    <iframe
+      width="200"
+      height="50"
+      src={`https://datastudio.google.com/embed/reporting/1t6Qx0P_3lsQilD1PPNf0jIfXsJ1Id7uC/page/q0iq?config=%7B%22df1%22:%22include%25EE%2580%25800%25EE%2580%2580IN%25EE%2580%2580${id}%22%7D`}
+      {...iframeProps}
+      style={{ border: 0, ...(iframeProps.style || {}) }}
+    />
+  );
+}
+
+export default Trendline;

--- a/pages/article.js
+++ b/pages/article.js
@@ -226,7 +226,9 @@ class ArticlePage extends React.Component {
           <section className="section">
             <header className="header">
               <h2>訊息原文</h2>
-              <Trendline id={article.get('id')} />
+              <div className="trendline">
+                <Trendline id={article.get('id')} />
+              </div>
               <ArticleInfo article={article} />
             </header>
             <article className="message">

--- a/pages/article.js
+++ b/pages/article.js
@@ -13,6 +13,7 @@ import ReplySearch from 'components/ReplySearch/ReplySearch.js';
 import ReplyForm from 'components/ReplyForm';
 import ReplyRequestReason from 'components/ReplyRequestReason';
 import Hyperlinks from 'components/Hyperlinks';
+import Trendline from 'components/Trendline';
 import {
   load,
   loadAuth,
@@ -225,6 +226,7 @@ class ArticlePage extends React.Component {
           <section className="section">
             <header className="header">
               <h2>訊息原文</h2>
+              <Trendline id={article.get('id')} />
               <ArticleInfo article={article} />
             </header>
             <article className="message">

--- a/pages/article.styles.js
+++ b/pages/article.styles.js
@@ -15,7 +15,10 @@ export const detailStyle = css`
   .header {
     display: flex;
     align-items: center;
-    justify-content: space-between;
+    flex-flow: row wrap;
+  }
+  .header > :global(iframe) {
+    margin: 0 16px 0 auto;
   }
   .message {
     border: 1px solid #ccc;

--- a/pages/article.styles.js
+++ b/pages/article.styles.js
@@ -17,7 +17,7 @@ export const detailStyle = css`
     align-items: center;
     flex-flow: row wrap;
   }
-  .header > :global(iframe) {
+  .header > .trendline {
     margin: 0 16px 0 auto;
   }
   .message {


### PR DESCRIPTION
Fixes #111 

## Desktop
<img width="707" alt="螢幕快照 2019-05-25 下午3 25 36" src="https://user-images.githubusercontent.com/108608/58366284-a7991380-7f02-11e9-8d89-e2d77330120f.png">

## Mobile
<img width="469" alt="螢幕快照 2019-05-25 下午3 25 27" src="https://user-images.githubusercontent.com/108608/58366289-b089e500-7f02-11e9-9b1e-a4e084b44e27.png">

## Loading
Google datastudio is slow...
![loading](https://user-images.githubusercontent.com/108608/58366298-c8616900-7f02-11e9-9afd-1b20e476d360.gif)
