### PR TITLE
[Hyperlinks] support polling hyperlinks when hyperlinks are loading

### DIFF
--- a/components/ArticleReply.js
+++ b/components/ArticleReply.js
@@ -211,7 +211,11 @@ class ArticleReply extends React.PureComponent {
           ? nl2br(linkify(reference))
           : `⚠️️ ${t`There is no reference for this reply. Its truthfulness may be doubtful.`}`}
 
-        <Hyperlinks hyperlinks={articleReply.reply.hyperlinks} />
+        <Hyperlinks
+          hyperlinks={articleReply.reply.hyperlinks}
+          pollingType="replies"
+          pollingId={articleReply.replyId}
+        />
         <style jsx>{sectionStyle}</style>
       </section>
     );

--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -151,6 +151,12 @@ function Hyperlink({ hyperlink }) {
 }
 
 function PollingHyperlink({ pollingType, pollingId }) {
+  // The loaded data will populate apollo-client's normalized Article/Reply cache via apollo-client
+  // automatic cache updates.
+  // Ref: https://www.apollographql.com/docs/react/caching/cache-configuration/#automatic-cache-updates
+  //
+  // Therefore, we don't need to read query results here.
+  //
   useQuery(POLLING_QUERY[pollingType], {
     variables: { id: pollingId },
     pollInterval: 2000,

--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -1,7 +1,43 @@
 import gql from 'graphql-tag';
+import CircularProgress from '@material-ui/core/CircularProgress';
+import { useQuery } from '@apollo/react-hooks';
+
+const HyperlinkData = gql`
+  fragment HyperlinkData on Hyperlink {
+    title
+    url
+    summary
+    topImageUrl
+    error
+  }
+`;
+
+const POLLING_QUERY = {
+  articles: gql`
+    query PollingArticleHyperlink($id: String!) {
+      GetArticle(id: $id) {
+        id
+        hyperlinks {
+          ...HyperlinkData
+        }
+      }
+    }
+    ${HyperlinkData}
+  `,
+  replies: gql`
+    query PollingReplyHyperlink($id: String!) {
+      GetReply(id: $id) {
+        id
+        hyperlinks {
+          ...HyperlinkData
+        }
+      }
+    }
+    ${HyperlinkData}
+  `,
+};
 
 /**
- *
  * @param {string} error - One of ResolveError https://github.com/cofacts/url-resolver/blob/master/src/typeDefs/ResolveError.graphql
  */
 function getErrorText(error) {
@@ -114,17 +150,35 @@ function Hyperlink({ hyperlink }) {
   );
 }
 
+function PollingHyperlink({ pollingType, pollingId }) {
+  useQuery(POLLING_QUERY[pollingType], {
+    variables: { id: pollingId },
+    pollInterval: 2000,
+  });
+
+  return <CircularProgress />;
+}
+
 /**
- * @param {object[]} props.hyperlinks
+ * @param {object[] | null} props.hyperlinks
+ * @param {'articles'|'replies'?} props.pollingType - poll article or reply for hyperlinks when it's not loaded (null)
+ * @param {string?} props.pollingId - polling article or reply id for hyperlinks when it's not loaded (null)
  */
-function Hyperlinks({ hyperlinks = [] }) {
-  if (!hyperlinks || hyperlinks.length === 0) return null;
+function Hyperlinks({ hyperlinks, pollingType, pollingId }) {
+  if (!((pollingId && pollingType) || (!pollingId && !pollingType))) {
+    throw new Error('pollingType and pollingId must be specified together');
+  }
+
+  if (hyperlinks && hyperlinks.length === 0) return null;
 
   return (
     <section className="links">
-      {hyperlinks.map((hyperlink, idx) => (
+      {(hyperlinks || []).map((hyperlink, idx) => (
         <Hyperlink key={idx} hyperlink={hyperlink} />
       ))}
+      {!hyperlinks && pollingId && (
+        <PollingHyperlink pollingId={pollingId} pollingType={pollingType} />
+      )}
       <style jsx>{`
         .links {
           display: flex;
@@ -138,15 +192,7 @@ function Hyperlinks({ hyperlinks = [] }) {
 }
 
 Hyperlinks.fragments = {
-  HyperlinkData: gql`
-    fragment HyperlinkData on Hyperlink {
-      title
-      url
-      summary
-      topImageUrl
-      error
-    }
-  `,
+  HyperlinkData,
 };
 
 export default Hyperlinks;


### PR DESCRIPTION
This PR implements "CreateReply 不要等 url resolving，有時候還會出錯" function mentioned in [202200212 meeting](https://g0v.hackmd.io/AwNFa7L1QKiBPziTtYva0A#CreateReply-%E4%B8%8D%E8%A6%81%E7%AD%89-url-resolving%EF%BC%8C%E6%9C%89%E6%99%82%E5%80%99%E9%82%84%E6%9C%83%E5%87%BA%E9%8C%AF). It significantly reduces the time editors need to wait after submitting replies:
![polling](https://user-images.githubusercontent.com/108608/74608491-77427680-511c-11ea-99c2-74b659a0fae5.gif)

The editors can freely navigate away even when the spinner loading hyperlinks is still spinning. The hyperlinks will still be properly loaded on API server.

It is achieved by [changing API](https://github.com/cofacts/rumors-api/pull/147) so that it don't wait for hyperlink resolution, and perform polling if hyperlink is not loaded.

### Request flow
![image](https://user-images.githubusercontent.com/108608/74608447-131fb280-511c-11ea-9283-c63c89733af8.png)
The requests in the chart:
1. `CreateReply` API, which creates reply & articleReply in article
2. `GetArticle` request that re-reads the list of `articleReplies`
3. the following: Polling hyperlink using `GetReply`; query include reply `id` so that it populates the normalized cache for the reply instance