### PR TITLE
Reply list

### DIFF
--- a/components/SearchInput.js
+++ b/components/SearchInput.js
@@ -1,0 +1,28 @@
+import { useCallback } from 'react';
+import TextField from '@material-ui/core/TextField';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import SearchIcon from '@material-ui/icons/Search';
+
+function SearchInput({ q = '', onChange = () => {} }) {
+  const handleSubmit = useCallback(e => onChange(e.target.value), [onChange]);
+  const handleKeyUp = useCallback(e => {
+    e.which === 13 && e.target.blur();
+  }, []);
+
+  return (
+    <TextField
+      defaultValue={q}
+      onBlur={handleSubmit}
+      onKeyUp={handleKeyUp}
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <SearchIcon />
+          </InputAdornment>
+        ),
+      }}
+    />
+  );
+}
+
+export default SearchInput;

--- a/constants/replyType.js
+++ b/constants/replyType.js
@@ -1,3 +1,5 @@
+import { t } from 'ttag';
+
 export const TYPE_ICON = {
   NOT_ARTICLE: '⚠️️',
   OPINIONATED: '💬',
@@ -6,18 +8,17 @@ export const TYPE_ICON = {
 };
 
 export const TYPE_NAME = {
-  NOT_ARTICLE: '⚠️️ 不在查證範圍',
-  OPINIONATED: '💬 含有個人意見',
-  NOT_RUMOR: '⭕ 含有正確訊息',
-  RUMOR: '❌ 含有不實訊息',
+  NOT_ARTICLE: `${TYPE_ICON.NOT_ARTICLE} ${t`Invalid request`}`,
+  OPINIONATED: `${TYPE_ICON.OPINIONATED} ${t`Contains personal perspective`}`,
+  NOT_RUMOR: `${TYPE_ICON.NOT_RUMOR} ${t`Contains true information`}`,
+  RUMOR: `${TYPE_ICON.RUMOR} ${t`Contains misinformation`}`,
 };
 
 export const TYPE_DESC = {
-  NOT_ARTICLE: '這篇訊息不是編輯能夠處理、或 Cofacts 不應該受理此類文章。',
-  NOT_RUMOR: '轉傳訊息或網路文章有一部分內容查證屬實。',
-  OPINIONATED:
-    '轉傳訊息或網路文章含有個人感想、假說猜測、陰謀論、尚無共識的研究、對政策的推論等等。',
-  RUMOR: '轉傳訊息或網路文章有一部分含有不實資訊。',
+  NOT_ARTICLE: t`This message cannot or should not be processed by Cofacts editors.`,
+  NOT_RUMOR: t`The message has some of its content proved to be true.`,
+  OPINIONATED: t`The message contains personal opinion, unproven hypotheses, conspiracy theories, studies that has not reached concensus, inferences of political policies, etc.`,
+  RUMOR: t`This message has some of its content proved to be false.`,
 };
 
 export const TYPE_INSTRUCTION = {

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -107,7 +107,7 @@ msgid "Click here to include messages only reported 1 time."
 msgstr "按這裡加入僅被回報 1 次的訊息。"
 
 #: pages/articles.js:147
-#: pages/replies.js:107
+#: pages/replies.js:147
 msgid "Sort by"
 msgstr "排序方式"
 
@@ -120,7 +120,7 @@ msgid "Most asked"
 msgstr "最多人詢問"
 
 #: pages/articles.js:228
-#: pages/replies.js:189
+#: pages/replies.js:233
 msgid "Sort by Relevance"
 msgstr "以相關度排序"
 
@@ -134,6 +134,7 @@ msgstr "所有這個使用者回報的訊息"
 
 #: components/ArticleInfo.js:31
 #: components/ArticleReply.js:120
+#: components/ReplyItem.js:31
 #, javascript-format
 msgid "${ timeAgoStr } ago"
 msgstr "${ timeAgoStr }前"
@@ -262,61 +263,23 @@ msgstr "送出"
 msgid "Thank you for the feedback."
 msgstr "感謝您的意見。"
 
-#: pages/replies.js:94
+#: pages/replies.js:134
 msgid "All replies"
 msgstr "所有回應"
 
-#: pages/replies.js:119
+#: pages/replies.js:159
 msgid "Most recently written"
 msgstr "最近寫的"
 
-#: pages/replies.js:120
+#: pages/replies.js:160
 msgid "Least recently written"
 msgstr "最久以前寫的"
 
-#: pages/replies.js:155
-#. const {
-#. loading,
-#. data: { ListReplies: replyData },
-#. } = useQuery(LIST_REPLIES, {
-#. variables: {
-#. ...listQueryVars,
-#. before: query.before,
-#. after: query.after,
-#. },
-#. });
-#. Separate these stats query so that it will be cached by apollo-client and sends no network request
-#. on page change, but still works when filter options are updated.
-#.
-#. const {
-#. loading: statsLoading,
-#. data: { ListArticles: statsData },
-#. } = useQuery(LIST_STAT, {
-#. variables: listQueryVars,
-#. });
+#: pages/replies.js:197
 msgid "Reply list"
 msgstr "回應列表"
 
-#: pages/replies.js:185
-#. const {
-#. loading,
-#. data: { ListReplies: replyData },
-#. } = useQuery(LIST_REPLIES, {
-#. variables: {
-#. ...listQueryVars,
-#. before: query.before,
-#. after: query.after,
-#. },
-#. });
-#. Separate these stats query so that it will be cached by apollo-client and sends no network request
-#. on page change, but still works when filter options are updated.
-#.
-#. const {
-#. loading: statsLoading,
-#. data: { ListArticles: statsData },
-#. } = useQuery(LIST_STAT, {
-#. variables: listQueryVars,
-#. });
+#: pages/replies.js:228
 msgid "Only show replies written by me"
 msgstr "只顯示我寫的回應"
 
@@ -417,3 +380,9 @@ msgstr "轉傳訊息或網路文章含有個人感想、假說猜測、陰謀論
 #: constants/replyType.js:21
 msgid "This message has some of its content proved to be false."
 msgstr "轉傳訊息或網路文章有一部分含有不實資訊。"
+
+#: pages/replies.js:247
+#, javascript-format
+msgid "${ statsData.totalCount } reply"
+msgid_plural "${ statsData.totalCount } replies"
+msgstr[0] "${ statsData.totalCount } 份回應"

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -40,7 +40,7 @@ msgid "Save"
 msgstr "儲存"
 
 #: components/AppLayout/UserName.js:138
-#: components/ReplyFeedback.js:200
+#: components/ReplyFeedback.js:199
 msgid "Cancel"
 msgstr "取消"
 
@@ -61,6 +61,7 @@ msgid "Close"
 msgstr "關閉"
 
 #: components/AppLayout/AppHeader.js:18
+#: components/ReplySearch/ReplySearch.js:115
 msgid "Replies"
 msgstr "回應列表"
 
@@ -75,113 +76,115 @@ msgid "${ replyCount } response"
 msgid_plural "${ replyCount } responses"
 msgstr[0] "${ replyCount } 份回應"
 
-#: pages/articles.js:264
+#: pages/articles.js:241
 #, javascript-format
 msgid "${ statsData.totalCount } collected message"
 msgid_plural "${ statsData.totalCount } collected messages"
 msgstr[0] "${ statsData.totalCount } 份回報訊息"
 
-#: pages/articles.js:133
+#: pages/articles.js:132
 msgid "Not replied"
 msgstr "尚未回覆"
 
-#: pages/articles.js:136
+#: pages/articles.js:135
 msgid "Replied"
 msgstr "已回覆"
 
-#: pages/articles.js:139
+#: pages/articles.js:138
 msgid "All"
 msgstr "全部"
 
-#: pages/articles.js:247
+#: pages/articles.js:224
 msgid "Include messages reported only 1 time"
 msgstr "加列僅被回報 1 次的訊息"
 
-#: pages/articles.js:292
+#: pages/articles.js:269
 msgid "Shows messages reported multiple times by default."
 msgstr "預設僅會列出被回報數次的訊息。"
 
-#: pages/articles.js:302
+#: pages/articles.js:279
 msgid "Click here to include messages only reported 1 time."
 msgstr "按這裡加入僅被回報 1 次的訊息。"
 
-#: pages/articles.js:170
+#: pages/articles.js:147
+#: pages/replies.js:107
 msgid "Sort by"
 msgstr "排序方式"
 
-#: pages/articles.js:182
+#: pages/articles.js:159
 msgid "Most recently asked"
 msgstr "最近被查詢"
 
-#: pages/articles.js:183
+#: pages/articles.js:160
 msgid "Most asked"
 msgstr "最多人詢問"
 
-#: pages/articles.js:251
+#: pages/articles.js:228
+#: pages/replies.js:189
 msgid "Sort by Relevance"
 msgstr "以相關度排序"
 
-#: pages/article/[id].js:102
+#: pages/article/[id].js:122
 msgid "Reported Message"
 msgstr "使用者回報訊息"
 
-#: components/ReplyRequestReason/ReplyRequestReason.js:54
+#: components/ReplyRequestReason/ReplyRequestReason.js:55
 msgid "All messages reported by this user"
 msgstr "所有這個使用者回報的訊息"
 
 #: components/ArticleInfo.js:31
-#: components/ArticleReply.js:111
+#: components/ArticleReply.js:120
 #, javascript-format
 msgid "${ timeAgoStr } ago"
 msgstr "${ timeAgoStr }前"
 
-#: components/ArticleReply.js:87
+#: components/ArticleReply.js:89
 msgid "“Editor Manual”"
 msgstr "《編輯指南》"
 
-#: components/ArticleReply.js:93
+#: components/ArticleReply.js:95
 #, javascript-format
 msgid "Please refer to ${ refLink } for what to fact-check."
 msgstr "查證範圍請參考${ refLink }"
 
-#: components/ArticleReply.js:118
-#: components/ArticleReply.js:230
+#: components/ArticleReply.js:127
+#: components/ArticleReply.js:239
 msgid "Reason"
 msgstr "理由"
 
-#: components/ArticleReply.js:120
+#: components/ArticleReply.js:129
 msgid "Details"
 msgstr "詳細解釋"
 
-#: components/ArticleReply.js:122
-#: components/ArticleReply.js:199
+#: components/ArticleReply.js:131
+#: components/ArticleReply.js:208
 msgid "Reference"
 msgstr "出處"
 
-#: components/ArticleReply.js:164
-#: components/ReplyFeedback.js:161
+#: components/ArticleReply.js:173
+#: components/ReplyFeedback.js:160
 msgid "Someone"
 msgstr "有人"
 
-#: components/ArticleReply.js:175
+#: components/ArticleReply.js:184
 #, javascript-format
 msgid "${ originalAuthorElem }'s reply"
 msgstr "${ originalAuthorElem } 的回應"
 
-#: components/ArticleReply.js:182
+#: components/ArticleReply.js:191
 #, javascript-format
 msgid "${ articleReplyAuthorName } uses ${ originalAuthorsReply } to"
 msgstr "${ articleReplyAuthorName } 使用 ${ originalAuthorsReply }"
 
-#: components/ArticleReply.js:199
+#: components/ArticleReply.js:208
 msgid "Different opinion"
 msgstr "不同意見"
 
-#: components/ArticleReply.js:203
+#: components/ArticleReply.js:212
 msgid "There is no reference for this reply. Its truthfulness may be doubtful."
 msgstr "這則回應沒有出處，請自行斟酌其真實性。"
 
-#: components/ArticleReply.js:226
+#: components/ArticleReply.js:235
 #, javascript-format
 msgid "${ authorElem } mark the message as ${ typeElem }"
 msgstr "${ authorElem } 標記此篇為 ${ typeElem }"
@@ -194,30 +197,30 @@ msgstr "複製"
 msgid "Copied to clipboard."
 msgstr "已複製到剪貼簿。"
 
-#: components/CurrentReplies.js:50
+#: components/CurrentReplies.js:69
 msgid "Deleted replies"
 msgstr "已刪除的回應"
 
-#: components/CurrentReplies.js:58
+#: components/CurrentReplies.js:77
 #: pages/reply.js:135
 msgid "Restore"
 msgstr "恢復"
 
-#: components/CurrentReplies.js:82
+#: components/CurrentReplies.js:101
 #, javascript-format
 msgid "${ items.length } reply"
 msgid_plural "${ items.length } replies"
 msgstr[0] " ${ items.length } 則回應"
 
-#: components/CurrentReplies.js:92
+#: components/CurrentReplies.js:111
 msgid "There are ${ replyLink } deleted by its author."
 msgstr "有${ replyLink }被作者自行刪除。"
 
-#: components/CurrentReplies.js:116
+#: components/CurrentReplies.js:154
 msgid "There is no existing replies for now."
 msgstr "目前沒有已撰寫的回應。"
 
-#: components/CurrentReplies.js:137
+#: components/CurrentReplies.js:175
 #: pages/reply.js:135
 msgid "Delete"
 msgstr "刪除"
@@ -227,34 +230,190 @@ msgstr "刪除"
 msgid "Lv.${ editorLevel } ${ levelName }"
 msgstr "等級 ${ editorLevel }. ${ levelName }"
 
-#: pages/article/[id].js:131
+#: pages/article/[id].js:151
 msgid "Replies to the message"
 msgstr "現有回應"
 
-#: components/ReplyFeedback.js:101
+#: components/ReplyFeedback.js:100
 msgid "Is the reply helpful?"
 msgstr "這則回應是否有幫助？"
 
-#: components/ReplyFeedback.js:187
+#: components/ReplyFeedback.js:186
 msgid "Please share with us why you think this reply is not useful"
 msgstr "請告訴我們為什麼您覺得好心人的回應沒有幫助？"
 
-#: components/ReplyFeedback.js:139
+#: components/ReplyFeedback.js:138
 msgid "Why?"
 msgstr "Why?"
 
-#: components/ReplyFeedback.js:151
+#: components/ReplyFeedback.js:150
 msgid "Reasons why users think it's not useful"
 msgstr "覺得沒幫助的理由"
 
-#: components/ReplyFeedback.js:184
+#: components/ReplyFeedback.js:183
 msgid "Reasons why you think it's not useful"
 msgstr "您覺得沒幫助的理由"
 
-#: components/ReplyFeedback.js:203
+#: components/ReplyFeedback.js:202
 msgid "Submit"
 msgstr "送出"
 
-#: components/ReplyFeedback.js:212
+#: components/ReplyFeedback.js:211
 msgid "Thank you for the feedback."
 msgstr "感謝您的意見。"
+
+#: pages/replies.js:94
+msgid "All replies"
+msgstr "所有回應"
+
+#: pages/replies.js:119
+msgid "Most recently written"
+msgstr "最近寫的"
+
+#: pages/replies.js:120
+msgid "Least recently written"
+msgstr "最久以前寫的"
+
+#: pages/replies.js:155
+#. const {
+#. loading,
+#. data: { ListReplies: replyData },
+#. } = useQuery(LIST_REPLIES, {
+#. variables: {
+#. ...listQueryVars,
+#. before: query.before,
+#. after: query.after,
+#. },
+#. });
+#. Separate these stats query so that it will be cached by apollo-client and sends no network request
+#. on page change, but still works when filter options are updated.
+#.
+#. const {
+#. loading: statsLoading,
+#. data: { ListArticles: statsData },
+#. } = useQuery(LIST_STAT, {
+#. variables: listQueryVars,
+#. });
+msgid "Reply list"
+msgstr "回應列表"
+
+#: pages/replies.js:185
+#. const {
+#. loading,
+#. data: { ListReplies: replyData },
+#. } = useQuery(LIST_REPLIES, {
+#. variables: {
+#. ...listQueryVars,
+#. before: query.before,
+#. after: query.after,
+#. },
+#. });
+#. Separate these stats query so that it will be cached by apollo-client and sends no network request
+#. on page change, but still works when filter options are updated.
+#.
+#. const {
+#. loading: statsLoading,
+#. data: { ListArticles: statsData },
+#. } = useQuery(LIST_STAT, {
+#. variables: listQueryVars,
+#. });
+msgid "Only show replies written by me"
+msgstr "只顯示我寫的回應"
+
+#: pages/article/[id].js:156
+msgid "Add a new reply"
+msgstr "新增回應"
+
+#: pages/article/[id].js:169
+msgid "You may be interested in the following similar messages"
+msgstr "你可能對下面類似訊息感興趣"
+
+#: components/NewReplySection.js:76
+msgid "Your reply has been submitted."
+msgstr "已經送出回應。"
+
+#: components/NewReplySection.js:90
+#. Notify upper component of submission
+msgid "Your have attached the reply to this message."
+msgstr "已經加入回應。"
+
+#: components/NewReplySection.js:117
+msgid "Please login first."
+msgstr "請先登入。"
+
+#: components/NewReplySection.js:123
+msgid "New Reply"
+msgstr "寫新回應"
+
+#: components/NewReplySection.js:130
+msgid "Reuse existing reply"
+msgstr "使用現有回應"
+
+#: components/NewReplySection.js:134
+#: components/ReplySearch/ReplySearch.js:156
+msgid "Search"
+msgstr "搜尋"
+
+#: components/ReplySearch/ReplySearch.js:103
+#, javascript-format
+msgid "Searching for messages and replies containing “${ variables.query }”..."
+msgstr "正在搜尋含有「${ variables.query }」的訊息與回應⋯⋯"
+
+#: components/ReplySearch/ReplySearch.js:123
+msgid "Reported messages"
+msgstr "回報訊息"
+
+#: components/ReplySearch/SearchArticleItem.js:74
+msgid "Replies of the searched message"
+msgstr "搜尋訊息的回應"
+
+#: components/ReplySearch/SearchArticleItem.js:82
+msgid "Add this reply to message"
+msgstr "將回應加入到此訊息"
+
+#: components/ReplyRequestReason/ReplyRequestReason.js:191
+msgid "The reason is reasonable"
+msgstr "理由合理"
+
+#: components/ReplyRequestReason/ReplyRequestReason.js:196
+msgid "The reason is not reasonable"
+msgstr "理由不合理"
+
+#: components/AppLayout/LoginModal.js:13
+msgid "Login / Signup"
+msgstr "登入/註冊"
+
+#: constants/replyType.js:11
+msgid "Invalid request"
+msgstr "不在查證範圍"
+
+#: constants/replyType.js:12
+msgid "Contains personal perspective"
+msgstr "含有個人意見"
+
+#: constants/replyType.js:13
+msgid "Contains true information"
+msgstr "含有正確訊息"
+
+#: constants/replyType.js:14
+msgid "Contains misinformation"
+msgstr "含有不實訊息"
+
+#: constants/replyType.js:18
+msgid "This message cannot or should not be processed by Cofacts editors."
+msgstr "這篇訊息不是編輯能夠處理、或 Cofacts 不應該受理此類文章。"
+
+#: constants/replyType.js:19
+msgid "The message has some of its content proved to be true."
+msgstr "轉傳訊息或網路文章有一部分內容查證屬實。"
+
+#: constants/replyType.js:20
+msgid ""
+"The message contains personal opinion, unproven hypotheses, conspiracy "
+"theories, studies that has not reached concensus, inferences of political "
+"policies, etc."
+msgstr "轉傳訊息或網路文章含有個人感想、假說猜測、陰謀論、尚無共識的研究、對政策的推論等等。"
+
+#: constants/replyType.js:21
+msgid "This message has some of its content proved to be false."
+msgstr "轉傳訊息或網路文章有一部分含有不實資訊。"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint:fix": "eslint --fix .",
     "test": "jest",
     "start": "next start",
-    "i18n:extract": "ttag update i18n/zh_TW.po ./components ./pages",
+    "i18n:extract": "ttag update i18n/zh_TW.po ./components ./pages ./constants",
     "i18n:validate": "ttag validate i18n/zh_TW.po"
   },
   "dependencies": {

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -2,7 +2,6 @@ import gql from 'graphql-tag';
 import { t, ngettext, msgid } from 'ttag';
 import Router from 'next/router';
 import url from 'url';
-import { useCallback } from 'react';
 import { useQuery } from '@apollo/react-hooks';
 
 import ButtonGroup from '@material-ui/core/ButtonGroup';
@@ -10,7 +9,6 @@ import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
 import InputAdornment from '@material-ui/core/InputAdornment';
-import SearchIcon from '@material-ui/icons/Search';
 import SortIcon from '@material-ui/icons/Sort';
 import Grid from '@material-ui/core/Grid';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
@@ -21,6 +19,7 @@ import withData from 'lib/apollo';
 import AppLayout from 'components/AppLayout';
 import ArticleItem from 'components/ArticleItem';
 import Pagination from 'components/Pagination';
+import SearchInput from 'components/SearchInput';
 
 const DEFAULT_ORDER_BY = 'lastRequestedAt';
 const DEFAULT_TYPE_FILTER = 'unsolved';
@@ -139,28 +138,6 @@ function ArticleFilter({ filter = DEFAULT_TYPE_FILTER, onChange = () => {} }) {
         {t`All`}
       </Button>
     </ButtonGroup>
-  );
-}
-
-function SearchInput({ q = '', onChange = () => {} }) {
-  const handleSubmit = useCallback(e => onChange(e.target.value), [onChange]);
-  const handleKeyUp = useCallback(e => {
-    e.which === 13 && e.target.blur();
-  }, []);
-
-  return (
-    <TextField
-      defaultValue={q}
-      onBlur={handleSubmit}
-      onKeyUp={handleKeyUp}
-      InputProps={{
-        startAdornment: (
-          <InputAdornment position="start">
-            <SearchIcon />
-          </InputAdornment>
-        ),
-      }}
-    />
   );
 }
 

--- a/pages/replies.js
+++ b/pages/replies.js
@@ -216,7 +216,7 @@ function ReplyListPage({ query }) {
         <FormControlLabel
           control={
             <Checkbox
-              checked={query.mine}
+              checked={!!query.mine}
               onChange={e =>
                 goToUrlQueryAndResetPagination({
                   ...query,

--- a/pages/replies.js
+++ b/pages/replies.js
@@ -2,11 +2,7 @@
 // https://github.com/yannickcr/eslint-plugin-react/issues/1200
 
 import React from 'react';
-import { connect } from 'react-redux';
 import Head from 'next/head';
-import { List } from 'immutable';
-import { RadioGroup, Radio } from 'react-radio-group';
-import { load } from 'ducks/replyList';
 
 import { TYPE_NAME, TYPE_DESC } from '../constants/replyType';
 
@@ -16,6 +12,54 @@ import Pagination from 'components/Pagination';
 import ReplyItem from 'components/ReplyItem';
 
 import { mainStyle } from './articles.styles';
+
+const DEFAULT_ORDER_BY = 'createdAt_DESC';
+
+function SortInput({ orderBy = DEFAULT_ORDER_BY, onChange = () => {} }) {
+  return (
+    <TextField
+      label={t`Sort by`}
+      select
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <SortIcon />
+          </InputAdornment>
+        ),
+      }}
+      value={orderBy}
+      onChange={e => onChange(e.target.value)}
+    >
+      <MenuItem value="createdAt_DESC">{t`Most recently written`}</MenuItem>
+      <MenuItem value="createdAt_ASC">{t`Least recently written`}</MenuItem>
+    </TextField>
+  );
+}
+
+function ReplyListPage({query}) {
+  return (
+      <AppLayout>
+        <main>
+          <Head>
+            <title>回應列表</title>
+          </Head>
+          <h2>回應列表</h2>
+          {this.renderSearch()}
+          <br />
+          Order By:
+          {this.renderOrderBy()}
+          {this.renderFilter()}
+          {this.renderMyReplyOnlyCheckbox()}
+          {isLoading ? <p>Loading...</p> : this.renderList()}
+          <style jsx>{mainStyle}</style>
+        </main>
+      </AppLayout>
+    );
+}
+
+// Expose path query to component
+ArticleListPage.getInitialProps = ({ query }) => ({ query });
+
 
 class ReplyList extends ListPage {
   static async getInitialProps({ store, query, isServer }) {

--- a/pages/replies.js
+++ b/pages/replies.js
@@ -3,17 +3,102 @@
 
 import React from 'react';
 import Head from 'next/head';
+import { t, ngettext, msgid } from 'ttag';
+import url from 'url';
+import Router from 'next/router';
 
 import { TYPE_NAME, TYPE_DESC } from '../constants/replyType';
 
-import AppLayout from 'components/AppLayout';
-import ListPage from 'components/ListPage';
-import Pagination from 'components/Pagination';
-import ReplyItem from 'components/ReplyItem';
+import ButtonGroup from '@material-ui/core/ButtonGroup';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+import MenuItem from '@material-ui/core/MenuItem';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import SortIcon from '@material-ui/icons/Sort';
+import Grid from '@material-ui/core/Grid';
+import FormControlLabel from '@material-ui/core/FormControlLabel';
+import Checkbox from '@material-ui/core/Checkbox';
+import Typography from '@material-ui/core/Typography';
 
-import { mainStyle } from './articles.styles';
+import withData from 'lib/apollo';
+import AppLayout from 'components/AppLayout';
+import ArticleItem from 'components/ArticleItem';
+import Pagination from 'components/Pagination';
+import SearchInput from 'components/SearchInput';
 
 const DEFAULT_ORDER_BY = 'createdAt_DESC';
+const DEFAULT_TYPE_FILTER = 'all';
+
+/**
+ * @param {object} urlQuery - URL query object
+ * @returns {object} ListReplyFilter
+ */
+function urlQuery2Filter({ filter = DEFAULT_TYPE_FILTER, q, mine } = {}) {
+  const filterObj = {};
+  if (q) {
+    filterObj.moreLikeThis = { like: q, minimumShouldMatch: '0' };
+  }
+
+  if (filter && filter !== 'all') {
+    filterObj.type === filter;
+  }
+
+  if (mine) {
+    filterObj.selfOnly = true;
+  }
+
+  // Return filterObj only when it is populated.
+  if (!Object.keys(filterObj).length) {
+    return undefined;
+  }
+
+  return filterObj;
+}
+
+/**
+ * @param {object} urlQuery - URL query object
+ * @returns {object[]} ListArticleOrderBy array
+ */
+function urlQuery2OrderBy({ q, orderBy = DEFAULT_ORDER_BY } = {}) {
+  const [orderByItem, order] = orderBy.split('_');
+
+  // If there is query text, sort by _score first
+
+  if (q) {
+    return [{ _score: 'DESC' }, { [orderByItem]: order }];
+  }
+
+  return [{ [orderByItem]: order }];
+}
+
+/**
+ * @param {object} urlQuery
+ */
+function goToUrlQueryAndResetPagination(urlQuery) {
+  delete urlQuery.before;
+  delete urlQuery.after;
+  Router.push(`${location.pathname}${url.format({ query: urlQuery })}`);
+}
+
+function ReplyFilter({ filter = DEFAULT_TYPE_FILTER, onChange = () => {} }) {
+  return (
+    <ButtonGroup size="small" variant="outlined">
+      <Button disabled={filter === 'all'} onClick={() => onChange('all')}>
+        {t`All replies`}
+      </Button>
+      {['NOT_ARTICLE', 'OPINIONATED', 'NOT_RUMOR', 'RUMOR'].map(type => (
+        <Button
+          key={type}
+          disabled={filter === type}
+          onClick={() => onChange(type)}
+          title={TYPE_DESC[type]}
+        >
+          {TYPE_NAME[type]}
+        </Button>
+      ))}
+    </ButtonGroup>
+  );
+}
 
 function SortInput({ orderBy = DEFAULT_ORDER_BY, onChange = () => {} }) {
   return (
@@ -36,216 +121,312 @@ function SortInput({ orderBy = DEFAULT_ORDER_BY, onChange = () => {} }) {
   );
 }
 
-function ReplyListPage({query}) {
+function ReplyListPage({ query }) {
+  const listQueryVars = {
+    filter: urlQuery2Filter(query),
+    orderBy: urlQuery2OrderBy(query),
+  };
+
+  // const {
+  //   loading,
+  //   data: { ListReplies: replyData },
+  // } = useQuery(LIST_REPLIES, {
+  //   variables: {
+  //     ...listQueryVars,
+  //     before: query.before,
+  //     after: query.after,
+  //   },
+  // });
+
+  // Separate these stats query so that it will be cached by apollo-client and sends no network request
+  // on page change, but still works when filter options are updated.
+  //
+  // const {
+  //   loading: statsLoading,
+  //   data: { ListArticles: statsData },
+  // } = useQuery(LIST_STAT, {
+  //   variables: listQueryVars,
+  // });
+
   return (
-      <AppLayout>
-        <main>
-          <Head>
-            <title>回應列表</title>
-          </Head>
-          <h2>回應列表</h2>
-          {this.renderSearch()}
-          <br />
-          Order By:
-          {this.renderOrderBy()}
-          {this.renderFilter()}
-          {this.renderMyReplyOnlyCheckbox()}
-          {isLoading ? <p>Loading...</p> : this.renderList()}
-          <style jsx>{mainStyle}</style>
-        </main>
-      </AppLayout>
-    );
+    <AppLayout>
+      <Grid container spacing={2}>
+        <Grid item>
+          <ReplyFilter
+            filter={query.filter}
+            onChange={filter =>
+              goToUrlQueryAndResetPagination({ ...query, filter })
+            }
+          />
+        </Grid>
+        <Grid item>
+          <SearchInput
+            q={query.q}
+            onChange={q => goToUrlQueryAndResetPagination({ ...query, q })}
+          />
+        </Grid>
+      </Grid>
+      <FormControlLabel
+        control={
+          <Checkbox
+            checked={query.mine}
+            onChange={e =>
+              goToUrlQueryAndResetPagination({
+                ...query,
+                mine: e.target.checked ? 1 : undefined,
+              })
+            }
+          />
+        }
+        label={t`Only show replies written by me`}
+      />
+      <div>
+        {query.q ? (
+          t`Sort by Relevance`
+        ) : (
+          <SortInput
+            orderBy={query.orderBy}
+            onChange={orderBy =>
+              goToUrlQueryAndResetPagination({ ...query, orderBy })
+            }
+          />
+        )}
+      </div>
+
+      {/* <p>
+        {statsLoading
+          ? 'Loading...'
+          : ngettext(
+              msgid`${statsData.totalCount} collected message`,
+              `${statsData.totalCount} collected messages`,
+              statsData.totalCount
+            )}
+      </p> */}
+
+      {/* {loading ? (
+        'Loading....'
+      ) : (
+        <>
+          <Pagination
+            query={query}
+            pageInfo={statsData?.pageInfo}
+            edges={replyData?.edges}
+          />
+          <ul className="reply-list">
+            {replyData.edges.map(({ node }) => (
+              <ReplyItem key={node.id} reply={node} showUser={query.mine} />
+            ))}
+          </ul>
+          <Pagination
+            query={query}
+            pageInfo={statsData?.pageInfo}
+            edges={replyData?.edges}
+          />
+        </>
+      )} */}
+
+      <style jsx>
+        {`
+          .reply-list {
+            padding: 0;
+            list-style: none;
+          }
+        `}
+      </style>
+    </AppLayout>
+  );
 }
 
 // Expose path query to component
-ArticleListPage.getInitialProps = ({ query }) => ({ query });
+ReplyListPage.getInitialProps = ({ query }) => ({ query });
 
+export default withData(ReplyListPage);
 
-class ReplyList extends ListPage {
-  static async getInitialProps({ store, query, isServer }) {
-    // Load on server-side render only when query.mine is not set.
-    // This makes sure that reply list can be crawled by search engines too, and it can load fast
-    if (query.mine && isServer) return;
-    await store.dispatch(load(query));
-    return { query };
-  }
+// class ReplyList extends ListPage {
+//   static async getInitialProps({ store, query, isServer }) {
+//     // Load on server-side render only when query.mine is not set.
+//     // This makes sure that reply list can be crawled by search engines too, and it can load fast
+//     if (query.mine && isServer) return;
+//     await store.dispatch(load(query));
+//     return { query };
+//   }
 
-  componentDidMount() {
-    const { query, dispatch } = this.props;
+//   componentDidMount() {
+//     const { query, dispatch } = this.props;
 
-    // Pick up initial data loading when server-side render skips
-    if (!query.mine) return;
-    return dispatch(load(query));
-  }
+//     // Pick up initial data loading when server-side render skips
+//     if (!query.mine) return;
+//     return dispatch(load(query));
+//   }
 
-  handleMyReplyOnlyCheck = e => {
-    this.goToQuery({
-      mine: e.target.checked ? 1 : undefined,
-    });
-  };
+//   handleMyReplyOnlyCheck = e => {
+//     this.goToQuery({
+//       mine: e.target.checked ? 1 : undefined,
+//     });
+//   };
 
-  renderSearch = () => {
-    const {
-      query: { q },
-    } = this.props;
-    return (
-      <label>
-        Search For:
-        <input
-          type="search"
-          onBlur={this.handleKeywordChange}
-          onKeyUp={this.handleKeywordKeyup}
-          defaultValue={q}
-        />
-      </label>
-    );
-  };
+//   renderSearch = () => {
+//     const {
+//       query: { q },
+//     } = this.props;
+//     return (
+//       <label>
+//         Search For:
+//         <input
+//           type="search"
+//           onBlur={this.handleKeywordChange}
+//           onKeyUp={this.handleKeywordKeyup}
+//           defaultValue={q}
+//         />
+//       </label>
+//     );
+//   };
 
-  renderOrderBy = () => {
-    const {
-      query: { orderBy, q },
-    } = this.props;
-    if (q) {
-      return <span> Relevance</span>;
-    }
+//   renderOrderBy = () => {
+//     const {
+//       query: { orderBy, q },
+//     } = this.props;
+//     if (q) {
+//       return <span> Relevance</span>;
+//     }
 
-    return (
-      <select
-        onChange={this.handleOrderByChange}
-        value={orderBy || 'createdAt_DESC'}
-      >
-        <option value="createdAt_DESC">Most recently written</option>
-        <option value="createdAt_ASC">Least recently written</option>
-      </select>
-    );
-  };
+//     return (
+//       <select
+//         onChange={this.handleOrderByChange}
+//         value={orderBy || 'createdAt_DESC'}
+//       >
+//         <option value="createdAt_DESC">Most recently written</option>
+//         <option value="createdAt_ASC">Least recently written</option>
+//       </select>
+//     );
+//   };
 
-  renderMyReplyOnlyCheckbox() {
-    const {
-      isLoggedIn,
-      query: { mine },
-    } = this.props;
-    if (!isLoggedIn) return null;
+//   renderMyReplyOnlyCheckbox() {
+//     const {
+//       isLoggedIn,
+//       query: { mine },
+//     } = this.props;
+//     if (!isLoggedIn) return null;
 
-    return (
-      <label>
-        <input
-          type="checkbox"
-          onChange={this.handleMyReplyOnlyCheck}
-          checked={!!mine}
-        />
-        只顯示我寫的
-      </label>
-    );
-  }
+//     return (
+//       <label>
+//         <input
+//           type="checkbox"
+//           onChange={this.handleMyReplyOnlyCheck}
+//           checked={!!mine}
+//         />
+//         只顯示我寫的
+//       </label>
+//     );
+//   }
 
-  renderFilter = () => {
-    const {
-      query: { filter },
-    } = this.props;
-    return (
-      <RadioGroup
-        onChange={this.handleFilterChange}
-        selectedValue={filter || 'all'}
-        Component="ul"
-      >
-        <li>
-          <label>
-            <Radio value="all" />All
-          </label>
-        </li>
-        {['NOT_ARTICLE', 'OPINIONATED', 'NOT_RUMOR', 'RUMOR'].map(type => (
-          <li key={type}>
-            <label>
-              <Radio value={type} title={TYPE_DESC[type]} />
-              {TYPE_NAME[type]}
-            </label>
-          </li>
-        ))}
-      </RadioGroup>
-    );
-  };
+//   renderFilter = () => {
+//     const {
+//       query: { filter },
+//     } = this.props;
+//     return (
+//       <RadioGroup
+//         onChange={this.handleFilterChange}
+//         selectedValue={filter || 'all'}
+//         Component="ul"
+//       >
+//         <li>
+//           <label>
+//             <Radio value="all" />All
+//           </label>
+//         </li>
+//         {['NOT_ARTICLE', 'OPINIONATED', 'NOT_RUMOR', 'RUMOR'].map(type => (
+//           <li key={type}>
+//             <label>
+//               <Radio value={type} title={TYPE_DESC[type]} />
+//               {TYPE_NAME[type]}
+//             </label>
+//           </li>
+//         ))}
+//       </RadioGroup>
+//     );
+//   };
 
-  renderPagination = () => {
-    const {
-      query = {}, // URL params
-      firstCursor,
-      lastCursor,
-      firstCursorOfPage,
-      lastCursorOfPage,
-    } = this.props;
+//   renderPagination = () => {
+//     const {
+//       query = {}, // URL params
+//       firstCursor,
+//       lastCursor,
+//       firstCursorOfPage,
+//       lastCursorOfPage,
+//     } = this.props;
 
-    return (
-      <Pagination
-        query={query}
-        firstCursor={firstCursor}
-        lastCursor={lastCursor}
-        firstCursorOfPage={firstCursorOfPage}
-        lastCursorOfPage={lastCursorOfPage}
-      />
-    );
-  };
+//     return (
+//       <Pagination
+//         query={query}
+//         firstCursor={firstCursor}
+//         lastCursor={lastCursor}
+//         firstCursorOfPage={firstCursorOfPage}
+//         lastCursorOfPage={lastCursorOfPage}
+//       />
+//     );
+//   };
 
-  renderList = () => {
-    const {
-      replies = null,
-      totalCount,
-      query: { mine },
-    } = this.props;
-    return (
-      <div>
-        <p>{totalCount} replies</p>
-        {this.renderPagination()}
-        <div className="reply-list">
-          {replies.map(reply => (
-            <ReplyItem key={reply.get('id')} reply={reply} showUser={!mine} />
-          ))}
-        </div>
-        {this.renderPagination()}
-        <style jsx>{`
-          .reply-list {
-            padding: 0;
-          }
-        `}</style>
-      </div>
-    );
-  };
+//   renderList = () => {
+//     const {
+//       replies = null,
+//       totalCount,
+//       query: { mine },
+//     } = this.props;
+//     return (
+//       <div>
+//         <p>{totalCount} replies</p>
+//         {this.renderPagination()}
+//         <div className="reply-list">
+//           {replies.map(reply => (
+//             <ReplyItem key={reply.get('id')} reply={reply} showUser={!mine} />
+//           ))}
+//         </div>
+//         {this.renderPagination()}
+//         <style jsx>{`
+//           .reply-list {
+//             padding: 0;
+//           }
+//         `}</style>
+//       </div>
+//     );
+//   };
 
-  render() {
-    const { isLoading = false } = this.props;
+//   render() {
+//     const { isLoading = false } = this.props;
 
-    return (
-      <AppLayout>
-        <main>
-          <Head>
-            <title>回應列表</title>
-          </Head>
-          <h2>回應列表</h2>
-          {this.renderSearch()}
-          <br />
-          Order By:
-          {this.renderOrderBy()}
-          {this.renderFilter()}
-          {this.renderMyReplyOnlyCheckbox()}
-          {isLoading ? <p>Loading...</p> : this.renderList()}
-          <style jsx>{mainStyle}</style>
-        </main>
-      </AppLayout>
-    );
-  }
-}
+//     return (
+//       <AppLayout>
+//         <main>
+//           <Head>
+//             <title>回應列表</title>
+//           </Head>
+//           <h2>回應列表</h2>
+//           {this.renderSearch()}
+//           <br />
+//           Order By:
+//           {this.renderOrderBy()}
+//           {this.renderFilter()}
+//           {this.renderMyReplyOnlyCheckbox()}
+//           {isLoading ? <p>Loading...</p> : this.renderList()}
+//           <style jsx>{mainStyle}</style>
+//         </main>
+//       </AppLayout>
+//     );
+//   }
+// }
 
-function mapStateToProps({ replyList, auth }) {
-  return {
-    isLoggedIn: !!auth.get('user'),
-    isLoading: replyList.getIn(['state', 'isLoading']),
-    replies: (replyList.get('edges') || List()).map(edge => edge.get('node')),
-    totalCount: replyList.get('totalCount'),
-    firstCursor: replyList.get('firstCursor'),
-    lastCursor: replyList.get('lastCursor'),
-    firstCursorOfPage: replyList.getIn(['edges', 0, 'cursor']),
-    lastCursorOfPage: replyList.getIn(['edges', -1, 'cursor']),
-  };
-}
+// function mapStateToProps({ replyList, auth }) {
+//   return {
+//     isLoggedIn: !!auth.get('user'),
+//     isLoading: replyList.getIn(['state', 'isLoading']),
+//     replies: (replyList.get('edges') || List()).map(edge => edge.get('node')),
+//     totalCount: replyList.get('totalCount'),
+//     firstCursor: replyList.get('firstCursor'),
+//     lastCursor: replyList.get('lastCursor'),
+//     firstCursorOfPage: replyList.getIn(['edges', 0, 'cursor']),
+//     lastCursorOfPage: replyList.getIn(['edges', -1, 'cursor']),
+//   };
+// }
 
-export default connect(mapStateToProps)(ReplyList);
+// export default connect(mapStateToProps)(ReplyList);

--- a/pages/replies.js
+++ b/pages/replies.js
@@ -3,26 +3,23 @@
 
 import React from 'react';
 import Head from 'next/head';
-import { t, ngettext, msgid } from 'ttag';
+import { t } from 'ttag';
 import url from 'url';
 import Router from 'next/router';
 
-import { TYPE_NAME, TYPE_DESC } from '../constants/replyType';
+import { TYPE_NAME } from '../constants/replyType';
 
-import ButtonGroup from '@material-ui/core/ButtonGroup';
-import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
 import MenuItem from '@material-ui/core/MenuItem';
 import InputAdornment from '@material-ui/core/InputAdornment';
 import SortIcon from '@material-ui/icons/Sort';
+import FilterListIcon from '@material-ui/icons/FilterList';
 import Grid from '@material-ui/core/Grid';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
-import Typography from '@material-ui/core/Typography';
 
 import withData from 'lib/apollo';
 import AppLayout from 'components/AppLayout';
-import ArticleItem from 'components/ArticleItem';
 import Pagination from 'components/Pagination';
 import SearchInput from 'components/SearchInput';
 
@@ -82,21 +79,25 @@ function goToUrlQueryAndResetPagination(urlQuery) {
 
 function ReplyFilter({ filter = DEFAULT_TYPE_FILTER, onChange = () => {} }) {
   return (
-    <ButtonGroup size="small" variant="outlined">
-      <Button disabled={filter === 'all'} onClick={() => onChange('all')}>
-        {t`All replies`}
-      </Button>
+    <TextField
+      select
+      value={filter}
+      onChange={e => onChange(e.target.value)}
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <FilterListIcon />
+          </InputAdornment>
+        ),
+      }}
+    >
+      <MenuItem value="all">{t`All replies`}</MenuItem>
       {['NOT_ARTICLE', 'OPINIONATED', 'NOT_RUMOR', 'RUMOR'].map(type => (
-        <Button
-          key={type}
-          disabled={filter === type}
-          onClick={() => onChange(type)}
-          title={TYPE_DESC[type]}
-        >
+        <MenuItem key={type} value={type}>
           {TYPE_NAME[type]}
-        </Button>
+        </MenuItem>
       ))}
-    </ButtonGroup>
+    </TextField>
   );
 }
 
@@ -150,6 +151,9 @@ function ReplyListPage({ query }) {
 
   return (
     <AppLayout>
+      <Head>
+        <title>{t`Reply list`}</title>
+      </Head>
       <Grid container spacing={2}>
         <Grid item>
           <ReplyFilter


### PR DESCRIPTION
Implements list of replies with apollo-client.

Component hierarchy:
- `replies.js` - the page. Corresponds to [articles.js](https://github.com/cofacts/rumors-site/blob/dev/pages/articles.js)
  - `ReplyItem.js` - each reply. Corresponds to [`ArticleItem`](https://github.com/cofacts/rumors-site/blob/dev/components/ArticleItem.js) and [`ArticleInfo`](https://github.com/cofacts/rumors-site/blob/dev/components/ArticleInfo.js)



<img width="681" alt="螢幕快照 2019-10-27 下午7 51 13" src="https://user-images.githubusercontent.com/108608/67634235-1b957880-f8f4-11e9-898f-0a390a77c496.png">

## Filtering
![reply-load](https://user-images.githubusercontent.com/108608/67634238-2a7c2b00-f8f4-11e9-8fe3-f862d0bac0d0.gif)

## Sorting && show only mine
![sort-only-me](https://user-images.githubusercontent.com/108608/67634239-2e0fb200-f8f4-11e9-8106-b9a3387c9526.gif)
