### PR TITLE
Fix HTTP header & handle empty users

### DIFF
--- a/components/ArticleReply.js
+++ b/components/ArticleReply.js
@@ -175,8 +175,8 @@ class ArticleReply extends React.PureComponent {
     const originalAuthorElem = (
       <EditorName
         key="editorName"
-        editorName={replyAuthor.name}
-        editorLevel={replyAuthor.level}
+        editorName={replyAuthor?.name}
+        editorLevel={replyAuthor?.level}
       />
     );
     const originalAuthorsReply = (
@@ -185,7 +185,7 @@ class ArticleReply extends React.PureComponent {
       </Link>
     );
 
-    if (replyAuthor.name && articleReplyAuthor.id !== replyAuthor.id) {
+    if (replyAuthor?.name && articleReplyAuthor?.id !== replyAuthor?.id) {
       return (
         <span key="editor">
           {jt`${articleReplyAuthorName} uses ${originalAuthorsReply} to`}

--- a/components/ReplyFeedback.js
+++ b/components/ReplyFeedback.js
@@ -91,7 +91,7 @@ function ReplyFeedback({
   });
 
   // Note that currentUser and user may be undefined or null (when appId mismatch)
-  // Noth case should not consider as ownArticleReply
+  // Both case should not consider as ownArticleReply
   //
   const isOwnArticleReply = currentUser && user && currentUser.id === user.id;
   const downVoteReasons = (feedbacks || []).filter(

--- a/components/ReplyFeedback.js
+++ b/components/ReplyFeedback.js
@@ -90,7 +90,10 @@ function ReplyFeedback({
     onCompleted: () => setReorderSnackShow(true),
   });
 
-  const isOwnArticleReply = currentUser?.id === user.id;
+  // Note that currentUser and user may be undefined or null (when appId mismatch)
+  // Noth case should not consider as ownArticleReply
+  //
+  const isOwnArticleReply = currentUser && user && currentUser.id === user.id;
   const downVoteReasons = (feedbacks || []).filter(
     feedback => !!feedback.comment
   );

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -2,6 +2,7 @@ import { withData } from 'next-apollo';
 import { BatchHttpLink } from 'apollo-link-batch-http';
 import { InMemoryCache, defaultDataIdFromObject } from 'apollo-cache-inmemory';
 import getConfig from 'next/config';
+import { headers } from './fetchAPI';
 
 const {
   publicRuntimeConfig: { PUBLIC_API_URL },
@@ -24,6 +25,7 @@ function customIdMapper(object) {
 const config = {
   link: new BatchHttpLink({
     uri: `${PUBLIC_API_URL}/graphql`, // Server URL (must be absolute)
+    headers,
     credentials: 'include', // Additional fetch() options like `credentials` or `headers`
   }),
   createCache() {

--- a/lib/fetchAPI.js
+++ b/lib/fetchAPI.js
@@ -5,12 +5,16 @@ const {
   publicRuntimeConfig: { PUBLIC_API_URL },
 } = getConfig();
 
+export const headers = {
+  'x-app-id': process.env.APP_ID,
+};
+
 export default function(endpoint = '/', args = {}) {
   return fetch(`${PUBLIC_API_URL}${endpoint}`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'x-app-id': process.env.APP_ID,
+      ...headers,
       ...args.headers,
     },
     credentials: 'include',


### PR DESCRIPTION
Deployed to https://cofacts.hacktabl.org/

This PR fixes:
- Correct `x-app-id` should be provided in GraphQL request headers so that current user can be recognized as author of new replies
- Handle the case when empty reply.user causes exceptions

We will be deploying this to production soon. Please try navigating pages and submit replies in https://cofacts.hacktabl.org/ to see if there are any unhandled exceptions, thanks!