### PR TITLE
RSS for article lists

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -17,6 +17,9 @@ SERVER_ROLLBAR_TOKEN=
 SERVER_STACKIMPACT_AGENT_KEY=
 SERVER_STACKIMPACT_APP_NAME=
 
+# This website's public URL
+PUBLIC_URL=https://cofacts.hacktabl.org
+
 # rumors-api's URL
 PUBLIC_API_URL=https://cofacts-api.hacktabl.org
 

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 coverage
 .vscode
 .env
+.DS_Store

--- a/components/FeedDisplay.js
+++ b/components/FeedDisplay.js
@@ -1,0 +1,73 @@
+import { useState } from 'react';
+import { t, jt } from 'ttag';
+import Button from '@material-ui/core/Button';
+import Popover from '@material-ui/core/Popover';
+import RssFeedIcon from '@material-ui/icons/RssFeed';
+import TextField from '@material-ui/core/TextField';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles(theme => ({
+  leftIcon: { marginRight: theme.spacing(1) },
+  paper: { padding: theme.spacing(2) },
+}));
+
+function FeedDisplay({ feedUrl }) {
+  const classes = useStyles();
+  const [anchorEl, setAnchorEl] = useState(null);
+
+  const handleClick = event => {
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      <Button onClick={handleClick}>
+        <RssFeedIcon className={classes.leftIcon} />
+        {t`Subscribe to this list`}
+      </Button>
+      <Popover
+        anchorEl={anchorEl}
+        open={!!anchorEl}
+        onClose={handleClose}
+        classes={{
+          paper: classes.paper,
+        }}
+        anchorOrigin={{
+          vertical: 'bottom',
+          horizontal: 'center',
+        }}
+        transformOrigin={{
+          vertical: 'top',
+          horizontal: 'center',
+        }}
+      >
+        {jt`You can follow this list using any RSS reader.`}
+        <TextField
+          label={t`RSS Feed URL`}
+          defaultValue={feedUrl}
+          margin="normal"
+          variant="outlined"
+          InputProps={{ readOnly: true }}
+          onFocus={e => e.target.select()}
+          fullWidth
+        />
+        {t`Add to`}{' '}
+        <a
+          href={`https://feedly.com/i/discover/sources/search/feed/${encodeURIComponent(
+            feedUrl
+          )}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {t`Feedly`}
+        </a>
+      </Popover>
+    </>
+  );
+}
+
+export default FeedDisplay;

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -22,7 +22,7 @@ function customIdMapper(object) {
   }
 }
 
-const config = {
+export const config = {
   link: new BatchHttpLink({
     uri: `${PUBLIC_API_URL}/graphql`, // Server URL (must be absolute)
     headers,

--- a/package-lock.json
+++ b/package-lock.json
@@ -4783,6 +4783,14 @@
         "bser": "^2.0.0"
       }
     },
+    "feed": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/feed/-/feed-4.1.0.tgz",
+      "integrity": "sha512-dAXWXM8QMxZ1DRnAxDmy1MaWZFlh1Ku7TU3onbXgHrVJynsxkNGPUed1AxszVW8AXo43xExronVkIqK+ACsoBA==",
+      "requires": {
+        "xml-js": "^1.6.11"
+      }
+    },
     "figgy-pudding": {
       "version": "3.5.1",
       "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.1.tgz",
@@ -10421,8 +10429,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-      "dev": true
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
     },
     "scheduler": {
       "version": "0.13.6",
@@ -12349,6 +12356,14 @@
       "dev": true,
       "requires": {
         "async-limiter": "~1.0.0"
+      }
+    },
+    "xml-js": {
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/xml-js/-/xml-js-1.6.11.tgz",
+      "integrity": "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g==",
+      "requires": {
+        "sax": "^1.2.4"
       }
     },
     "xml-name-validator": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "clsx": "^1.0.4",
     "date-fns": "^2.0.1",
     "dotenv": "^8.0.0",
+    "feed": "^4.1.0",
     "graphql": "^14.4.2",
     "immer": "^5.0.0",
     "isomorphic-unfetch": "^3.0.0",

--- a/pages/api/articles/[feed].js
+++ b/pages/api/articles/[feed].js
@@ -8,10 +8,18 @@ async function articleFeedHandler(req, res) {
     query: { feed, args },
   } = req;
 
-  const variables = JSON.parse(args || '{}');
-
   if (!AVAILABLE_FEEDS.includes(feed)) {
     res.status(400).send('Invalid feed type');
+    return;
+  }
+
+  let variables;
+  try {
+    variables = JSON.parse(args || '{}');
+    if (typeof variables !== 'object')
+      throw Error('args should be an JSON object');
+  } catch (e) {
+    res.status(400).send(`Error parsing args: ${e}`);
     return;
   }
 

--- a/pages/api/articles/[feed].js
+++ b/pages/api/articles/[feed].js
@@ -5,8 +5,10 @@ const AVAILABLE_FEEDS = ['rss2', 'atom1', 'json1'];
 
 async function articleFeedHandler(req, res) {
   const {
-    query: { feed },
+    query: { feed, args },
   } = req;
+
+  const variables = JSON.parse(args || '{}');
 
   if (!AVAILABLE_FEEDS.includes(feed)) {
     res.status(400).send('Invalid feed type');
@@ -18,6 +20,7 @@ async function articleFeedHandler(req, res) {
 
   const { data, errors } = await client.query({
     query: LIST_ARTICLES,
+    variables,
   });
   if (errors && errors.length) {
     res.status(400).json(errors);

--- a/pages/api/articles/[feed].js
+++ b/pages/api/articles/[feed].js
@@ -3,12 +3,16 @@ import querystring from 'querystring';
 import { t } from 'ttag';
 import { Feed } from 'feed';
 import { ApolloClient } from 'apollo-boost';
+import getConfig from 'next/config';
 import { ellipsis } from 'lib/text';
 import { config } from 'lib/apollo';
 import { getQueryVars } from 'pages/articles';
 
 const TITLE_LENGTH = 40;
 const AVAILABLE_FEEDS = ['rss2', 'atom1', 'json1'];
+const {
+  publicRuntimeConfig: { PUBLIC_URL },
+} = getConfig();
 
 // Arguments must match the ones in pages/articles.js
 const LIST_ARTICLES = gql`
@@ -79,12 +83,12 @@ async function articleFeedHandler(req, res) {
   const queryString = querystring.stringify(query, '&amp;'); // Use &amp; for XML meta tags
   const feedOption = {
     title: (query.q ? `${query.q} | ` : '') + t`Cofacts reported messages`,
-    link: `https://cofacts.g0v.tw/articles?${queryString}`,
+    link: `${PUBLIC_URL}/articles?${queryString}`,
     description: t`List of messages reported by Cofacts users`,
     feedLinks: {
-      json: `https://cofacts.g0v.tw/api/articles/json1?${queryString}`,
-      rss: `https://cofacts.g0v.tw/api/articles/rss2?${queryString}`,
-      atom: `https://cofacts.g0v.tw/api/articles/atom1?${queryString}`,
+      json: `${PUBLIC_URL}/api/articles/json1?${queryString}`,
+      rss: `${PUBLIC_URL}/api/articles/rss2?${queryString}`,
+      atom: `${PUBLIC_URL}/api/articles/atom1?${queryString}`,
     },
   };
 
@@ -96,7 +100,7 @@ async function articleFeedHandler(req, res) {
       id: node.id,
       title: ellipsis(text, { wordCount: TITLE_LENGTH }),
       description: ellipsis(text, { wordCount: 200 }),
-      link: `https://cofacts.g0v.tw/article/${node.id}`,
+      link: `${PUBLIC_URL}/article/${node.id}`,
       date: new Date(node.createdAt),
     });
   });

--- a/pages/api/articles/[feed].js
+++ b/pages/api/articles/[feed].js
@@ -1,6 +1,7 @@
 import { LIST_ARTICLES } from 'pages/articles';
 import { ApolloClient } from 'apollo-boost';
 import { config } from 'lib/apollo';
+import { Feed } from 'feed';
 const AVAILABLE_FEEDS = ['rss2', 'atom1', 'json1'];
 
 async function articleFeedHandler(req, res) {
@@ -34,7 +35,22 @@ async function articleFeedHandler(req, res) {
     res.status(400).json(errors);
   }
 
-  res.status(200).json(data);
+  const feedInstance = new Feed({
+    title: 'test feed',
+  });
+
+  data.ListArticles.edges.forEach(({ node }) => {
+    feedInstance.addItem({
+      content: node.text,
+      date: new Date(node.createdAt),
+    });
+  });
+
+  try {
+    res.send(feedInstance[feed]());
+  } catch (e) {
+    res.status(500).send(e);
+  }
 }
 
 export default articleFeedHandler;

--- a/pages/api/articles/[feed].js
+++ b/pages/api/articles/[feed].js
@@ -96,11 +96,12 @@ async function articleFeedHandler(req, res) {
 
   data.ListArticles.edges.forEach(({ node }) => {
     const text = getArticleText(node);
+    const url = `${PUBLIC_URL}/article/${node.id}`;
     feedInstance.addItem({
-      id: node.id,
+      id: url,
       title: ellipsis(text, { wordCount: TITLE_LENGTH }),
       description: ellipsis(text, { wordCount: 200 }),
-      link: `${PUBLIC_URL}/article/${node.id}`,
+      link: url,
       date: new Date(node.createdAt),
     });
   });

--- a/pages/api/articles/[feed].js
+++ b/pages/api/articles/[feed].js
@@ -1,0 +1,29 @@
+import { LIST_ARTICLES } from 'pages/articles';
+import { ApolloClient } from 'apollo-boost';
+import { config } from 'lib/apollo';
+const AVAILABLE_FEEDS = ['rss2', 'atom1', 'json1'];
+
+async function articleFeedHandler(req, res) {
+  const {
+    query: { feed },
+  } = req;
+
+  if (!AVAILABLE_FEEDS.includes(feed)) {
+    res.status(400).send('Invalid feed type');
+    return;
+  }
+
+  const { createCache, ...otherConfigs } = config;
+  const client = new ApolloClient({ ...otherConfigs, cache: createCache() });
+
+  const { data, errors } = await client.query({
+    query: LIST_ARTICLES,
+  });
+  if (errors && errors.length) {
+    res.status(400).json(errors);
+  }
+
+  res.status(200).json(data);
+}
+
+export default articleFeedHandler;

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import querystring from 'querystring';
 import { t, ngettext, msgid, jt } from 'ttag';
 import Router, { useRouter } from 'next/router';
 import Head from 'next/head';
@@ -168,13 +169,22 @@ function SortInput({ orderBy = DEFAULT_ORDER_BY, onChange = () => {} }) {
   );
 }
 
-function ArticleListPage() {
-  const { query } = useRouter();
-
-  const listQueryVars = {
+/**
+ *
+ * @param {object} query
+ * @returns {object}
+ */
+export function getQueryVars(query) {
+  return {
     filter: urlQuery2Filter(query),
     orderBy: urlQuery2OrderBy(query),
   };
+}
+
+function ArticleListPage() {
+  const { query } = useRouter();
+
+  const listQueryVars = getQueryVars(query);
 
   const {
     loading,
@@ -207,8 +217,7 @@ function ArticleListPage() {
     </mark>
   );
 
-  const feedArgs = JSON.stringify(listQueryVars);
-
+  const queryString = querystring.stringify(query);
   return (
     <AppLayout>
       <Head>
@@ -216,12 +225,12 @@ function ArticleListPage() {
         <link
           rel="alternate"
           type="application/rss+xml"
-          href={`https://cofacts.g0v.tw/api/articles/rss2?args=${feedArgs}`}
+          href={`https://cofacts.g0v.tw/api/articles/rss2?${queryString}`}
         />
         <link
           rel="alternate"
           type="application/atom+xml"
-          href={`https://cofacts.g0v.tw/api/articles/atom1?args=${feedArgs}`}
+          href={`https://cofacts.g0v.tw/api/articles/atom1?${queryString}`}
         />
       </Head>
 

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -3,6 +3,7 @@ import querystring from 'querystring';
 import { t, ngettext, msgid, jt } from 'ttag';
 import Router, { useRouter } from 'next/router';
 import Head from 'next/head';
+import getConfig from 'next/config';
 import url from 'url';
 import { useQuery } from '@apollo/react-hooks';
 
@@ -28,6 +29,10 @@ const DEFAULT_ORDER_BY = 'lastRequestedAt';
 const DEFAULT_TYPE_FILTER = 'unsolved';
 const DEFAULT_REPLY_REQUEST_COUNT = 2;
 const MAX_KEYWORD_LENGTH = 100;
+
+const {
+  publicRuntimeConfig: { PUBLIC_URL },
+} = getConfig();
 
 const LIST_ARTICLES = gql`
   query ListArticles(
@@ -225,12 +230,12 @@ function ArticleListPage() {
         <link
           rel="alternate"
           type="application/rss+xml"
-          href={`https://cofacts.g0v.tw/api/articles/rss2?${queryString}`}
+          href={`${PUBLIC_URL}/api/articles/rss2?${queryString}`}
         />
         <link
           rel="alternate"
           type="application/atom+xml"
-          href={`https://cofacts.g0v.tw/api/articles/atom1?${queryString}`}
+          href={`${PUBLIC_URL}/api/articles/atom1?${queryString}`}
         />
       </Head>
 

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -27,7 +27,7 @@ const DEFAULT_ORDER_BY = 'lastRequestedAt';
 const DEFAULT_TYPE_FILTER = 'unsolved';
 const DEFAULT_REPLY_REQUEST_COUNT = 2;
 
-export const LIST_ARTICLES = gql`
+const LIST_ARTICLES = gql`
   query ListArticles(
     $filter: ListArticleFilter
     $orderBy: [ListArticleOrderBy]

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -24,6 +24,7 @@ import AppLayout from 'components/AppLayout';
 import ArticleItem from 'components/ArticleItem';
 import Pagination from 'components/Pagination';
 import SearchInput from 'components/SearchInput';
+import FeedDisplay from 'components/FeedDisplay';
 
 const DEFAULT_ORDER_BY = 'lastRequestedAt';
 const DEFAULT_TYPE_FILTER = 'unsolved';
@@ -252,10 +253,15 @@ function ArticleListPage() {
             }
           />
         </Grid>
-        <Grid item>
+        <Grid item style={{ marginRight: 'auto' }}>
           <SearchInput
             q={query.q}
             onChange={q => goToUrlQueryAndResetPagination({ ...query, q })}
+          />
+        </Grid>
+        <Grid item>
+          <FeedDisplay
+            feedUrl={`${PUBLIC_URL}/api/articles/rss2?${queryString}`}
           />
         </Grid>
       </Grid>

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -27,7 +27,7 @@ const DEFAULT_ORDER_BY = 'lastRequestedAt';
 const DEFAULT_TYPE_FILTER = 'unsolved';
 const DEFAULT_REPLY_REQUEST_COUNT = 2;
 
-const LIST_ARTICLES = gql`
+export const LIST_ARTICLES = gql`
   query ListArticles(
     $filter: ListArticleFilter
     $orderBy: [ListArticleOrderBy]

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -26,6 +26,7 @@ import SearchInput from 'components/SearchInput';
 const DEFAULT_ORDER_BY = 'lastRequestedAt';
 const DEFAULT_TYPE_FILTER = 'unsolved';
 const DEFAULT_REPLY_REQUEST_COUNT = 2;
+const MAX_KEYWORD_LENGTH = 100;
 
 const LIST_ARTICLES = gql`
   query ListArticles(
@@ -79,7 +80,10 @@ function urlQuery2Filter({
 } = {}) {
   const filterObj = {};
   if (q) {
-    filterObj.moreLikeThis = { like: q, minimumShouldMatch: '0' };
+    filterObj.moreLikeThis = {
+      like: q.slice(0, MAX_KEYWORD_LENGTH),
+      minimumShouldMatch: '0',
+    };
   }
 
   filterObj.replyRequestCount = { GT: replyRequestCount - 1 };
@@ -203,10 +207,22 @@ function ArticleListPage() {
     </mark>
   );
 
+  const feedArgs = JSON.stringify(listQueryVars);
+
   return (
     <AppLayout>
       <Head>
         <title>{t`Article list`}</title>
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          href={`https://cofacts.g0v.tw/api/articles/rss2?args=${feedArgs}`}
+        />
+        <link
+          rel="alternate"
+          type="application/atom+xml"
+          href={`https://cofacts.g0v.tw/api/articles/atom1?args=${feedArgs}`}
+        />
       </Head>
 
       {query.searchUserByArticleId && (

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,10 +1,16 @@
 import { Fragment, useState } from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
+import getConfig from 'next/config';
 import cx from 'clsx';
 import { t } from 'ttag';
 import { NEWS, Jumbotron, Stats } from 'components/LandingPage';
 import qrCodeURL from './../components/LandingPage/images/qr-code.png';
+import ogImage from 'components/LandingPage/images/ogimage.png';
+
+const {
+  publicRuntimeConfig: { PUBLIC_URL },
+} = getConfig();
 
 function Home() {
   const [navCollapsed, setNavCollapsed] = useState(true);
@@ -25,11 +31,8 @@ function Home() {
         <meta property="og:description" content={description} />
         <meta property="og:locale" content={process.env.LOCALE} />
         <meta property="og:type" content="article" />
-        <meta property="og:url" content="https://cofacts.g0v.tw" />
-        <meta
-          property="og:image"
-          content={`https://cofacts.g0v.tw${require('components/LandingPage/images/ogimage.png')}`}
-        />
+        <meta property="og:url" content={PUBLIC_URL} />
+        <meta property="og:image" content={`${PUBLIC_URL}${ogImage}`} />
         <meta property="og:image:type" content="image/png" />
         <meta property="og:image:width" content="1920" />
         <meta property="og:image:height" content="1271" />


### PR DESCRIPTION
This PR implements part of #170 

- Adds RSS endpoint: `/api/articles/rss2`, `/api/articles/atom1`, `/api/articles/json1`
- Each endpoint supports same URL query as article page. For instance, `/api/articles/rss2?q=&replyRequestCount=1&filter=solved` will present "solved" messages with 1 or more reply requests.
- Add "Subscribe to list" button to article list.
- Adds feed syndication to `<head>`

### Refactor
- Adds `PUBLIC_URL` to replace all hard-coded `https://cofacts.g0v.tw`, allowing different URL for each site
- Applies `MAX_KEYWORD_LENGTH` (100) to keywords, so that URL's won't be too long when searching for long messages.

### Screenshot
![image](https://user-images.githubusercontent.com/108608/71763436-dbb3c880-2f16-11ea-8252-204d94457c6b.png)


### Demo
- Staging site: https://cofacts.hacktabl.org/articles
- Live RSS URL: https://cofacts.hacktabl.org/api/articles/rss2?q=&replyRequestCount=1&filter=solved
