### PR TITLE
Connect replies component

### DIFF
--- a/components/NewReplySection.js
+++ b/components/NewReplySection.js
@@ -140,9 +140,8 @@ function NewReplySection({
       )}
       {selectedTab === 1 && (
         <RelatedReplies
-          onConnect={handleConnect}
           relatedArticleReplies={relatedArticleReplies}
-          existingReplyIds={existingReplyIds}
+          onConnect={handleConnect}
         />
       )}
       <Snackbar

--- a/components/NewReplySection.js
+++ b/components/NewReplySection.js
@@ -10,6 +10,7 @@ import Snackbar from '@material-ui/core/Snackbar';
 
 import useCurrentUser from 'lib/useCurrentUser';
 import ReplyForm from './ReplyForm';
+import RelatedReplies from './RelatedReplies';
 
 const CREATE_REPLY = gql`
   mutation CreateReplyInArticlePage(
@@ -29,7 +30,12 @@ const CREATE_REPLY = gql`
   }
 `;
 
-function NewReplySection({ articleId, onSubmissionComplete }) {
+function NewReplySection({
+  articleId,
+  existingReplyIds,
+  relatedArticles,
+  onSubmissionComplete,
+}) {
   const [selectedTab, setSelectedTab] = useState(0);
   const [flashMessage, setFlashMessage] = useState(0);
   const currentUser = useCurrentUser();
@@ -58,6 +64,9 @@ function NewReplySection({ articleId, onSubmissionComplete }) {
     [createReply]
   );
 
+  // TODO
+  const handleConnect = () => {};
+
   if (!currentUser) {
     return <p>{t`Please login first.`}</p>;
   }
@@ -81,6 +90,13 @@ function NewReplySection({ articleId, onSubmissionComplete }) {
           ref={replyFormRef}
           onSubmit={handleSubmit}
           disabled={creatingReply}
+        />
+      )}
+      {selectedTab === 1 && (
+        <RelatedReplies
+          onConnect={handleConnect}
+          relatedArticles={relatedArticles}
+          existingReplyIds={existingReplyIds}
         />
       )}
       <Snackbar

--- a/components/NewReplySection.js
+++ b/components/NewReplySection.js
@@ -120,7 +120,10 @@ function NewReplySection({
         <Tab label={t`New Reply`} />
         <Tab
           label={
-            <Badge color="secondary" badgeContent={4}>
+            <Badge
+              color="secondary"
+              badgeContent={relatedArticleReplies.length}
+            >
               {t`Reuse existing reply`}
             </Badge>
           }

--- a/components/RelatedReplies.js
+++ b/components/RelatedReplies.js
@@ -26,17 +26,17 @@ const RelatedArticleReplyData = gql`
 `;
 
 /**
- * @param {Map} props.article - {id, text} of the article text
- * @param {Map} props.reply - {id, type, createdAt, text} of the reply
+ * @param {object} props.article - {id, text} of the article text
+ * @param {object} props.reply - {id, type, createdAt, text} of the reply
+ * @param {function} props.onConnect - (replyId) => undefined
+ * @param {boolean} props.disabled - if we should disable the connect button
  */
-function RelatedReplyItem({ article, reply, onConnect }) {
-  const articleId = article.id;
-  const articleText = article.text;
+function RelatedReplyItem({ article, reply, onConnect, disabled }) {
   const createdAt = new Date(reply.createdAt);
   return (
     <li className="root">
       <header className="section">
-        <Link href="/article/[id]" as={`/article/${articleId}`}>
+        <Link href="/article/[id]" as={`/article/${article.id}`}>
           <a>相關訊息</a>
         </Link>
         被標示為：
@@ -50,7 +50,7 @@ function RelatedReplyItem({ article, reply, onConnect }) {
               Don't need nl2br here, because the user just need a glimpse on the content.
               Line breaks won't help the users.
             */}
-            {linkify(articleText)}
+            {linkify(article.text)}
           </ExpandableText>
         </blockquote>
       </section>
@@ -63,7 +63,11 @@ function RelatedReplyItem({ article, reply, onConnect }) {
           <a title={format(createdAt)}>{formatDistanceToNow(createdAt)}</a>
         </Link>
         ・
-        <button type="button" value={reply.id} onClick={onConnect}>
+        <button
+          type="button"
+          onClick={() => onConnect(reply.id)}
+          disabled={disabled}
+        >
           將這份回應加進此文章的回應
         </button>
       </footer>
@@ -96,7 +100,12 @@ function RelatedReplyItem({ article, reply, onConnect }) {
   );
 }
 
-function RelatedReplies({ relatedArticleReplies = [], onConnect }) {
+function RelatedReplies({
+  articleId = '',
+  relatedArticleReplies = [],
+  onConnect,
+  disabled = false,
+}) {
   if (!relatedArticleReplies.length) {
     return <p>目前沒有相關的回應</p>;
   }
@@ -107,9 +116,11 @@ function RelatedReplies({ relatedArticleReplies = [], onConnect }) {
         return (
           <RelatedReplyItem
             key={`${article.id}/${reply.id}`}
+            targetArticleId={articleId}
             article={article}
             reply={reply}
             onConnect={onConnect}
+            disabled={disabled}
           />
         );
       })}

--- a/components/RelatedReplies.js
+++ b/components/RelatedReplies.js
@@ -16,6 +16,7 @@ const RelatedArticleReplyData = gql`
       id
       createdAt
       type
+      text
     }
     article {
       id
@@ -35,7 +36,7 @@ function RelatedReplyItem({ article, reply, onConnect }) {
   return (
     <li className="root">
       <header className="section">
-        <Link route="article" params={{ id: articleId }}>
+        <Link href="/article/[id]" as={`/article/${articleId}`}>
           <a>相關訊息</a>
         </Link>
         被標示為：
@@ -58,7 +59,7 @@ function RelatedReplyItem({ article, reply, onConnect }) {
         <ExpandableText>{nl2br(linkify(reply.text))}</ExpandableText>
       </section>
       <footer>
-        <Link route="reply" params={{ id: reply.id }}>
+        <Link href="/reply/[id]" as={`/reply/${reply.id}`}>
           <a title={format(createdAt)}>{formatDistanceToNow(createdAt)}</a>
         </Link>
         ・

--- a/components/RelatedReplies.js
+++ b/components/RelatedReplies.js
@@ -8,24 +8,18 @@ import { linkify, nl2br } from 'lib/text';
 import Link from 'next/link';
 import { sectionStyle } from './ReplyConnection.styles';
 
-const RelatedReplyData = gql`
-  fragment RelatedReplyData on Article {
-    relatedArticles(filter: { replyCount: { GT: 0 } }) {
-      edges {
-        node {
-          id
-          text
-          articleReplies {
-            articleId
-            replyId
-            reply {
-              id
-              createdAt
-              type
-            }
-          }
-        }
-      }
+const RelatedArticleReplyData = gql`
+  fragment RelatedReplyData on ArticleReply {
+    articleId
+    replyId
+    reply {
+      id
+      createdAt
+      type
+    }
+    article {
+      id
+      text
     }
   }
 `;
@@ -129,7 +123,7 @@ function RelatedReplies({ relatedArticleReplies = [], onConnect }) {
 }
 
 RelatedReplies.fragments = {
-  RelatedReplyData,
+  RelatedArticleReplyData,
 };
 
 export default RelatedReplies;

--- a/components/RelatedReplies.js
+++ b/components/RelatedReplies.js
@@ -9,7 +9,7 @@ import Link from 'next/link';
 import { sectionStyle } from './ReplyConnection.styles';
 
 const RelatedArticleReplyData = gql`
-  fragment RelatedReplyData on ArticleReply {
+  fragment RelatedArticleReplyData on ArticleReply {
     articleId
     replyId
     reply {

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -41,6 +41,7 @@ const LOAD_ARTICLE = gql`
   ${Hyperlinks.fragments.HyperlinkData}
   ${ReplyRequestReason.fragments.ReplyRequestInfo}
   ${CurrentReplies.fragments.CurrentRepliesData}
+  ${NewReplySection.fragments.RelatedArticleData}
 `;
 
 const LOAD_ARTICLE_FOR_USER = gql`
@@ -145,6 +146,10 @@ function ArticlePage({ query }) {
         <h2>{t`Add a new reply`}</h2>
         <NewReplySection
           articleId={article.id}
+          existingReplyIds={(article?.articleReplies || []).map(
+            ({ replyId }) => replyId
+          )}
+          relatedArticles={article?.relatedArticles}
           onSubmissionComplete={handleNewReplySubmit}
         />
       </section>

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -36,6 +36,7 @@ const LOAD_ARTICLE = gql`
       articleReplies {
         ...CurrentRepliesData
       }
+      ...RelatedArticleData
     }
   }
   ${Hyperlinks.fragments.HyperlinkData}


### PR DESCRIPTION
This PR implements "existing reply" tab.
- Component hierarchy:
  - `[id].js` - article page, loads related reply field
    - `NewReplySection.js` - the functional component of "New Reply" tabs, handles all mutations. DIsplays number of relatedReplies in tab badge.
      - `RelatedReplies.js` - the content of "Reuse existing reply" tab
        - `<RelatedReplyItem>`: each related reply item

## Refactors

To avoid confusion, `NewReplySection`  now doesn't pass anything when invoking `onSubmissionComplete` callback, which is invoked by both "create new reply" and "connect existing reply". The article page does not need that data anyway.

## Screenshot
![connect](https://user-images.githubusercontent.com/108608/66185061-c11c4a00-e6b0-11e9-946f-0b74af273f0f.gif)
