### PR TITLE
Handle when latestReply is undefined

### DIFF
--- a/components/ArticleItem.js
+++ b/components/ArticleItem.js
@@ -8,6 +8,35 @@ import { format, formatDistanceToNow } from 'lib/dateWithLocale';
 // import ArticleItemWidget from './ArticleItemWidget/ArticleItemWidget.js';
 import cx from 'clsx';
 
+function LatestReply({ reply }) {
+  if (!reply) return null;
+
+  const lastRepliedAt = new Date(reply.createdAt);
+  const timeAgoStr = formatDistanceToNow(lastRepliedAt);
+
+  return (
+    <div className="latest-reply">
+      <strong>{t`Latest Reply`}</strong>
+      <br />
+      {reply.text}
+      {isValid(lastRepliedAt) && (
+        <span title={format(lastRepliedAt)}>
+          {' - '}
+          {t`${timeAgoStr} ago`}
+        </span>
+      )}
+
+      <style jsx>{`
+        .latest-reply {
+          background-color: #64b5f6;
+          padding: 1rem;
+          border-radius: 4px;
+        }
+      `}</style>
+    </div>
+  );
+}
+
 export default function ArticleItem({
   article,
   read = false, // from localEditorHelperList, it only provide after did mount
@@ -17,8 +46,6 @@ export default function ArticleItem({
   // isLogin,
 }) {
   const latestReply = article.articleReplies[0]?.reply;
-  const lastRepliedAt = new Date(latestReply.createdAt);
-  const timeAgoStr = formatDistanceToNow(lastRepliedAt);
 
   return (
     <li
@@ -31,19 +58,7 @@ export default function ArticleItem({
         <a>
           <div className="item-text">{article.text}</div>
           <ArticleInfo article={article} />
-          {showLastReply && latestReply && (
-            <div className="latest-reply">
-              <strong>{t`Latest Reply`}</strong>
-              <br />
-              {latestReply.text}
-              {isValid(lastRepliedAt) && (
-                <span title={format(lastRepliedAt)}>
-                  {' - '}
-                  {t`${timeAgoStr} ago`}
-                </span>
-              )}
-            </div>
-          )}
+          {showLastReply && <LatestReply reply={latestReply} />}
           {/* {isLogin && (
             <ArticleItemWidget
               id={id}
@@ -56,16 +71,6 @@ export default function ArticleItem({
       </Link>
 
       <style jsx>{listItemStyle}</style>
-      <style jsx>{`
-        .latest-reply {
-          background-color: #64b5f6;
-          padding: 1rem;
-          border-radius: 4px;
-        }
-        .item:hover .latest-reply {
-          color: black;
-        }
-      `}</style>
     </li>
   );
 }
@@ -75,10 +80,11 @@ ArticleItem.fragments = {
     fragment ArticleItem on Article {
       id
       text
-      articleReplies {
+      articleReplies(status: NORMAL) {
         articleId
         replyId
         reply {
+          id
           text
           createdAt
         }


### PR DESCRIPTION
Currently visiting [article list](https://cofacts.hacktabl.org/articles) will see 500 internal server error:
![image](https://user-images.githubusercontent.com/108608/75956309-93069480-5ef2-11ea-91a6-e4f830f97632.png)

The root cause is `ArticleItem` trying to read `createAt` on empty reply:
```
cofacts-staging-zh_1_26a0c24950d3 | 2020-03-05 06:04 +00:00: Error while running `getDataFromTree` TypeError: Cannot read property 'createdAt' of undefined
cofacts-staging-zh_1_26a0c24950d3 |     at ArticleItem (/srv/www/.next/server/static/RmJ6dlBKzFB7gLIxTollr/pages/articles.js:331:46)
```

Another bug is, when navigating to article page with existing reply, this error may come up:
```
    'Store error: the application attempted to write an object with no provided ' +
    'id but the store already contains an id of Reply:Hjq2E2UBbZnN2I-EOZtn for ' +
    'this object. The selectionSet that was trying to be written is:\n' +
    '{"kind":"Field","name":{"kind":"Name","value":"reply"},"arguments":[],"directives":[],"selectionSet":{"kind":"SelectionSet","selections":[{"kind":"Field","name":{"kind":"Name","value":"text"},"arguments":[],"directives":[]},{"kind":"Field","name":{"kind":"Name","value":"createdAt"},"arguments":[],"directives":[]},{"kind":"Field","name":{"kind":"Name","value":"__typename"}}]}}',
```

This PR fixes the errors above via:
1. early-return when rendering latest reply
2. provide id in reply query