### PR TITLE
Article list category selector

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -19,5 +19,6 @@ module.exports = {
       'ttag', {resolve: {translations: `i18n/${process.env.LOCALE}.po`}}
     ],
     "@babel/plugin-proposal-optional-chaining",
+    "@babel/plugin-proposal-nullish-coalescing-operator",
   ]
 }

--- a/components/ArticleListPage/ArticleStatusFilter.js
+++ b/components/ArticleListPage/ArticleStatusFilter.js
@@ -1,0 +1,30 @@
+import { t } from 'ttag';
+
+import ButtonGroup from '@material-ui/core/ButtonGroup';
+import Button from '@material-ui/core/Button';
+
+export const DEFAULT_STATUS_FILTER = 'unsolved';
+
+function ArticleStatusFilter({
+  filter = DEFAULT_STATUS_FILTER,
+  onChange = () => {},
+}) {
+  return (
+    <ButtonGroup size="small" variant="outlined">
+      <Button
+        disabled={filter === 'unsolved'}
+        onClick={() => onChange('unsolved')}
+      >
+        {t`Not replied`}
+      </Button>
+      <Button disabled={filter === 'solved'} onClick={() => onChange('solved')}>
+        {t`Replied`}
+      </Button>
+      <Button disabled={filter === 'all'} onClick={() => onChange('all')}>
+        {t`All`}
+      </Button>
+    </ButtonGroup>
+  );
+}
+
+export default ArticleStatusFilter;

--- a/components/ArticleListPage/CategoryFilter.js
+++ b/components/ArticleListPage/CategoryFilter.js
@@ -1,0 +1,45 @@
+import { t } from 'ttag';
+
+import TextField from '@material-ui/core/TextField';
+import MenuItem from '@material-ui/core/MenuItem';
+import Checkbox from '@material-ui/core/Checkbox';
+import ListItemText from '@material-ui/core/ListItemText';
+
+export const DEFAULT_CATEGORY_IDS = [];
+
+/**
+ * @param {string[]} props.categoryIds - selected category id
+ * @param {Category[]} props.categories - category options
+ * @param {(categoryIds: string[]) => void} props.onChange
+ */
+function CategoryFilter({
+  categoryIds = DEFAULT_CATEGORY_IDS,
+  categories = [],
+  onChange = () => {},
+}) {
+  return (
+    <TextField
+      label={t`Category`}
+      select
+      SelectProps={{
+        multiple: true,
+        renderValue: selectedIds =>
+          selectedIds
+            .map(id => categories.find(category => category.id === id)?.title)
+            .filter(c => c)
+            .join(', '),
+      }}
+      value={categoryIds}
+      onChange={e => onChange(e.target.value)}
+    >
+      {categories.map(({ id, title }) => (
+        <MenuItem key={id} value={id}>
+          <Checkbox checked={categoryIds.includes(id)} />
+          <ListItemText>{title}</ListItemText>
+        </MenuItem>
+      ))}
+    </TextField>
+  );
+}
+
+export default CategoryFilter;

--- a/components/ArticleListPage/CategoryFilter.js
+++ b/components/ArticleListPage/CategoryFilter.js
@@ -22,6 +22,7 @@ function CategoryFilter({
       label={t`Category`}
       select
       SelectProps={{
+        style: { minWidth: 100 },
         multiple: true,
         renderValue: selectedIds =>
           selectedIds

--- a/components/ArticleListPage/SortInput.js
+++ b/components/ArticleListPage/SortInput.js
@@ -1,0 +1,32 @@
+import { t } from 'ttag';
+
+import TextField from '@material-ui/core/TextField';
+import MenuItem from '@material-ui/core/MenuItem';
+import InputAdornment from '@material-ui/core/InputAdornment';
+import SortIcon from '@material-ui/icons/Sort';
+
+export const DEFAULT_ORDER_BY = 'lastRequestedAt';
+
+function SortInput({ orderBy = DEFAULT_ORDER_BY, onChange = () => {} }) {
+  return (
+    <TextField
+      label={t`Sort by`}
+      select
+      InputProps={{
+        startAdornment: (
+          <InputAdornment position="start">
+            <SortIcon />
+          </InputAdornment>
+        ),
+      }}
+      value={orderBy}
+      onChange={e => onChange(e.target.value)}
+    >
+      <MenuItem value="lastRequestedAt">{t`Most recently asked`}</MenuItem>
+      <MenuItem value="lastRepliedAt">{t`Most recently replied`}</MenuItem>
+      <MenuItem value="replyRequestCount">{t`Most asked`}</MenuItem>
+    </TextField>
+  );
+}
+
+export default SortInput;

--- a/components/ArticleListPage/index.js
+++ b/components/ArticleListPage/index.js
@@ -1,0 +1,14 @@
+import ArticleStatusFilter, {
+  DEFAULT_STATUS_FILTER,
+} from './ArticleStatusFilter';
+import CategoryFilter, { DEFAULT_CATEGORY_IDS } from './CategoryFilter';
+import SortInput, { DEFAULT_ORDER_BY } from './SortInput';
+
+export {
+  ArticleStatusFilter,
+  CategoryFilter,
+  SortInput,
+  DEFAULT_STATUS_FILTER,
+  DEFAULT_CATEGORY_IDS,
+  DEFAULT_ORDER_BY,
+};

--- a/lib/__tests__/url.js
+++ b/lib/__tests__/url.js
@@ -1,0 +1,33 @@
+import Router from "next/router";
+import querystring from "querystring";
+import { goToUrlQueryAndResetPagination, getArrayFromQueryParam } from "../url";
+
+jest.mock("next/router");
+
+it("goToUrlQueryAndResetPagination converts object to query string", () => {
+  // Setup
+  Router.push.mockClear();
+  goToUrlQueryAndResetPagination({});
+  goToUrlQueryAndResetPagination({
+    foo: "string",
+    bar: [1, 2, 3],
+    before: "cursor1",
+    after: "cursor2"
+  });
+
+  expect(Router.push.mock.calls[0][0]).toMatchInlineSnapshot(`"/"`);
+  expect(Router.push.mock.calls[1][0]).toMatchInlineSnapshot(
+    `"/?foo=string&bar=1&bar=2&bar=3"`
+  );
+
+  // Teardown
+  Router.push.mockClear();
+});
+
+it("getArrayFromQueryParam ensures querystring arrays are arrays", () => {
+  expect(getArrayFromQueryParam(querystring.parse("ids=1").ids)).toEqual(["1"]);
+  expect(getArrayFromQueryParam(querystring.parse("ids=1&ids=2").ids)).toEqual([
+    "1",
+    "2"
+  ]);
+});

--- a/lib/__tests__/url.js
+++ b/lib/__tests__/url.js
@@ -1,18 +1,18 @@
-import Router from "next/router";
-import querystring from "querystring";
-import { goToUrlQueryAndResetPagination, getArrayFromQueryParam } from "../url";
+import Router from 'next/router';
+import querystring from 'querystring';
+import { goToUrlQueryAndResetPagination, getArrayFromQueryParam } from '../url';
 
-jest.mock("next/router");
+jest.mock('next/router');
 
-it("goToUrlQueryAndResetPagination converts object to query string", () => {
+it('goToUrlQueryAndResetPagination converts object to query string', () => {
   // Setup
   Router.push.mockClear();
   goToUrlQueryAndResetPagination({});
   goToUrlQueryAndResetPagination({
-    foo: "string",
+    foo: 'string',
     bar: [1, 2, 3],
-    before: "cursor1",
-    after: "cursor2"
+    before: 'cursor1',
+    after: 'cursor2',
   });
 
   expect(Router.push.mock.calls[0][0]).toMatchInlineSnapshot(`"/"`);
@@ -24,10 +24,10 @@ it("goToUrlQueryAndResetPagination converts object to query string", () => {
   Router.push.mockClear();
 });
 
-it("getArrayFromQueryParam ensures querystring arrays are arrays", () => {
-  expect(getArrayFromQueryParam(querystring.parse("ids=1").ids)).toEqual(["1"]);
-  expect(getArrayFromQueryParam(querystring.parse("ids=1&ids=2").ids)).toEqual([
-    "1",
-    "2"
+it('getArrayFromQueryParam ensures querystring arrays are arrays', () => {
+  expect(getArrayFromQueryParam(querystring.parse('ids=1').ids)).toEqual(['1']);
+  expect(getArrayFromQueryParam(querystring.parse('ids=1&ids=2').ids)).toEqual([
+    '1',
+    '2',
   ]);
 });

--- a/lib/url.js
+++ b/lib/url.js
@@ -1,0 +1,25 @@
+import Router from 'next/router';
+import url from 'url';
+
+/**
+ * Navigates to same path but with different query string, with pagination param (before / after)
+ * resetted.
+ *
+ * @param {object} urlQuery
+ */
+export function goToUrlQueryAndResetPagination(urlQuery) {
+  delete urlQuery.before;
+  delete urlQuery.after;
+  Router.push(`${location.pathname}${url.format({ query: urlQuery })}`);
+}
+
+/**
+ * Ensures query string arrays are arrays.
+ *
+ * @param {string|string[]} stringOrArray
+ * @returns {string[]}
+ */
+export function getArrayFromQueryParam(stringOrArray) {
+  if (typeof stringOrArray === 'string') return [stringOrArray];
+  return stringOrArray;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -531,6 +531,24 @@
         "@babel/plugin-syntax-json-strings": "^7.2.0"
       }
     },
+    "@babel/plugin-proposal-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.6.2",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.6.2.tgz",
@@ -644,6 +662,23 @@
       "integrity": "sha512-VyN4QANJkRW6lDBmENzRszvZf3/4AXaj9YR7GwrWeeN9tEBPuXbmDYVU9bYBN0D70zCWVwUy0HWq2553VCb6Hw==",
       "requires": {
         "@babel/helper-plugin-utils": "^7.0.0"
+      }
+    },
+    "@babel/plugin-syntax-nullish-coalescing-operator": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
+      "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "dependencies": {
+        "@babel/helper-plugin-utils": {
+          "version": "7.8.3",
+          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
+          "integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-syntax-object-rest-spread": {

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "ttag": "^1.7.17"
   },
   "devDependencies": {
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
     "@babel/plugin-proposal-optional-chaining": "^7.6.0",
     "babel-eslint": "^10.0.3",
     "babel-plugin-module-resolver": "^4.0.0",

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -1,35 +1,36 @@
 import gql from 'graphql-tag';
 import querystring from 'querystring';
 import { t, ngettext, msgid, jt } from 'ttag';
-import Router, { useRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import Head from 'next/head';
 import getConfig from 'next/config';
-import url from 'url';
-import { useQuery } from '@apollo/react-hooks';
 
-import ButtonGroup from '@material-ui/core/ButtonGroup';
-import Button from '@material-ui/core/Button';
-import TextField from '@material-ui/core/TextField';
-import MenuItem from '@material-ui/core/MenuItem';
-import InputAdornment from '@material-ui/core/InputAdornment';
-import SortIcon from '@material-ui/icons/Sort';
 import Grid from '@material-ui/core/Grid';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 import Typography from '@material-ui/core/Typography';
-import ListItemText from '@material-ui/core/ListItemText';
 
+import { useQuery } from '@apollo/react-hooks';
 import withData from 'lib/apollo';
 import { ellipsis } from 'lib/text';
+import {
+  goToUrlQueryAndResetPagination,
+  getArrayFromQueryParam,
+} from 'lib/url';
 import AppLayout from 'components/AppLayout';
 import ArticleItem from 'components/ArticleItem';
 import Pagination from 'components/Pagination';
 import SearchInput from 'components/SearchInput';
 import FeedDisplay from 'components/FeedDisplay';
+import {
+  ArticleStatusFilter,
+  CategoryFilter,
+  SortInput,
+  DEFAULT_STATUS_FILTER,
+  DEFAULT_CATEGORY_IDS,
+  DEFAULT_ORDER_BY,
+} from 'components/ArticleListPage';
 
-const DEFAULT_ORDER_BY = 'lastRequestedAt';
-const DEFAULT_STATUS_FILTER = 'unsolved';
-const DEFAULT_CATEGORY_IDS = [];
 const DEFAULT_REPLY_REQUEST_COUNT = 2;
 const MAX_KEYWORD_LENGTH = 100;
 
@@ -91,15 +92,6 @@ const LIST_CATEGORIES = gql`
 `;
 
 /**
- * @param {string|string[]} stringOrArray
- * @returns {string[]}
- */
-function getArrayFromQueryParam(stringOrArray) {
-  if (typeof stringOrArray === 'string') return [stringOrArray];
-  return stringOrArray;
-}
-
-/**
  * @param {object} urlQuery - URL query object
  * @returns {object} ListArticleFilter
  */
@@ -154,94 +146,6 @@ function urlQuery2OrderBy({ q, orderBy = DEFAULT_ORDER_BY } = {}) {
   }
 
   return [{ [orderBy]: 'DESC' }];
-}
-
-/**
- * @param {object} urlQuery
- */
-function goToUrlQueryAndResetPagination(urlQuery) {
-  delete urlQuery.before;
-  delete urlQuery.after;
-  Router.push(`${location.pathname}${url.format({ query: urlQuery })}`);
-}
-
-function ArticleStatusFilter({
-  filter = DEFAULT_STATUS_FILTER,
-  onChange = () => {},
-}) {
-  return (
-    <ButtonGroup size="small" variant="outlined">
-      <Button
-        disabled={filter === 'unsolved'}
-        onClick={() => onChange('unsolved')}
-      >
-        {t`Not replied`}
-      </Button>
-      <Button disabled={filter === 'solved'} onClick={() => onChange('solved')}>
-        {t`Replied`}
-      </Button>
-      <Button disabled={filter === 'all'} onClick={() => onChange('all')}>
-        {t`All`}
-      </Button>
-    </ButtonGroup>
-  );
-}
-
-/**
- * @param {string[]} props.categoryIds - selected category id
- * @param {Category[]} props.categories - category options
- * @param {(categoryIds: string[]) => void} props.onChange
- */
-function CategoryFilter({
-  categoryIds = DEFAULT_CATEGORY_IDS,
-  categories = [],
-  onChange = () => {},
-}) {
-  return (
-    <TextField
-      label={t`Category`}
-      select
-      SelectProps={{
-        multiple: true,
-        renderValue: selectedIds =>
-          selectedIds
-            .map(id => categories.find(category => category.id === id)?.title)
-            .filter(c => c)
-            .join(', '),
-      }}
-      value={categoryIds}
-      onChange={e => onChange(e.target.value)}
-    >
-      {categories.map(({ id, title }) => (
-        <MenuItem key={id} value={id}>
-          <Checkbox checked={categoryIds.includes(id)} />
-          <ListItemText>{title}</ListItemText>
-        </MenuItem>
-      ))}
-    </TextField>
-  );
-}
-
-function SortInput({ orderBy = DEFAULT_ORDER_BY, onChange = () => {} }) {
-  return (
-    <TextField
-      label={t`Sort by`}
-      select
-      InputProps={{
-        startAdornment: (
-          <InputAdornment position="start">
-            <SortIcon />
-          </InputAdornment>
-        ),
-      }}
-      value={orderBy}
-      onChange={e => onChange(e.target.value)}
-    >
-      <MenuItem value="lastRequestedAt">{t`Most recently asked`}</MenuItem>
-      <MenuItem value="lastRepliedAt">{t`Most recently replied`}</MenuItem>
-      <MenuItem value="replyRequestCount">{t`Most asked`}</MenuItem>
-    </TextField>
-  );
 }
 
 /**

--- a/pages/articles.js
+++ b/pages/articles.js
@@ -223,7 +223,7 @@ function ArticleListPage() {
         <h1>{jt`Messages reported by user that reported “${searchedUserArticleElem}”`}</h1>
       )}
 
-      <Grid container spacing={2}>
+      <Grid container spacing={2} alignItems="flex-end">
         <Grid item>
           <ArticleStatusFilter
             filter={query.filter}

--- a/pages/replies.js
+++ b/pages/replies.js
@@ -1,9 +1,8 @@
 import gql from 'graphql-tag';
 import React from 'react';
 import Head from 'next/head';
-import Router, { useRouter } from 'next/router';
+import { useRouter } from 'next/router';
 import { t, ngettext, msgid } from 'ttag';
-import url from 'url';
 
 import { useQuery } from '@apollo/react-hooks';
 
@@ -17,6 +16,7 @@ import FormControlLabel from '@material-ui/core/FormControlLabel';
 import Checkbox from '@material-ui/core/Checkbox';
 
 import withData from 'lib/apollo';
+import { goToUrlQueryAndResetPagination } from 'lib/url';
 import useCurrentUser from 'lib/useCurrentUser';
 import AppLayout from 'components/AppLayout';
 import Pagination from 'components/Pagination';
@@ -107,15 +107,6 @@ function urlQuery2OrderBy({ q, orderBy = DEFAULT_ORDER_BY } = {}) {
   }
 
   return [{ [orderByItem]: order }];
-}
-
-/**
- * @param {object} urlQuery
- */
-function goToUrlQueryAndResetPagination(urlQuery) {
-  delete urlQuery.before;
-  delete urlQuery.after;
-  Router.push(`${location.pathname}${url.format({ query: urlQuery })}`);
 }
 
 function ReplyFilter({ filter = DEFAULT_TYPE_FILTER, onChange = () => {} }) {


### PR DESCRIPTION
Implements part of #213 .
 
![category-selector](https://user-images.githubusercontent.com/108608/74826308-578e9680-5346-11ea-98b4-6a44fe4f1ae0.gif)

This PR also moves `ArticleListPage` components to under `components/ArticleListPage`, so that article list logics are not mixed up with component implementation in `pages/articles.js`.

Also, we collect list-page URL processing utility functions in `lib/util` and add some unit test on its implementation.

The PR will not be merged until API is fully implemented ( cofacts/rumors-api#143 ).