### PR TITLE
Category list in article page

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -43,3 +43,6 @@ APP_ID=DEV
 
 # pm2 cluster mode instance count
 WEB_CONCURRENCY=1
+
+# Temp: show category add button in article page
+PUBLIC_SHOW_ADD_CATEGORY=

--- a/components/ArticleCategories.js
+++ b/components/ArticleCategories.js
@@ -1,0 +1,29 @@
+import gql from 'graphql-tag';
+import Chip from '@material-ui/core/Chip';
+
+const ArticleCategoriesData = gql`
+  fragment ArticleCategoriesData on ArticleCategory {
+    articleId
+    categoryId
+    category {
+      title
+      description
+    }
+  }
+`;
+
+function ArticleCategories({ articleId, articleCategories }) {
+  return (
+    <aside>
+      {(articleCategories || []).map(({ categoryId, category }) => (
+        <Chip key={categoryId} label={category.title} />
+      ))}
+    </aside>
+  );
+}
+
+ArticleCategories.fragments = {
+  ArticleCategoriesData,
+};
+
+export default ArticleCategories;

--- a/components/ArticleCategories.js
+++ b/components/ArticleCategories.js
@@ -1,5 +1,7 @@
 import { useState } from 'react';
 import gql from 'graphql-tag';
+import { t } from 'ttag';
+import { useQuery, useMutation } from '@apollo/react-hooks';
 import Chip from '@material-ui/core/Chip';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
@@ -7,7 +9,7 @@ import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
 import AddIcon from '@material-ui/icons/Add';
 
-import { t } from 'ttag';
+import { dataIdFromObject } from 'lib/apollo';
 
 const useStyles = makeStyles(theme => ({
   button: { marginTop: theme.spacing(1) },
@@ -17,18 +19,113 @@ const useStyles = makeStyles(theme => ({
 
 const ArticleCategoriesData = gql`
   fragment ArticleCategoriesData on ArticleCategory {
+    # articleId and categoryId are required to identify ArticleCategory instances
     articleId
     categoryId
     category {
       title
       description
     }
+    positiveFeedbackCount
+    negativeFeedbackCount
+    ownVote
+    canUpdateStatus
   }
 `;
 
-function Category({ category }) {
+const ArticleCategoriesDataForUser = gql`
+  fragment ArticleCategoriesDataForUser on ArticleCategory {
+    # articleId and categoryId are required to identify ArticleCategory instances
+    articleId
+    categoryId
+    ownVote
+    canUpdateStatus
+  }
+`;
+
+const ArticleWithCategories = gql`
+  fragment ArticleWithCategories on Article {
+    articleCategories {
+      ...ArticleCategoriesData
+    }
+  }
+  ${ArticleCategoriesData}
+`;
+
+const CATEGORY_LIST_QUERY = gql`
+  query ListCategoryForSelect {
+    ListCategories(first: 50) {
+      edges {
+        node {
+          id
+          title
+          description
+        }
+      }
+    }
+  }
+`;
+
+const DELETE_CATEGORY = gql`
+  mutation RemoveCategoryFromArticle(
+    $articleId: String!
+    $categoryId: String!
+  ) {
+    UpdateArticleCategoryStatus(
+      articleId: $articleId
+      categoryId: $categoryId
+      status: DELETED
+    ) {
+      articleId
+      categoryId
+      status
+    }
+  }
+`;
+
+function Category({ articleId, categoryId, category, canDelete }) {
   const [anchorEl, setAnchorEl] = useState(null);
   const classes = useStyles();
+  const [deleteCategory, { loading: deletingCategory }] = useMutation(
+    DELETE_CATEGORY,
+    {
+      variables: { articleId, categoryId },
+      update(
+        cache,
+        {
+          data: { UpdateArticleCategoryStatus },
+        }
+      ) {
+        // Process data returned from mutation into a categoryId -> is-normal map
+        const categoryIsNormal = UpdateArticleCategoryStatus.reduce(
+          (map, { categoryId, status }) => {
+            map[categoryId] = status === 'NORMAL';
+            return map;
+          },
+          {}
+        );
+
+        // Read & update Article instance
+        const id = dataIdFromObject({ __typename: 'Article', id: articleId });
+        const article = cache.readFragment({
+          id,
+          fragmentName: 'ArticleWithCategories',
+          fragment: ArticleWithCategories,
+        });
+        cache.writeFragment({
+          id,
+          fragmentName: 'ArticleWithCategories',
+          fragment: ArticleWithCategories,
+          data: {
+            ...article,
+            articleCategories: article.articleCategories.filter(
+              ({ categoryId }) => categoryIsNormal[categoryId]
+            ),
+          },
+        });
+      },
+    }
+  );
   const handleOpen = e => {
     setAnchorEl(e.currentTarget);
   };
@@ -40,8 +137,10 @@ function Category({ category }) {
     <>
       <Chip
         className={classes.category}
+        disabled={deletingCategory}
         label={category.title}
         onClick={handleOpen}
+        onDelete={canDelete ? () => deleteCategory() : undefined}
       />
       <Menu
         anchorEl={anchorEl}
@@ -59,23 +158,48 @@ function Category({ category }) {
 
 function ArticleCategories({ articleId, articleCategories }) {
   const classes = useStyles();
+  const { data: allCategoryData } = useQuery(CATEGORY_LIST_QUERY, {
+    ssr: false,
+  });
+
+  const isInArticle = (articleCategories || []).reduce(
+    (map, { categoryId }) => {
+      map[categoryId] = true;
+      return map;
+    },
+    {}
+  );
+  const otherCategories = (allCategoryData?.ListCategories?.edges || [])
+    .filter(({ node }) => !isInArticle[node.id])
+    .map(({ node }) => node);
 
   return (
     <aside>
-      {(articleCategories || []).map(({ categoryId, category }) => (
-        <Category key={categoryId} category={category} />
-      ))}
+      {(articleCategories || []).map(
+        ({ categoryId, category, canUpdateStatus }) => (
+          <Category
+            key={categoryId}
+            category={category}
+            articleId={articleId}
+            categoryId={categoryId}
+            canDelete={canUpdateStatus}
+          />
+        )
+      )}
 
-      <Button className={classes.button}>
-        <AddIcon className={classes.buttonIcon} />
-        {t`Add category`}
-      </Button>
+      {otherCategories.length > 0 && (
+        <Button className={classes.button}>
+          <AddIcon className={classes.buttonIcon} />
+          {t`Add category`}
+        </Button>
+      )}
     </aside>
   );
 }
 
 ArticleCategories.fragments = {
   ArticleCategoriesData,
+  ArticleCategoriesDataForUser,
 };
 
 export default ArticleCategories;

--- a/components/ArticleCategories.js
+++ b/components/ArticleCategories.js
@@ -1,5 +1,19 @@
+import { useState } from 'react';
 import gql from 'graphql-tag';
 import Chip from '@material-ui/core/Chip';
+import Menu from '@material-ui/core/Menu';
+import MenuItem from '@material-ui/core/MenuItem';
+import Button from '@material-ui/core/Button';
+import { makeStyles } from '@material-ui/core/styles';
+import AddIcon from '@material-ui/icons/Add';
+
+import { t } from 'ttag';
+
+const useStyles = makeStyles(theme => ({
+  button: { marginTop: theme.spacing(1) },
+  buttonIcon: { marginRight: theme.spacing(1) },
+  category: { marginRight: theme.spacing(1), marginTop: theme.spacing(1) },
+}));
 
 const ArticleCategoriesData = gql`
   fragment ArticleCategoriesData on ArticleCategory {
@@ -12,12 +26,50 @@ const ArticleCategoriesData = gql`
   }
 `;
 
+function Category({ category }) {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const classes = useStyles();
+  const handleOpen = e => {
+    setAnchorEl(e.currentTarget);
+  };
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <>
+      <Chip
+        className={classes.category}
+        label={category.title}
+        onClick={handleOpen}
+      />
+      <Menu
+        anchorEl={anchorEl}
+        keepMounted
+        open={Boolean(anchorEl)}
+        onClose={handleClose}
+      >
+        <MenuItem>Profile</MenuItem>
+        <MenuItem>My account</MenuItem>
+        <MenuItem>Logout</MenuItem>
+      </Menu>
+    </>
+  );
+}
+
 function ArticleCategories({ articleId, articleCategories }) {
+  const classes = useStyles();
+
   return (
     <aside>
       {(articleCategories || []).map(({ categoryId, category }) => (
-        <Chip key={categoryId} label={category.title} />
+        <Category key={categoryId} category={category} />
       ))}
+
+      <Button className={classes.button}>
+        <AddIcon className={classes.buttonIcon} />
+        {t`Add category`}
+      </Button>
     </aside>
   );
 }

--- a/components/ArticleCategories/ArticleCategories.js
+++ b/components/ArticleCategories/ArticleCategories.js
@@ -46,13 +46,23 @@ function ArticleCategories({ articleId, articleCategories }) {
   return (
     <aside>
       {(articleCategories || []).map(
-        ({ categoryId, category, canUpdateStatus }) => (
+        ({
+          categoryId,
+          category,
+          canUpdateStatus,
+          positiveFeedbackCount,
+          negativeFeedbackCount,
+          ownVote,
+        }) => (
           <ArticleCategory
             key={categoryId}
             category={category}
             articleId={articleId}
             categoryId={categoryId}
             canDelete={canUpdateStatus}
+            positiveFeedbackCount={positiveFeedbackCount}
+            negativeFeedbackCount={negativeFeedbackCount}
+            ownVote={ownVote}
           />
         )
       )}

--- a/components/ArticleCategories/ArticleCategories.js
+++ b/components/ArticleCategories/ArticleCategories.js
@@ -1,0 +1,74 @@
+import gql from 'graphql-tag';
+import { t } from 'ttag';
+import { useQuery } from '@apollo/react-hooks';
+import Button from '@material-ui/core/Button';
+import { makeStyles } from '@material-ui/core/styles';
+import AddIcon from '@material-ui/icons/Add';
+
+import ArticleCategory from './ArticleCategory';
+
+const useStyles = makeStyles(theme => ({
+  button: { marginTop: theme.spacing(1) },
+  buttonIcon: { marginRight: theme.spacing(1) },
+}));
+
+const CATEGORY_LIST_QUERY = gql`
+  query ListCategoryForSelect {
+    ListCategories(first: 50) {
+      edges {
+        node {
+          id
+          title
+          description
+        }
+      }
+    }
+  }
+`;
+
+function ArticleCategories({ articleId, articleCategories }) {
+  const classes = useStyles();
+  const { data: allCategoryData } = useQuery(CATEGORY_LIST_QUERY, {
+    ssr: false,
+  });
+
+  const isInArticle = (articleCategories || []).reduce(
+    (map, { categoryId }) => {
+      map[categoryId] = true;
+      return map;
+    },
+    {}
+  );
+  const otherCategories = (allCategoryData?.ListCategories?.edges || [])
+    .filter(({ node }) => !isInArticle[node.id])
+    .map(({ node }) => node);
+
+  return (
+    <aside>
+      {(articleCategories || []).map(
+        ({ categoryId, category, canUpdateStatus }) => (
+          <ArticleCategory
+            key={categoryId}
+            category={category}
+            articleId={articleId}
+            categoryId={categoryId}
+            canDelete={canUpdateStatus}
+          />
+        )
+      )}
+
+      {otherCategories.length > 0 && (
+        <Button className={classes.button}>
+          <AddIcon className={classes.buttonIcon} />
+          {t`Add category`}
+        </Button>
+      )}
+    </aside>
+  );
+}
+
+ArticleCategories.fragments = {
+  ...ArticleCategory.fragments,
+};
+
+export default ArticleCategories;

--- a/components/ArticleCategories/ArticleCategories.js
+++ b/components/ArticleCategories/ArticleCategories.js
@@ -1,4 +1,5 @@
 import gql from 'graphql-tag';
+import getConfig from 'next/config';
 import { t } from 'ttag';
 import { useQuery } from '@apollo/react-hooks';
 import Button from '@material-ui/core/Button';
@@ -6,6 +7,10 @@ import { makeStyles } from '@material-ui/core/styles';
 import AddIcon from '@material-ui/icons/Add';
 
 import ArticleCategory from './ArticleCategory';
+
+const {
+  publicRuntimeConfig: { PUBLIC_SHOW_ADD_CATEGORY },
+} = getConfig();
 
 const useStyles = makeStyles(theme => ({
   button: { marginTop: theme.spacing(1) },
@@ -67,7 +72,7 @@ function ArticleCategories({ articleId, articleCategories }) {
         )
       )}
 
-      {otherCategories.length > 0 && (
+      {PUBLIC_SHOW_ADD_CATEGORY && otherCategories.length > 0 && (
         <Button className={classes.button}>
           <AddIcon className={classes.buttonIcon} />
           {t`Add category`}

--- a/components/ArticleCategories/ArticleCategory.js
+++ b/components/ArticleCategories/ArticleCategory.js
@@ -1,24 +1,19 @@
 import { useState } from 'react';
 import gql from 'graphql-tag';
-import { t } from 'ttag';
-import { useQuery, useMutation } from '@apollo/react-hooks';
+import { useMutation } from '@apollo/react-hooks';
 import Chip from '@material-ui/core/Chip';
 import Menu from '@material-ui/core/Menu';
 import MenuItem from '@material-ui/core/MenuItem';
-import Button from '@material-ui/core/Button';
 import { makeStyles } from '@material-ui/core/styles';
-import AddIcon from '@material-ui/icons/Add';
 
 import { dataIdFromObject } from 'lib/apollo';
 
 const useStyles = makeStyles(theme => ({
-  button: { marginTop: theme.spacing(1) },
-  buttonIcon: { marginRight: theme.spacing(1) },
   category: { marginRight: theme.spacing(1), marginTop: theme.spacing(1) },
 }));
 
-const ArticleCategoriesData = gql`
-  fragment ArticleCategoriesData on ArticleCategory {
+const ArticleCategoryData = gql`
+  fragment ArticleCategoryData on ArticleCategory {
     # articleId and categoryId are required to identify ArticleCategory instances
     articleId
     categoryId
@@ -33,8 +28,8 @@ const ArticleCategoriesData = gql`
   }
 `;
 
-const ArticleCategoriesDataForUser = gql`
-  fragment ArticleCategoriesDataForUser on ArticleCategory {
+const ArticleCategoryDataForUser = gql`
+  fragment ArticleCategoryDataForUser on ArticleCategory {
     # articleId and categoryId are required to identify ArticleCategory instances
     articleId
     categoryId
@@ -46,24 +41,10 @@ const ArticleCategoriesDataForUser = gql`
 const ArticleWithCategories = gql`
   fragment ArticleWithCategories on Article {
     articleCategories {
-      ...ArticleCategoriesData
+      ...ArticleCategoryData
     }
   }
-  ${ArticleCategoriesData}
-`;
-
-const CATEGORY_LIST_QUERY = gql`
-  query ListCategoryForSelect {
-    ListCategories(first: 50) {
-      edges {
-        node {
-          id
-          title
-          description
-        }
-      }
-    }
-  }
+  ${ArticleCategoryData}
 `;
 
 const DELETE_CATEGORY = gql`
@@ -83,7 +64,7 @@ const DELETE_CATEGORY = gql`
   }
 `;
 
-function Category({ articleId, categoryId, category, canDelete }) {
+function ArticleCategory({ articleId, categoryId, category, canDelete }) {
   const [anchorEl, setAnchorEl] = useState(null);
   const classes = useStyles();
   const [deleteCategory, { loading: deletingCategory }] = useMutation(
@@ -156,50 +137,9 @@ function Category({ articleId, categoryId, category, canDelete }) {
   );
 }
 
-function ArticleCategories({ articleId, articleCategories }) {
-  const classes = useStyles();
-  const { data: allCategoryData } = useQuery(CATEGORY_LIST_QUERY, {
-    ssr: false,
-  });
-
-  const isInArticle = (articleCategories || []).reduce(
-    (map, { categoryId }) => {
-      map[categoryId] = true;
-      return map;
-    },
-    {}
-  );
-  const otherCategories = (allCategoryData?.ListCategories?.edges || [])
-    .filter(({ node }) => !isInArticle[node.id])
-    .map(({ node }) => node);
-
-  return (
-    <aside>
-      {(articleCategories || []).map(
-        ({ categoryId, category, canUpdateStatus }) => (
-          <Category
-            key={categoryId}
-            category={category}
-            articleId={articleId}
-            categoryId={categoryId}
-            canDelete={canUpdateStatus}
-          />
-        )
-      )}
-
-      {otherCategories.length > 0 && (
-        <Button className={classes.button}>
-          <AddIcon className={classes.buttonIcon} />
-          {t`Add category`}
-        </Button>
-      )}
-    </aside>
-  );
-}
-
-ArticleCategories.fragments = {
-  ArticleCategoriesData,
-  ArticleCategoriesDataForUser,
+ArticleCategory.fragments = {
+  ArticleCategoryData,
+  ArticleCategoryDataForUser,
 };
 
-export default ArticleCategories;
+export default ArticleCategory;

--- a/components/ArticleCategories/DownVoteDialog.js
+++ b/components/ArticleCategories/DownVoteDialog.js
@@ -1,0 +1,106 @@
+import { t } from 'ttag';
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
+
+import DialogTitle from '@material-ui/core/DialogTitle';
+import Dialog from '@material-ui/core/Dialog';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogContentText from '@material-ui/core/DialogContentText';
+import DialogActions from '@material-ui/core/DialogActions';
+import Button from '@material-ui/core/Button';
+import List from '@material-ui/core/List';
+import ListItem from '@material-ui/core/ListItem';
+import ListItemAvatar from '@material-ui/core/ListItemAvatar';
+import ListItemText from '@material-ui/core/ListItemText';
+import TextField from '@material-ui/core/TextField';
+import Avatar from '@material-ui/core/Avatar';
+import PersonIcon from '@material-ui/icons/Person';
+import LinearProgress from '@material-ui/core/LinearProgress';
+
+const LIST_DOWNVOTE_FEEDBACKS = gql`
+  query ListArticleCategoryDownvoteFeedbacks($articleId: String!) {
+    GetArticle(id: $articleId) {
+      id
+      articleCategories(status: NORMAL) {
+        articleId
+        categoryId
+        feedbacks {
+          id
+          user {
+            name
+          }
+          comment
+          vote
+        }
+      }
+    }
+  }
+`;
+
+function DownVoteDialog({
+  articleId,
+  categoryId,
+  onClose = () => {},
+  onVote = () => {},
+}) {
+  const { data, loading } = useQuery(LIST_DOWNVOTE_FEEDBACKS, {
+    variables: { articleId },
+  });
+
+  const downVoteFeedbacks = (
+    data.GetArticle?.articleCategories.find(ac => ac.categoryId === categoryId)
+      ?.feedbacks ?? []
+  ).filter(({ vote, comment }) => vote === 'DOWNVOTE' && comment);
+
+  return (
+    <Dialog onClose={onClose} aria-labelledby="donevote-dialog-title" open>
+      <DialogTitle id="donevote-dialog-title">{t`Report wrong category`}</DialogTitle>
+      {loading ? (
+        <LinearProgress />
+      ) : downVoteFeedbacks.length === 0 ? null : (
+        <List>
+          {downVoteFeedbacks.map((feedback, index) => (
+            <ListItem key={index}>
+              <ListItemAvatar>
+                <Avatar>
+                  <PersonIcon />
+                </Avatar>
+              </ListItemAvatar>
+              <ListItemText
+                primary={feedback.user?.name || t`Someone`}
+                secondary={feedback.comment}
+              />
+            </ListItem>
+          ))}
+        </List>
+      )}
+      <form
+        onSubmit={e => {
+          e.preventDefault();
+          onVote(e.target.reason.value);
+        }}
+      >
+        <DialogContent>
+          <DialogContentText>
+            {t`Please share with us why you think this message does not belong to this category`}
+            :
+          </DialogContentText>
+          <TextField
+            autoFocus
+            margin="dense"
+            name="reason"
+            multiline
+            rows="3"
+            fullWidth
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>{t`Cancel`}</Button>
+          <Button color="primary" type="submit">{t`Submit`}</Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}
+
+export default DownVoteDialog;

--- a/components/ArticleCategories/index.js
+++ b/components/ArticleCategories/index.js
@@ -1,3 +1,3 @@
-import ArticleCategories from './ArticleCategories'
+import ArticleCategories from './ArticleCategories';
 
 export default ArticleCategories;

--- a/components/ArticleCategories/index.js
+++ b/components/ArticleCategories/index.js
@@ -1,0 +1,3 @@
+import ArticleCategories from './ArticleCategories'
+
+export default ArticleCategories;

--- a/components/ReplyFeedback.js
+++ b/components/ReplyFeedback.js
@@ -176,6 +176,7 @@ function ReplyFeedback({
         >
           <form
             onSubmit={e => {
+              e.preventDefault();
               const comment = e.target.reason.value;
               voteReply({
                 variables: { articleId, replyId, vote: 'DOWNVOTE', comment },

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -20,6 +20,8 @@ function customIdMapper(object) {
   switch (object.__typename) {
     case 'ArticleReply':
       return `${object.__typename}:${object.articleId}__${object.replyId}`;
+    case 'ArticleCategory':
+      return `${object.__typename}:${object.articleId}__${object.categoryId}`;
     default:
       // fall back to default handling
       return defaultDataIdFromObject(object);

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -16,7 +16,7 @@ const {
  * Maps GraphQL object
  * @param {object} object
  */
-function customIdMapper(object) {
+export function dataIdFromObject(object) {
   switch (object.__typename) {
     case 'ArticleReply':
       return `${object.__typename}:${object.articleId}__${object.replyId}`;
@@ -46,7 +46,7 @@ export const config = {
     }),
   ]),
   createCache() {
-    return new InMemoryCache({ dataIdFromObject: customIdMapper });
+    return new InMemoryCache({ dataIdFromObject });
   },
 };
 

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -50,7 +50,7 @@ const LOAD_ARTICLE = gql`
         }
       }
       articleCategories {
-        ...ArticleCategoriesData
+        ...ArticleCategoryData
       }
     }
   }
@@ -59,7 +59,7 @@ const LOAD_ARTICLE = gql`
   ${CurrentReplies.fragments.CurrentRepliesData}
   ${NewReplySection.fragments.RelatedArticleData}
   ${ArticleItem.fragments.ArticleItem}
-  ${ArticleCategories.fragments.ArticleCategoriesData}
+  ${ArticleCategories.fragments.ArticleCategoryData}
 `;
 
 const LOAD_ARTICLE_FOR_USER = gql`
@@ -73,13 +73,13 @@ const LOAD_ARTICLE_FOR_USER = gql`
         ...ArticleReplyForUser
       }
       articleCategories {
-        ...ArticleCategoriesDataForUser
+        ...ArticleCategoryDataForUser
       }
     }
   }
   ${ReplyRequestReason.fragments.ReplyRequestInfoForUser}
   ${CurrentReplies.fragments.ArticleReplyForUser}
-  ${ArticleCategories.fragments.ArticleCategoriesDataForUser}
+  ${ArticleCategories.fragments.ArticleCategoryDataForUser}
 `;
 
 function ArticlePage() {

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -19,6 +19,7 @@ import ReplyRequestReason from 'components/ReplyRequestReason';
 import CreateReplyRequestDialog from 'components/CreateReplyRequestDialog';
 import NewReplySection from 'components/NewReplySection';
 import ArticleItem from 'components/ArticleItem';
+import ArticleCategories from 'components/ArticleCategories';
 
 const LOAD_ARTICLE = gql`
   query LoadArticlePage($id: String!) {
@@ -48,6 +49,9 @@ const LOAD_ARTICLE = gql`
           }
         }
       }
+      articleCategories {
+        ...ArticleCategoriesData
+      }
     }
   }
   ${Hyperlinks.fragments.HyperlinkData}
@@ -55,6 +59,7 @@ const LOAD_ARTICLE = gql`
   ${CurrentReplies.fragments.CurrentRepliesData}
   ${NewReplySection.fragments.RelatedArticleData}
   ${ArticleItem.fragments.ArticleItem}
+  ${ArticleCategories.fragments.ArticleCategoriesData}
 `;
 
 const LOAD_ARTICLE_FOR_USER = gql`
@@ -166,6 +171,10 @@ function ArticlePage() {
           ))}
           <CreateReplyRequestDialog articleId={article.id} />
         </footer>
+        <ArticleCategories
+          articleId={article.id}
+          articleCategories={article.articleCategories}
+        />
       </section>
 
       <section className="section" id="current-replies" ref={replySectionRef}>

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -72,10 +72,14 @@ const LOAD_ARTICLE_FOR_USER = gql`
       articleReplies {
         ...ArticleReplyForUser
       }
+      articleCategories {
+        ...ArticleCategoriesDataForUser
+      }
     }
   }
   ${ReplyRequestReason.fragments.ReplyRequestInfoForUser}
   ${CurrentReplies.fragments.ArticleReplyForUser}
+  ${ArticleCategories.fragments.ArticleCategoriesDataForUser}
 `;
 
 function ArticlePage() {


### PR DESCRIPTION
Implements Article page UI in #213.

- List article categories under article text & reply request list.
- The person adding the category (`canUpdateStatus === true`) can remove category (has delete button)
- Clicking category label opens a dropdown that has options which
    - links to article list under that category
    - performs upvote and display upvote count
        - If user has upvoted, the option will be disabled.
    - opens downvote dialog, which displays others' reason of downvote and can fill in own downvote reason
        - If user has downvoted, the dialog should include their own submitted reason. They can update their own reason by casting downvote again.
    - "Add category" button is hidden by default. Shown only when env var `PUBLIC_SHOW_ADD_CATEGORY` is set.

## Screenshots

![image](https://user-images.githubusercontent.com/108608/76079707-3a152a00-5fe0-11ea-9179-e9da21275f72.png)

### Casting upvote
![upvote](https://user-images.githubusercontent.com/108608/76080009-f242d280-5fe0-11ea-9c36-3b1c76ef559d.gif)

### Listing other's reason and casting downvote
Currently the API mock does not contain any reason, thus the list is empty.
![downvote](https://user-images.githubusercontent.com/108608/76080014-f5d65980-5fe0-11ea-9db2-8ac21f622f0d.gif)

## TODO
The implementation of "Add category" button will be implemented in the next PR.

## Refactor
- export `dataIdFromObject` for mutation updates
- Resolve "Form submission is canceled" warning when submitting feedback reason for article replies.