### PR TITLE
Sends PUBLIC_GA_TRACKING_ID to dataLayer

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -26,6 +26,9 @@ PUBLIC_API_URL=https://cofacts-api.hacktabl.org
 # Google tag manager ID GTM-XXXXX
 PUBLIC_GTM_ID=
 
+# Google analytics tracking ID UA-XXXXXXXX-X, pass through to dataLayer as GA_TRACKING_ID
+PUBLIC_GA_TRACKING_ID=
+
 # ------
 # Build-time config that does not vary across docker images.
 # All of them must be passed as build arg in Dockerfile, so that Webpack Define plugin can replace

--- a/README.md
+++ b/README.md
@@ -54,7 +54,11 @@ On [docker hub](https://hub.docker.com/r/cofacts/rumors-site), `hooks/build` is 
 
 ## Analytics
 
-This project supports Google Tag Manager; populate `PUBLIC_GTM_ID` in `.env` with your Google Tag Manager Container ID.
+This project supports Google Tag Manager. You can prepare the following setup in `.env` file:
+- `PUBLIC_GTM_ID`: Google Tag Manager Container ID (`GTM-XXXXXXX`)
+- `PUBLIC_GA_TRACKING_ID`: Google analytics trakcing ID (`UA-XXXXXXXX-X`). `rumors-site` will *not*
+  load Google analytics itself; instead, it will push `GA_TRACKING_ID` to `dataLayer`, and it is your
+  responsibility to pick it up as a Data Layer Variable and setup Google Analytics in Google Tag Manager.
 
 The application will fire the following custom events:
 

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -10,6 +10,7 @@ const LANG = (process.env.LOCALE || 'en').replace('_', '-');
 const {
   publicRuntimeConfig: {
     PUBLIC_GTM_ID,
+    PUBLIC_GA_TRACKING_ID,
     PUBLIC_ROLLBAR_TOKEN,
     PUBLIC_ROLLBAR_ENV,
   },
@@ -50,6 +51,9 @@ class MyDocument extends Document {
           <script
             dangerouslySetInnerHTML={{
               __html: `
+                window.dataLayer = window.dataLayer || [];
+                dataLayer.push({GA_TRACKING_ID: '${PUBLIC_GA_TRACKING_ID}'});
+
                 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
                 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
                 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=


### PR DESCRIPTION
Currently we use different Google tag manager container ID for development, staging & production.

However, tag manager configurations are pretty complicated. This separation cannot make sure what we have tested on staging will ever work on production.

This PR exposes `GA_TRACKING_ID` from env vars to `dataLayer`, so that google tag manager can pick the variable up:
![image](https://user-images.githubusercontent.com/108608/74833661-e1ddf700-5354-11ea-9a57-495a9ba00459.png)

In this way, all environments can share the same GTM container ID, while keeping GA tracking ID different:
![image](https://user-images.githubusercontent.com/108608/74833923-64ff4d00-5355-11ea-8f93-857e752f659d.png)
![image](https://user-images.githubusercontent.com/108608/74834189-e6ef7600-5355-11ea-9663-548b38b73cee.png)
