### PR TITLE
Fix apollo-link-error causing SSR requests to halt

### DIFF
--- a/components/AppLayout/AppHeader.js
+++ b/components/AppLayout/AppHeader.js
@@ -109,7 +109,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const LIST_UNSOLVED_ARTICLES = gql`
-  query ListArticles {
+  query ListUnresolvedArticles {
     ListArticles(filter: { replyCount: { EQ: 0 } }) {
       totalCount
     }

--- a/lib/apollo.js
+++ b/lib/apollo.js
@@ -30,11 +30,13 @@ export function dataIdFromObject(object) {
 
 export const config = {
   link: ApolloLink.from([
-    onError(({ graphQLErrors }) => {
+    onError(errors => {
+      console.error('[apollo-link-error]', errors);
       if (
-        graphQLErrors &&
-        graphQLErrors.length === 1 &&
-        graphQLErrors[0].message === AUTH_ERROR_MSG
+        typeof alert !== 'undefined' &&
+        errors.graphQLErrors &&
+        errors.graphQLErrors.length === 1 &&
+        errors.graphQLErrors[0].message === AUTH_ERROR_MSG
       ) {
         alert(t`Please login first.`);
       }


### PR DESCRIPTION
During SSR, an GraphQL Error can halt the processing of Apollo-link middlewares, causing the server-side render to return nothing.

This PR:
1. Always print error console whenever apollo-link-error callback is invoked.
    - `console.error` works on both browsers and servers, and does not interrupt users at all, thus is a great choice to help with development
    - We don't use rollbar here because this would also capture the case when user does mutation without logging in
2. Fix SSR by detecting if `alert` exists in the global namespace (it's `undefined` during NodeJS SSR)
3. Includes a minor fix that renames a GraphQL query to avoid naming collisions, which allows us better identifying GraphQL queries.


From discussion: https://g0v-tw.slack.com/archives/C2PPMRQGP/p1589437262448200?thread_ts=1588665581.350300&cid=C2PPMRQGP

> 2. 我們用的 apollo-link-error 如果有 exception 的話，他就會無聲無息地悶不吭聲，讓後面的 apollo-client resolve 一整個卡住。我是在 BatchHttpLink 與 onError 中間插了一個印 console 的 link 才能抓到那個 error。
> 目前我們的 onError 裡頭用了 alert()，在 NodeJS 環境下並無此 function，所以他其實應該在 runtime 時遇到了 Reference error，但卻無聲無息。