### PR TITLE
Add /analytics & /hack redirect page

### DIFF
--- a/pages/analytics.js
+++ b/pages/analytics.js
@@ -1,0 +1,15 @@
+function AnalyticsPage() {
+  return null;
+}
+
+AnalyticsPage.getInitialProps = function({ res }) {
+  // Redirect to analytics
+  res.writeHead(303, {
+    Location:
+      'https://datastudio.google.com/open/18J8jZYumsoaCPBk9bdRd97GKvi_W5v-r',
+  });
+  res.end('Redirecting...');
+  return {};
+};
+
+export default AnalyticsPage;

--- a/pages/hack.js
+++ b/pages/hack.js
@@ -1,0 +1,14 @@
+function HackfoldrPage() {
+  return null;
+}
+
+HackfoldrPage.getInitialProps = function({ res }) {
+  // Redirect to hackfoldr
+  res.writeHead(303, {
+    Location: 'https://beta.hackfoldr.org/cofacts',
+  });
+  res.end('Redirecting...');
+  return {};
+};
+
+export default HackfoldrPage;


### PR DESCRIPTION
[Previously](https://github.com/cofacts/rumors-site/blob/pocky-day-gathering/server.js), visiting `cofacts.g0v.tw/analytics` redirects to google data studio and `cofacts.g0v.tw/hack` redirects to our hackfoldr.

This PR reimplements such redirection mechanism, in [next.js v9](https://nextjs.org/docs#fetching-data-and-component-lifecycle) way.

![analytics-redirect](https://user-images.githubusercontent.com/108608/70409570-24e33a80-1a87-11ea-9fe9-0089e61c22bf.gif)
