### PR TITLE
Similar article list in article page

### DIFF
--- a/components/ArticleItem.js
+++ b/components/ArticleItem.js
@@ -40,7 +40,7 @@ export default function ArticleItem({
 }
 
 ArticleItem.fragments = {
-  articleItem: gql`
+  ArticleItem: gql`
     fragment ArticleItem on Article {
       id
       text

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -13,6 +13,7 @@ import Trendline from 'components/Trendline';
 import CurrentReplies from 'components/CurrentReplies';
 import ReplyRequestReason from 'components/ReplyRequestReason';
 import NewReplySection from 'components/NewReplySection';
+import ArticleItem from 'components/ArticleItem';
 
 import { nl2br, linkify } from 'lib/text';
 
@@ -37,12 +38,20 @@ const LOAD_ARTICLE = gql`
         ...CurrentRepliesData
       }
       ...RelatedArticleData
+      similarArticles: relatedArticles {
+        edges {
+          node {
+            ...ArticleItem
+          }
+        }
+      }
     }
   }
   ${Hyperlinks.fragments.HyperlinkData}
   ${ReplyRequestReason.fragments.ReplyRequestInfo}
   ${CurrentReplies.fragments.CurrentRepliesData}
   ${NewReplySection.fragments.RelatedArticleData}
+  ${ArticleItem.fragments.ArticleItem}
 `;
 
 const LOAD_ARTICLE_FOR_USER = gql`
@@ -155,6 +164,17 @@ function ArticlePage({ query }) {
         />
       </section>
 
+      {article?.similarArticles?.edges?.length > 0 && (
+        <section className="section">
+          <h2>{t`You may be interested in the following similar messages`}</h2>
+          <ul className="similar-articles">
+            {article.similarArticles.edges.map(({ node }) => (
+              <ArticleItem key={node.id} article={node} />
+            ))}
+          </ul>
+        </section>
+      )}
+
       <style jsx>{`
         .section {
           margin-bottom: 64px;
@@ -177,6 +197,10 @@ function ArticlePage({ query }) {
         .items {
           list-style-type: none;
           padding-left: 0;
+        }
+        .similar-articles {
+          padding: 0;
+          list-style: none;
         }
       `}</style>
     </AppLayout>

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -48,7 +48,7 @@ const LIST_ARTICLES = gql`
       }
     }
   }
-  ${ArticleItem.fragments.articleItem}
+  ${ArticleItem.fragments.ArticleItem}
 `;
 
 const LIST_STAT = gql`


### PR DESCRIPTION
Implements the similar article list of an article.

## Refactor
- Rename `ArticleItem` fragment to PascalCase to match the convention of other fragments

## Screenshot
<img width="777" alt="螢幕快照 2019-10-13 上午9 49 07" src="https://user-images.githubusercontent.com/108608/66709874-4aadd500-ed9f-11e9-955b-b4beb2f1794e.png">
