### PR TITLE
Add core-js polyfill in webpack

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -38,7 +38,7 @@ module.exports = {
       if (entry['main.js'] && !entry['main.js'].includes('core-js')) {
         // As specified by React official doc
         // https://reactjs.org/docs/javascript-environment-requirements.html
-        entry['main.js'].push('core-js');
+        entry['main.js'].unshift('core-js');
       }
       return entry;
     };

--- a/next.config.js
+++ b/next.config.js
@@ -29,6 +29,20 @@ module.exports = {
   publicRuntimeConfig,
   serverRuntimeConfig,
   webpack(config, { isServer }) {
+    const originalEntryFn = config.entry;
+
+    // Inserting polyfill for old Browsers
+    // https://github.com/zeit/next.js/blob/canary/examples/with-polyfills/next.config.js
+    config.entry = async () => {
+      const entry = await originalEntryFn();
+      if (entry['main.js'] && !entry['main.js'].includes('core-js')) {
+        // As specified by React official doc
+        // https://reactjs.org/docs/javascript-environment-requirements.html
+        entry['main.js'].push('core-js');
+      }
+      return entry;
+    };
+
     //
     // Simplified from https://github.com/twopluszero/next-images/blob/master/index.js
     //

--- a/package-lock.json
+++ b/package-lock.json
@@ -4532,9 +4532,9 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
     },
     "core-js": {
-      "version": "2.6.10",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-      "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA=="
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+      "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
     },
     "core-js-compat": {
       "version": "3.1.4",


### PR DESCRIPTION
Fixes #208 .

React 16 [depends on](https://reactjs.org/docs/javascript-environment-requirements.html) `Set` and `Map`, which is not provided on old browswers like IE<11 or Chrome < 37. Despite their super low market share, some old phones are still using them, and hundreds of "Set is not defined" error is triggered every single day by these legacy browsers, eating up our Rollbar free quota:

![image](https://user-images.githubusercontent.com/108608/75028679-a883c380-54db-11ea-8e6b-e409eed9b8fd.png)

While Next.js includes babel-preset-env which invokes core-js transformation, [dependencies in NPM modules are not polyfilled nor transformed](https://github.com/zeit/next.js/tree/canary/examples/with-polyfills). This is why simply adding `target: "default, chrome 33"` in babel config doesn't work.

In addition, some of our dependencies are depending on `Object.assign`, which does not exist on Chrome 33. We will need to polyfill all these features instead.

This PR adds `core-js` directly to webpack, as the [official example suggests](https://github.com/zeit/next.js/tree/canary/examples/with-polyfills).

## Chrome 33 Screenshots, before polyfill

### Article page

`"Uncaught ReferenceError: Set is not defined"` exists
![](https://user-images.githubusercontent.com/108608/74905469-3d59c480-53e9-11ea-8c67-675393bcec6c.png)

### Article list
`"TypeError: Object function Object() {} has no method 'assign'"` exists
![](https://user-images.githubusercontent.com/108608/75026218-84be7e80-54d7-11ea-9205-be2b5bb78ee2.png)


### After polyfill

The error above disappears

![image](https://user-images.githubusercontent.com/108608/75029412-f51bce80-54dc-11ea-9343-a283718fc066.png)

![image](https://user-images.githubusercontent.com/108608/75029566-3d3af100-54dd-11ea-9598-a92fdb7b6325.png)
(Other errors are incurred by Google data studio, ignore them :P )