### PR TITLE
[Hotfix] Fix reply form empty submission bug

### DIFF
--- a/components/NewReplySection/index.js
+++ b/components/NewReplySection/index.js
@@ -105,7 +105,7 @@ const NewReplySection = withContext(
           variables: { type, reference, text, articleId: article.id },
         });
       },
-      [createReply]
+      [createReply, fields]
     );
 
     const relatedArticleReplies = getDedupedArticleReplies(


### PR DESCRIPTION
Ref: https://www.facebook.com/groups/cofacts/permalink/2702689166629562/

## Impact
All reply submission. No one can submit new replies to Cofacts now.

## Root cause
In `NewReplySection/index`, `handleSubmit` is picking up old `fields` variable, which is always empty.

## Proposed fix
- Add `fields` to `useCallback` deps
- TODO: Make eslint emit error on omitted dependency