### PR TITLE
Add CURRENT_USER to GTM dataLayer after user is logged in

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ The application will fire the following custom events:
 - `routeChangeComplete` - when next-router finish route change
 - `dataLoaded` - when article / reply is loaded in article & reply page
 
+Also, it will push the following custom variable to `dataLayer`;
+
+- `GA_TRACKING_ID` - see `PUBLIC_GA_TRACKING_ID`
+- `CURRENT_USER` - Current user object, set by `useCurrentUser`.
+
 ## Design and Mockups
 
 * [真的假的 hackfoldr](http://beta.hackfoldr.org/rumors)

--- a/components/AppLayout/UserName.js
+++ b/components/AppLayout/UserName.js
@@ -3,7 +3,6 @@ import { t } from 'ttag';
 import gql from 'graphql-tag';
 import { useLazyQuery, useMutation } from '@apollo/react-hooks';
 import Link from 'next/link';
-import LEVEL_NAMES from 'constants/levelNames';
 import Button from '@material-ui/core/Button';
 import Dialog from '@material-ui/core/Dialog';
 import DialogActions from '@material-ui/core/DialogActions';
@@ -12,8 +11,10 @@ import DialogContentText from '@material-ui/core/DialogContentText';
 import IconButton from '@material-ui/core/IconButton';
 import EditIcon from '@material-ui/icons/Edit';
 
-import LoginModal from './LoginModal';
 import fetchAPI from 'lib/fetchAPI';
+import { usePushToDataLayer } from 'lib/gtm';
+import LEVEL_NAMES from 'constants/levelNames';
+import LoginModal from './LoginModal';
 
 const USER_QUERY = gql`
   query UserLevelQuery {
@@ -172,6 +173,8 @@ function UserName() {
     if (prevLevel !== null) setLevelUpPopupShow(true);
     setPrevLevel(data.GetUser.level);
   }, [data?.GetUser?.level]);
+
+  usePushToDataLayer(data?.GetUser, { CURRENT_USER: data?.GetUser });
 
   const handleUserNameEdit = useCallback(name => {
     setName({ variables: { name } });

--- a/lib/useCurrentUser.js
+++ b/lib/useCurrentUser.js
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useLazyQuery } from '@apollo/react-hooks';
 import gql from 'graphql-tag';
+import { usePushToDataLayer } from './gtm';
 
 export const CurrentUser = gql`
   fragment CurrentUser on User {
@@ -24,6 +25,7 @@ const USER_QUERY = gql`
 function useCurrentUser() {
   const [loadUser, { data }] = useLazyQuery(USER_QUERY);
   useEffect(() => loadUser(), []);
+  usePushToDataLayer(data?.GetUser, { CURRENT_USER: data?.GetUser });
 
   return data?.GetUser;
 }


### PR DESCRIPTION
According to Google analytics doc ["Handling authentication after pageload"](https://developers.google.com/analytics/devguides/collection/analyticsjs/cookies-user-id#handling_authentication_after_pageload) section, for applications that handles authentication after page load, we can set `userId` and then as following event fires, the whole session will have userId through [session unification](https://support.google.com/analytics/answer/4574780).

In Google Tag Manager we will load `CURRENT_USER` as variable and set it to Google Analytics setup.

![image](https://user-images.githubusercontent.com/108608/75426720-31897780-5980-11ea-8f92-86911a5c3753.png)

