### PR TITLE
Message list reported by author with article id

### DIFF
--- a/components/Pagination.js
+++ b/components/Pagination.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from 'next/link';
+import { t } from 'ttag';
 
 export default function Pagination({
   query = {}, // URL params
@@ -8,7 +9,7 @@ export default function Pagination({
 }) {
   const { firstCursor, lastCursor } = pageInfo;
   if (!firstCursor || !lastCursor) {
-    return <p>Loading...</p>;
+    return null;
   }
 
   const firstCursorOfPage = edges.length && edges[0] && edges[0].cursor;
@@ -23,7 +24,7 @@ export default function Pagination({
             query: { ...query, before: firstCursorOfPage, after: undefined },
           }}
         >
-          <a>Prev</a>
+          <a>{t`Prev`}</a>
         </Link>
       ) : (
         ''
@@ -34,7 +35,7 @@ export default function Pagination({
             query: { ...query, after: lastCursorOfPage, before: undefined },
           }}
         >
-          <a>Next</a>
+          <a>{t`Next`}</a>
         </Link>
       ) : (
         ''

--- a/lib/text.js
+++ b/lib/text.js
@@ -126,11 +126,29 @@ export function nl2br(elem) {
 }
 
 /**
+ *
+ * @param {string} text
+ * @param {number} option.wordCount
+ * @param {string} option.morePostfix
+ */
+export function ellipsis(
+  text,
+  { wordCount = Infinity, morePostfix = '⋯⋯' } = {}
+) {
+  if (text.length <= wordCount) {
+    return text;
+  }
+
+  return `${text.slice(0, wordCount)}${morePostfix}`;
+}
+
+/**
  * Truncates the given elem to the specified wordCount.
  * When truncated, appends moreElem to the end of the string.
  *
  * @param {*} elem React element, string, array of string & react elements
  * @param {<wordCount: Number, moreElem: ReactElement>} options
+ * @returns {JSXElement}
  */
 export function truncate(elem, { wordCount = Infinity, moreElem = null } = {}) {
   let currentWordCount = 0;

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -7,7 +7,7 @@ import Head from 'next/head';
 
 import withData from 'lib/apollo';
 import useCurrentUser from 'lib/useCurrentUser';
-import { nl2br, linkify } from 'lib/text';
+import { nl2br, linkify, ellipsis } from 'lib/text';
 import { usePushToDataLayer } from 'lib/gtm';
 
 import AppLayout from 'components/AppLayout';
@@ -129,13 +129,11 @@ function ArticlePage() {
     );
   }
 
-  const slicedArticleTitle = article.text.slice(0, 100);
-
   return (
     <AppLayout>
       <Head>
         <title>
-          {slicedArticleTitle}⋯⋯ | {t`Cofacts`}
+          {ellipsis(article.text, { wordCount: 100 })} | {t`Cofacts`}
         </title>
       </Head>
       <section className="section">

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag';
-import { t, ngettext, msgid } from 'ttag';
+import { t, ngettext, msgid, jt } from 'ttag';
 import Router, { useRouter } from 'next/router';
 import Head from 'next/head';
 import url from 'url';
@@ -17,6 +17,7 @@ import Checkbox from '@material-ui/core/Checkbox';
 import Typography from '@material-ui/core/Typography';
 
 import withData from 'lib/apollo';
+import { ellipsis } from 'lib/text';
 import AppLayout from 'components/AppLayout';
 import ArticleItem from 'components/ArticleItem';
 import Pagination from 'components/Pagination';
@@ -193,12 +194,25 @@ function ArticleListPage() {
   });
 
   const showOneTimeMessages = +query.replyRequestCount === 1;
+  const searchedArticleEdge = (articleData?.edges || []).find(
+    ({ node: { id } }) => id === query.searchUserByArticleId
+  );
+  const searchedUserArticleElem = (
+    <mark>
+      {ellipsis(searchedArticleEdge?.node?.text || '', { wordCount: 15 })}
+    </mark>
+  );
 
   return (
     <AppLayout>
       <Head>
         <title>{t`Article list`}</title>
       </Head>
+
+      {query.searchUserByArticleId && (
+        <h1>{jt`Messages reported by user that reported “${searchedUserArticleElem}”`}</h1>
+      )}
+
       <Grid container spacing={2}>
         <Grid item>
           <ArticleFilter

--- a/pages/reply/[id].js
+++ b/pages/reply/[id].js
@@ -14,7 +14,7 @@ import AppLayout from 'components/AppLayout';
 import Hyperlinks from 'components/Hyperlinks';
 import ArticleReply from 'components/ArticleReply';
 
-import { nl2br, linkify } from 'lib/text';
+import { nl2br, linkify, ellipsis } from 'lib/text';
 
 const LOAD_REPLY = gql`
   query LoadReplyPage($id: String!) {
@@ -138,7 +138,6 @@ function ReplyPage() {
     );
   }
 
-  const slicedReplyTitle = reply.text.slice(0, 100);
   const originalArticleReply = reply.articleReplies.reduce(
     (earliest, articleReply) =>
       articleReply.createdAt < earliest.createdAt ? articleReply : earliest,
@@ -151,7 +150,7 @@ function ReplyPage() {
     <AppLayout>
       <Head>
         <title>
-          {slicedReplyTitle}⋯⋯ | {t`Cofacts`}
+          {ellipsis(reply.text, { wordCount: 100 })} | {t`Cofacts`}
         </title>
       </Head>
       <section className="section">


### PR DESCRIPTION
Add title to list of reported messages reported by same author. This previously existed but was omitted in #164.

Refactor:
- Besides `truncate(elem, option)`, we implement additional, text-only `ellipsis(text, option)` for pure-text cases like HTML titles.
- Remove excessive "loading" from `<Pagination>` when no result is available

<img width="706" alt="螢幕快照 2019-12-08 下午9 02 24" src="https://user-images.githubusercontent.com/108608/70389721-100e9480-19fe-11ea-86b5-599d4e4d93f1.png">

