### PR TITLE
Fixes searchUserByArticleId and reply page error

### DIFF
--- a/components/ReplyItem.js
+++ b/components/ReplyItem.js
@@ -61,10 +61,12 @@ ReplyItem.fragments = {
       type
       createdAt
       user {
+        id
         name
       }
       articleReplies(status: NORMAL) {
         articleId
+        replyId
       }
     }
   `,

--- a/constants/errors.js
+++ b/constants/errors.js
@@ -1,2 +1,6 @@
 // Matches setup in rumors-api
 export const AUTH_ERROR_MSG = 'userId is not set via query string.';
+
+// Matches setup in rumors-api
+export const NO_USER_FOR_ARTICLE =
+  'fromUserOfArticleId does not match any existing articles';

--- a/lib/rollbar.js
+++ b/lib/rollbar.js
@@ -5,6 +5,7 @@
  */
 import Rollbar from 'rollbar';
 import getConfig from 'next/config';
+import { NO_USER_FOR_ARTICLE } from 'constants/errors';
 
 if (typeof window !== 'undefined') {
   throw new Error(
@@ -25,6 +26,7 @@ const rollbar = new Rollbar({
   captureUncaught: true,
   captureUnhandledRejections: true,
   nodeSourceMaps: true,
+  ignoredMessages: [NO_USER_FOR_ARTICLE],
 });
 
 export default rollbar;

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -2,7 +2,7 @@ import React from 'react';
 import Document, { Head, Main, NextScript } from 'next/document';
 import getConfig from 'next/config';
 import { ServerStyleSheets } from '@material-ui/styles';
-import { AUTH_ERROR_MSG } from 'constants/errors';
+import { AUTH_ERROR_MSG, NO_USER_FOR_ARTICLE } from 'constants/errors';
 import theme from 'lib/theme';
 import agent from 'lib/stackimpact';
 import rollbar from 'lib/rollbar';
@@ -60,7 +60,7 @@ class MyDocument extends Document {
                   captureUncaught: true,
                   captureUnhandledRejections: true,
                   payload: { environment: "${PUBLIC_ROLLBAR_ENV}" },
-                  ignoredMessages: ["${AUTH_ERROR_MSG}"],
+                  ignoredMessages: ["${AUTH_ERROR_MSG}", "${NO_USER_FOR_ARTICLE}"],
                 };
                 ${rollbarSnippet}
               `,

--- a/pages/replies.js
+++ b/pages/replies.js
@@ -171,10 +171,7 @@ function ReplyListPage() {
     orderBy: urlQuery2OrderBy(query),
   };
 
-  const {
-    loading,
-    data: { ListReplies: replyData },
-  } = useQuery(LIST_REPLIES, {
+  const { loading, data: listRepliesData } = useQuery(LIST_REPLIES, {
     variables: {
       ...listQueryVars,
       before: query.before,
@@ -185,14 +182,14 @@ function ReplyListPage() {
   // Separate these stats query so that it will be cached by apollo-client and sends no network request
   // on page change, but still works when filter options are updated.
 
-  const {
-    loading: statsLoading,
-    data: { ListReplies: statsData },
-  } = useQuery(LIST_STAT, {
+  const { loading: statsLoading, data: listStatData } = useQuery(LIST_STAT, {
     variables: listQueryVars,
   });
 
   const currentUser = useCurrentUser();
+
+  const replyEdges = listRepliesData?.ListReplies?.edges || [];
+  const statsData = listStatData?.ListReplies || {};
 
   return (
     <AppLayout>
@@ -261,17 +258,17 @@ function ReplyListPage() {
           <Pagination
             query={query}
             pageInfo={statsData?.pageInfo}
-            edges={replyData?.edges}
+            edges={replyEdges}
           />
           <ul className="reply-list">
-            {replyData.edges.map(({ node }) => (
+            {replyEdges.map(({ node }) => (
               <ReplyItem key={node.id} reply={node} showUser={!query.mine} />
             ))}
           </ul>
           <Pagination
             query={query}
             pageInfo={statsData?.pageInfo}
-            edges={replyData?.edges}
+            edges={replyEdges}
           />
         </>
       )}


### PR DESCRIPTION
Fixes #227  by
1. Display error and handle null values properly in article list page
2. ignore [that specific error](https://github.com/cofacts/rumors-api/blob/master/src/graphql/queries/ListArticles.js#L141) in Rollbar 

![image](https://user-images.githubusercontent.com/108608/75980311-3076be00-5f1d-11ea-861f-dd221d89bc57.png)

This PR also fixes #193 by properly handle null values in reply list page. Also, user ID and reply ID are added in query to avoid Apollo-client cache update failure.
![load-reply](https://user-images.githubusercontent.com/108608/75980643-d88c8700-5f1d-11ea-9f2e-a5951a458bfa.gif)
