### PR TITLE
Create new reply form

### DIFF
--- a/components/AppLayout/LoginModal.js
+++ b/components/AppLayout/LoginModal.js
@@ -1,3 +1,4 @@
+import { t } from 'ttag';
 import Dialog from '@material-ui/core/Dialog';
 import DialogTitle from '@material-ui/core/DialogTitle';
 import DialogContent from '@material-ui/core/DialogContent';
@@ -9,7 +10,7 @@ function LoginModal({ onClose }) {
   );
   return (
     <Dialog open onClose={onClose}>
-      <DialogTitle>Login / Signup</DialogTitle>
+      <DialogTitle>{t`Login / Signup`}</DialogTitle>
       <DialogContent>
         <a
           href={`${process.env.API_URL}/login/facebook?redirect=${redirectUrl}`}

--- a/components/NewReplySection.js
+++ b/components/NewReplySection.js
@@ -1,0 +1,42 @@
+import { useState, useCallback } from 'react';
+import { t } from 'ttag';
+
+import Tabs from '@material-ui/core/Tabs';
+import Tab from '@material-ui/core/Tab';
+import Badge from '@material-ui/core/Badge';
+
+import useCurrentUser from 'lib/useCurrentUser';
+import ReplyForm from './ReplyForm';
+
+function NewReplySection({ onSubmit }) {
+  const [selectedTab, setSelectedTab] = useState(0);
+  const currentUser = useCurrentUser();
+
+  const handleTabChange = useCallback((e, v) => setSelectedTab(v), []);
+  const handleSubmit = useCallback(() => {
+    onSubmit(); // Notify upper component of submission
+  }, [onSubmit]);
+
+  if (!currentUser) {
+    return <p>{t`Please login first.`}</p>;
+  }
+
+  return (
+    <>
+      <Tabs value={selectedTab} onChange={handleTabChange}>
+        <Tab label={t`New Reply`} />
+        <Tab
+          label={
+            <Badge color="secondary" badgeContent={4}>
+              {t`Reuse existing reply`}
+            </Badge>
+          }
+        />
+        <Tab label={t`Search`} />
+      </Tabs>
+      {selectedTab === 0 && <ReplyForm onSubmit={handleSubmit} />}
+    </>
+  );
+}
+
+export default NewReplySection;

--- a/components/NewReplySection.js
+++ b/components/NewReplySection.js
@@ -35,7 +35,7 @@ function NewReplySection({ articleId, onSubmissionComplete }) {
   const currentUser = useCurrentUser();
   const replyFormRef = useRef();
   const [createReply, { loading: creatingReply }] = useMutation(CREATE_REPLY, {
-    refetchQueries: ['LoadArticlePage', 'LoadArticlePageForUser'],
+    refetchQueries: ['LoadArticlePage'],
     awaitRefetchQueries: true,
     onCompleted(data) {
       onSubmissionComplete(data.CreateReply.id); // Notify upper component of submission

--- a/components/NewReplySection.js
+++ b/components/NewReplySection.js
@@ -1,21 +1,62 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
+import { useMutation } from '@apollo/react-hooks';
+import gql from 'graphql-tag';
 import { t } from 'ttag';
 
 import Tabs from '@material-ui/core/Tabs';
 import Tab from '@material-ui/core/Tab';
 import Badge from '@material-ui/core/Badge';
+import Snackbar from '@material-ui/core/Snackbar';
 
 import useCurrentUser from 'lib/useCurrentUser';
 import ReplyForm from './ReplyForm';
 
-function NewReplySection({ onSubmit }) {
+const CREATE_REPLY = gql`
+  mutation CreateReplyInArticlePage(
+    $articleId: String!
+    $text: String!
+    $type: ReplyTypeEnum!
+    $reference: String
+  ) {
+    CreateReply(
+      articleId: $articleId
+      text: $text
+      type: $type
+      reference: $reference
+    ) {
+      id
+    }
+  }
+`;
+
+function NewReplySection({ articleId, onSubmissionComplete }) {
   const [selectedTab, setSelectedTab] = useState(0);
+  const [flashMessage, setFlashMessage] = useState(0);
   const currentUser = useCurrentUser();
+  const replyFormRef = useRef();
+  const [createReply, { loading: creatingReply }] = useMutation(CREATE_REPLY, {
+    refetchQueries: ['LoadArticlePage', 'LoadArticlePageForUser'],
+    awaitRefetchQueries: true,
+    onCompleted(data) {
+      onSubmissionComplete(data.CreateReply.id); // Notify upper component of submission
+      if (replyFormRef.current) {
+        replyFormRef.current.clear();
+      }
+      setFlashMessage(t`Your reply has been submitted.`);
+    },
+    onError(error) {
+      console.error(error);
+      setFlashMessage(error.toString());
+    },
+  });
 
   const handleTabChange = useCallback((e, v) => setSelectedTab(v), []);
-  const handleSubmit = useCallback(() => {
-    onSubmit(); // Notify upper component of submission
-  }, [onSubmit]);
+  const handleSubmit = useCallback(
+    replyData => {
+      createReply({ variables: { ...replyData, articleId } });
+    },
+    [createReply]
+  );
 
   if (!currentUser) {
     return <p>{t`Please login first.`}</p>;
@@ -34,7 +75,19 @@ function NewReplySection({ onSubmit }) {
         />
         <Tab label={t`Search`} />
       </Tabs>
-      {selectedTab === 0 && <ReplyForm onSubmit={handleSubmit} />}
+      
+      {selectedTab === 0 && (
+        <ReplyForm
+          ref={replyFormRef}
+          onSubmit={handleSubmit}
+          disabled={creatingReply}
+        />
+      )}
+      <Snackbar
+        open={!!flashMessage}
+        onClose={() => setFlashMessage('')}
+        message={flashMessage}
+      />
     </>
   );
 }

--- a/components/ReplyFeedback.js
+++ b/components/ReplyFeedback.js
@@ -21,16 +21,24 @@ import Snackbar from '@material-ui/core/Snackbar';
 import { feedbackStyle } from './ReplyFeedback.styles';
 import useCurrentUser from 'lib/useCurrentUser';
 
-const ArticleReplyFeedbackData = gql`
-  fragment ArticleReplyFeedbackData on ArticleReply {
+// Subset of fields that needs to be updated after login
+//
+const ArticleReplyFeedbackForUser = gql`
+  fragment ArticleReplyFeedbackForUser on ArticleReply {
     articleId
     replyId
+    ownVote
+  }
+`;
+
+const ArticleReplyFeedbackData = gql`
+  fragment ArticleReplyFeedbackData on ArticleReply {
+    ...ArticleReplyFeedbackForUser
     user {
       id
     }
     positiveFeedbackCount
     negativeFeedbackCount
-    ownVote
     feedbacks {
       id
       user {
@@ -39,14 +47,7 @@ const ArticleReplyFeedbackData = gql`
       comment
     }
   }
-`;
-
-const ArticleReplyFeedbackForUser = gql`
-  fragment ArticleReplyFeedbackForUser on ArticleReply {
-    articleId
-    replyId
-    ownVote
-  }
+  ${ArticleReplyFeedbackForUser}
 `;
 
 const VOTE_REPLY = gql`
@@ -63,11 +64,9 @@ const VOTE_REPLY = gql`
       comment: $comment
     ) {
       ...ArticleReplyFeedbackData
-      ...ArticleReplyFeedbackForUser
     }
   }
   ${ArticleReplyFeedbackData}
-  ${ArticleReplyFeedbackForUser}
 `;
 
 function ReplyFeedback({

--- a/components/ReplyForm.js
+++ b/components/ReplyForm.js
@@ -41,6 +41,19 @@ export default class ReplyForm extends React.PureComponent {
     });
   }
 
+  /**
+   * Clears form and localStorage. Invoked by ReplyForm's parent component.
+   *
+   * @public
+   */
+  clear = () => {
+    delete localStorage.replyType;
+    delete localStorage.reference;
+    delete localStorage.text;
+
+    this.setState(formInitialState);
+  };
+
   set(key, value) {
     this.setState({ [key]: value });
 
@@ -68,13 +81,6 @@ export default class ReplyForm extends React.PureComponent {
 
     if (disabled) return;
     onSubmit({ type: replyType, reference, text });
-
-    // Clean up localStorage
-    delete localStorage.replyType;
-    delete localStorage.reference;
-    delete localStorage.text;
-
-    this.setState(formInitialState);
   };
 
   handleSuggestionAdd = e => {

--- a/components/ReplyForm.js
+++ b/components/ReplyForm.js
@@ -4,9 +4,9 @@ import {
   TYPE_DESC,
   TYPE_INSTRUCTION,
   TYPE_SUGGESTION_OPTIONS,
-} from '../constants/replyType';
+} from 'constants/replyType';
 
-import { EDITOR_FACEBOOK_GROUP, EDITOR_REFERENCE } from '../constants/urls';
+import { EDITOR_FACEBOOK_GROUP, EDITOR_REFERENCE } from 'constants/urls';
 
 const localStorage = typeof window === 'undefined' ? {} : window.localStorage;
 const formInitialState = {
@@ -17,9 +17,7 @@ const formInitialState = {
 
 export default class ReplyForm extends React.PureComponent {
   static defaultProps = {
-    onSubmit() {
-      return Promise.reject();
-    },
+    onSubmit() {},
     disabled: false,
   };
 
@@ -64,16 +62,19 @@ export default class ReplyForm extends React.PureComponent {
 
   handleSubmit = e => {
     e.preventDefault(); // prevent reload
-    if (this.props.disabled) return;
-    const { replyType, reference, text } = this.state;
-    this.props.onSubmit({ type: replyType, reference, text }).then(() => {
-      // Clean up localStorage on success
-      delete localStorage.replyType;
-      delete localStorage.reference;
-      delete localStorage.text;
 
-      this.setState(formInitialState);
-    });
+    const { onSubmit, disabled } = this.props;
+    const { replyType, reference, text } = this.state;
+
+    if (disabled) return;
+    onSubmit({ type: replyType, reference, text });
+
+    // Clean up localStorage
+    delete localStorage.replyType;
+    delete localStorage.reference;
+    delete localStorage.text;
+
+    this.setState(formInitialState);
   };
 
   handleSuggestionAdd = e => {
@@ -142,7 +143,8 @@ export default class ReplyForm extends React.PureComponent {
           查證範圍請參考{' '}
           <a href={EDITOR_REFERENCE} target="_blank" rel="noopener noreferrer">
             《Cofacts 編輯規則》
-          </a>。
+          </a>
+          。
         </p>
       );
     }
@@ -178,13 +180,11 @@ export default class ReplyForm extends React.PureComponent {
   renderHelp() {
     return (
       <span className="help">
-        不知道從何下手嗎？<a
-          href={EDITOR_REFERENCE}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        不知道從何下手嗎？
+        <a href={EDITOR_REFERENCE} target="_blank" rel="noopener noreferrer">
           Cofacts 編輯規則
-        </a>、
+        </a>
+        、
         <a
           href={EDITOR_FACEBOOK_GROUP}
           target="_blank"

--- a/components/ReplyRequestReason/ReplyRequestReason.js
+++ b/components/ReplyRequestReason/ReplyRequestReason.js
@@ -9,20 +9,23 @@ import PropTypes from 'prop-types';
 const UPVOTE = 'UPVOTE';
 const DOWNVOTE = 'DOWNVOTE';
 
-const ReplyRequestInfo = gql`
-  fragment ReplyRequestInfo on ReplyRequest {
-    id
-    reason
-    positiveFeedbackCount
-    negativeFeedbackCount
-  }
-`;
-
+// Subset of fields that needs to be updated after login
+//
 const ReplyRequestInfoForUser = gql`
   fragment ReplyRequestInfoForUser on ReplyRequest {
     id
     ownVote
   }
+`;
+
+const ReplyRequestInfo = gql`
+  fragment ReplyRequestInfo on ReplyRequest {
+    ...ReplyRequestInfoForUser
+    reason
+    positiveFeedbackCount
+    negativeFeedbackCount
+  }
+  ${ReplyRequestInfoForUser}
 `;
 
 const UPDATE_VOTE = gql`
@@ -32,11 +35,9 @@ const UPDATE_VOTE = gql`
       vote: $vote
     ) {
       ...ReplyRequestInfo
-      ...ReplyRequestInfoForUser
     }
   }
   ${ReplyRequestInfo}
-  ${ReplyRequestInfoForUser}
 `;
 
 const AuthorArticleLink = ({ articleId }) => (
@@ -187,12 +188,12 @@ function ReplyRequestReason({ isArticleCreator, replyRequest, articleId }) {
           opacity: 1;
         }
         .btn-up-vote::after {
-          content: '覺得合理';
+          content: ${t`The reason is reasonable`};
           bottom: 100%;
           transform: translateY(100%);
         }
         .btn-down-vote::after {
-          content: '覺得不合理';
+          content: ${t`The reason is not reasonable`};
           top: 100%;
           transform: translateY(-100%);
         }

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -5,6 +5,7 @@ import { useQuery, useLazyQuery } from '@apollo/react-hooks';
 import Head from 'next/head';
 
 import withData from 'lib/apollo';
+import useCurrentUser from 'lib/useCurrentUser';
 import AppLayout from 'components/AppLayout';
 import Hyperlinks from 'components/Hyperlinks';
 import ArticleInfo from 'components/ArticleInfo';
@@ -64,16 +65,24 @@ function ArticlePage({ query }) {
   const { data, loading } = useQuery(LOAD_ARTICLE, {
     variables: articleVars,
   });
-  const [loadArticleForUser] = useLazyQuery(LOAD_ARTICLE_FOR_USER, {
+  const [
+    loadArticleForUser,
+    { refetch: refetchArticleForUser, called: articleForUserCalled },
+  ] = useLazyQuery(LOAD_ARTICLE_FOR_USER, {
     variables: articleVars,
     fetchPolicy: 'network-only',
   });
+  const currentUser = useCurrentUser();
 
   const replySectionRef = useRef(null);
 
   useEffect(() => {
-    loadArticleForUser();
-  }, []);
+    if (!articleForUserCalled) {
+      loadArticleForUser();
+    } else {
+      refetchArticleForUser();
+    }
+  }, [currentUser]);
 
   const handleNewReplySubmit = useCallback(() => {
     if (!replySectionRef.current) return;

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useCallback } from 'react';
 import { t } from 'ttag';
 import { useQuery, useLazyQuery } from '@apollo/react-hooks';
 import merge from 'lodash/merge';
@@ -12,6 +12,7 @@ import ArticleInfo from 'components/ArticleInfo';
 import Trendline from 'components/Trendline';
 import CurrentReplies from 'components/CurrentReplies';
 import ReplyRequestReason from 'components/ReplyRequestReason';
+import NewReplySection from 'components/NewReplySection';
 
 import { nl2br, linkify } from 'lib/text';
 
@@ -82,6 +83,11 @@ function ArticlePage({ query }) {
     loadArticleForUser();
   }, []);
 
+  const handleNewReplySubmit = useCallback(() => {
+    if (!replySectionRef.current) return;
+    replySectionRef.current.scrollIntoView({ behavior: 'smooth' });
+  }, []);
+
   if (loading) {
     return <AppLayout>Loading...</AppLayout>;
   }
@@ -130,6 +136,11 @@ function ArticlePage({ query }) {
       <section className="section" id="current-replies" ref={replySectionRef}>
         <h2>{t`Replies to the message`}</h2>
         <CurrentReplies articleReplies={article.articleReplies} />
+      </section>
+
+      <section className="section">
+        <h2>{t`Add a new reply`}</h2>
+        <NewReplySection onSubmit={handleNewReplySubmit} />
       </section>
 
       <style jsx>{`

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -1,8 +1,7 @@
 import gql from 'graphql-tag';
-import { useEffect, useMemo, useRef, useCallback } from 'react';
+import { useEffect, useRef, useCallback } from 'react';
 import { t } from 'ttag';
 import { useQuery, useLazyQuery } from '@apollo/react-hooks';
-import merge from 'lodash/merge';
 import Head from 'next/head';
 
 import withData from 'lib/apollo';
@@ -65,17 +64,10 @@ function ArticlePage({ query }) {
   const { data, loading } = useQuery(LOAD_ARTICLE, {
     variables: articleVars,
   });
-  const [loadArticleForUser, { data: dataForUser }] = useLazyQuery(
-    LOAD_ARTICLE_FOR_USER,
-    {
-      variables: articleVars,
-    }
-  );
-
-  const article = useMemo(
-    () => merge({}, data?.GetArticle, dataForUser?.GetArticle),
-    [data, dataForUser]
-  );
+  const [loadArticleForUser] = useLazyQuery(LOAD_ARTICLE_FOR_USER, {
+    variables: articleVars,
+    fetchPolicy: 'network-only',
+  });
 
   const replySectionRef = useRef(null);
 
@@ -92,7 +84,9 @@ function ArticlePage({ query }) {
     return <AppLayout>Loading...</AppLayout>;
   }
 
-  if (!data?.GetArticle) {
+  const article = data?.GetArticle;
+
+  if (!article) {
     return <AppLayout>Article not found.</AppLayout>;
   }
 

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -140,7 +140,10 @@ function ArticlePage({ query }) {
 
       <section className="section">
         <h2>{t`Add a new reply`}</h2>
-        <NewReplySection onSubmit={handleNewReplySubmit} />
+        <NewReplySection
+          articleId={article.id}
+          onSubmissionComplete={handleNewReplySubmit}
+        />
       </section>
 
       <style jsx>{`


### PR DESCRIPTION
- Introduce `<NewReplySection>`, which will be the functional component performing apollo hooks for "Create reply" (this PR), "use existing reply" (future PR) and "search" (future PR)
- Component structure:
  - `[id].js` (article page)
    - `NewReplySection.js` the 3-tab functional component doing apollo-hooks
      - `ReplyForm.js` the "new reply" form
- `ReplyForm.js` no longer relies on its `onSubmit` returning a promise to clear the field. Instead, it exposes a public method `clear()` for its parent component to clear when reply submission succeeded. This API is similar to how HTML inputs are cleared.

## Screenshot
### Before login
![螢幕快照 2019-09-30 下午1 27 40](https://user-images.githubusercontent.com/108608/65851634-396bce00-e386-11e9-8baa-4bbc1edf64fb.png)

### After login
![螢幕快照 2019-09-30 下午1 28 11](https://user-images.githubusercontent.com/108608/65851636-3ec91880-e386-11e9-8945-eb5ddeea0904.png)

### Automatically scroll & clear form after submission
![submission](https://user-images.githubusercontent.com/108608/65851721-7cc63c80-e386-11e9-8f18-fcd4bf7eb6f5.gif)

## Refactor
During development, I found that the `merge()` in `[id].js` is actually causing issues. I tried to use `merge()` to merge `LoadArticlePage` and `LoadArticlePageForUser` operations; however, the cache of these two operations are not guaranteed to be updated in the same time. When `LoadArticlePage` and `LoadArticlePageForUser` has inconsistent order of `articleReplies`, `merge()` will erroneously merge the two arrays, causing issue like duplicated `replyIds`:
<img width="1345" alt="螢幕快照 2019-09-29 上午2 06 20" src="https://user-images.githubusercontent.com/108608/65851524-b6e30e80-e385-11e9-921f-c58182a2a42c.png">

To solve this, we should avoid doing `merge()` by ourselves, let apollo-client to update the normalized cache instead. In this PR, all fields in `xxxForUser` fragments are merged into `xxxData` fragments, so that refetching `LoadArticlePage` will fetch and update the for-user fields (like `ownVote`) as well.