### PR TITLE
Enable react hook lint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@ module.exports = {
     "plugin:import/errors",
     "plugin:import/warnings",
     "plugin:react/recommended",
+    "plugin:react-hooks/recommended",
     "prettier",
     "prettier/react",
   ],
@@ -15,6 +16,7 @@ module.exports = {
   rules: {
     'react/prop-types': 'off', // we don't use propTypes.
     'react/react-in-jsx-scope': 'off', // React import not needed in Next.js
+    'react-hooks/exhaustive-deps': 'error', // Require explicit ignore when we want to skip deps
     'prettier/prettier': ["error", {
       "trailingComma": "es5",
       "singleQuote": true,

--- a/components/AppLayout/AppLayout.js
+++ b/components/AppLayout/AppLayout.js
@@ -60,6 +60,7 @@ function AppLayout({ children }) {
   const classes = useStyles();
 
   // load user when first loaded
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => loadUser(), []);
 
   useEffect(() => {

--- a/components/AppLayout/GlobalSearch.js
+++ b/components/AppLayout/GlobalSearch.js
@@ -75,6 +75,7 @@ function GlobalSearch({ onIconClick }) {
 
   useEffect(() => void (query.q !== value && setValue(query.q || '')), [
     query.q,
+    value,
   ]);
 
   const input = (

--- a/components/AppLayout/UserName.js
+++ b/components/AppLayout/UserName.js
@@ -163,6 +163,7 @@ function UserName() {
   const [setName, { loading: loadingNameUpdate }] = useMutation(SET_NAME);
 
   // load user on mount
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => loadUser(), []);
 
   // toggle level popup level update
@@ -173,14 +174,17 @@ function UserName() {
 
     if (prevLevel !== null) setLevelUpPopupShow(true);
     setPrevLevel(data.GetUser.level);
-  }, [data?.GetUser?.level]);
+  }, [data?.GetUser?.level, prevLevel]);
 
   usePushToDataLayer(data?.GetUser, { CURRENT_USER: data?.GetUser });
 
-  const handleUserNameEdit = useCallback(name => {
-    setName({ variables: { name } });
-    setUserNameEdit(false);
-  }, []);
+  const handleUserNameEdit = useCallback(
+    name => {
+      setName({ variables: { name } });
+      setUserNameEdit(false);
+    },
+    [setName]
+  );
 
   if (loading || loadingNameUpdate) return 'Loading...';
 

--- a/components/ArticlePageLayout.js
+++ b/components/ArticlePageLayout.js
@@ -399,7 +399,7 @@ function ArticlePageLayout({
           onChange={time =>
             goToUrlQueryAndResetPagination({
               ...query,
-              start: time?.GT,
+              start: time?.GTE,
               end: time?.LTE,
             })
           }

--- a/components/ArticleReply/CopyButton.js
+++ b/components/ArticleReply/CopyButton.js
@@ -12,7 +12,7 @@ const CopyButton = React.memo(({ content = '', onClick = () => {} }) => {
     });
     clipboard.on('success', () => onClick());
     return () => clipboard.destroy();
-  }, [copyBtnRef.current, content, onClick]);
+  }, [content, onClick]);
 
   return <Button ref={copyBtnRef}>{t`Copy`}</Button>;
 });

--- a/components/ArticleReply/ReplyShare.js
+++ b/components/ArticleReply/ReplyShare.js
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react';
+import { useState } from 'react';
 import {
   Popper,
   Fade,
@@ -56,8 +56,6 @@ const ReplyShare = ({ copyText }) => {
     closeMenu();
   };
 
-  const onCopied = useCallback(() => onSuccess('Copied to clipboard!'));
-
   const handleShare = event => {
     if (window.navigator && window.navigator.share) {
       navigator
@@ -81,7 +79,7 @@ const ReplyShare = ({ copyText }) => {
               <Paper elevation={3}>
                 <CopyButton
                   content={copyText}
-                  onClick={onCopied}
+                  onClick={() => onSuccess('Copied to clipboard!')}
                 >{t`Copy`}</CopyButton>
               </Paper>
             </Fade>

--- a/components/ArticleReply/index.js
+++ b/components/ArticleReply/index.js
@@ -132,7 +132,7 @@ const ArticleReply = React.memo(
 
     const classes = useStyles({ replyType });
 
-    const renderFooter = useCallback(() => {
+    const renderFooter = () => {
       const copyText =
         typeof window !== 'undefined'
           ? `${TYPE_NAME[reply.type]} \n【${t`Reason`}】${(
@@ -159,7 +159,7 @@ const ArticleReply = React.memo(
           <ReplyShare copyText={copyText} />
         </Box>
       );
-    }, [reply, articleReply]);
+    };
 
     const renderAuthor = useCallback(
       () =>
@@ -175,7 +175,7 @@ const ArticleReply = React.memo(
       [articleReplyAuthor]
     );
 
-    const renderReference = useCallback(() => {
+    const renderReference = () => {
       if (replyType === 'NOT_ARTICLE') return null;
 
       const reference = reply.reference;
@@ -195,7 +195,7 @@ const ArticleReply = React.memo(
           />
         </section>
       );
-    }, [replyType, reply]);
+    };
 
     const authorElem = renderAuthor();
 

--- a/components/CreateReplyRequestForm/CreateReplyRequestForm.js
+++ b/components/CreateReplyRequestForm/CreateReplyRequestForm.js
@@ -145,6 +145,8 @@ const CreateReplyRequestForm = React.memo(
       // We don't do this in constructor to avoid server/client render mismatch.
       //
       setText(localStorage.text || text);
+
+      // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     const handleTextChange = ({ target: { value } }) => {
@@ -211,7 +213,7 @@ const CreateReplyRequestForm = React.memo(
             >
               {requestedForReply === true ? t`Update comment` : t`Comment`}
             </button>
-            {/* 
+            {/*
               <button
                 type="button"
                 className={cx(requestedForReply && 'active')}

--- a/components/ExpandableText.js
+++ b/components/ExpandableText.js
@@ -58,6 +58,7 @@ const ExpandableText = ({ className, lineClamp, wordCount = 40, children }) => {
     if (lineClamp) {
       cloneAndComputeHeight();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const renderWithLineChampLimits = () => {

--- a/components/Filters.js
+++ b/components/Filters.js
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { Paper } from '@material-ui/core';
 import { withStyles, makeStyles } from '@material-ui/core/styles';
 import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
@@ -112,26 +112,23 @@ export function Filter({
   );
   const [expand, setExpand] = useState(false);
 
-  const onOptionClicked = useCallback(
-    value => () => {
-      if (multiple) {
-        const newState = { ...selected, [value]: !selected[value] };
-        setSelected(newState);
-        onChange(
-          Object.entries(newState)
-            .filter(entry => entry[1])
-            .map(entry => entry[0])
-        );
-      } else {
-        const newState = Object.fromEntries(
-          Object.entries(selected).map(([key]) => [key, key === value])
-        );
-        setSelected(newState);
-        onChange(value);
-      }
-    },
-    [selected, options]
-  );
+  const onOptionClicked = value => () => {
+    if (multiple) {
+      const newState = { ...selected, [value]: !selected[value] };
+      setSelected(newState);
+      onChange(
+        Object.entries(newState)
+          .filter(entry => entry[1])
+          .map(entry => entry[0])
+      );
+    } else {
+      const newState = Object.fromEntries(
+        Object.entries(selected).map(([key]) => [key, key === value])
+      );
+      setSelected(newState);
+      onChange(value);
+    }
+  };
 
   useEffect(() => {
     const newSelected = Object.fromEntries(

--- a/components/NewReplySection/ReplyForm/context.js
+++ b/components/NewReplySection/ReplyForm/context.js
@@ -22,6 +22,7 @@ export const withReplyFormContext = Component => props => {
       reference: localStorage.reference || fields.reference,
       text: localStorage.text || fields.text,
     });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const clear = () => {

--- a/components/NewReplySection/ReplySearch/ReplySearch.js
+++ b/components/NewReplySection/ReplySearch/ReplySearch.js
@@ -76,7 +76,7 @@ function ReplySearch({
 
   useEffect(() => {
     loadSearchResults({ variables: { query: search } });
-  }, [search]);
+  }, [search, loadSearchResults]);
 
   const source = [FILTERS.ALL_REPLIES, FILTERS.MY_REPLIES].includes(filter)
     ? data?.ListReplies

--- a/components/NewReplySection/index.js
+++ b/components/NewReplySection/index.js
@@ -105,7 +105,7 @@ const NewReplySection = withContext(
           variables: { type, reference, text, articleId: article.id },
         });
       },
-      [createReply, fields]
+      [createReply, fields, article.id, creatingReply]
     );
 
     const relatedArticleReplies = getDedupedArticleReplies(

--- a/components/ReplySearchItem.js
+++ b/components/ReplySearchItem.js
@@ -94,10 +94,11 @@ export default function ReplySearchItem({
   query = '',
   ...reply
 }) {
+  const classes = useStyles();
+  const [open, setOpen] = useState(false);
+
   const articleReply = articleReplies[0];
   if (!articleReply) return null;
-
-  const [open, setOpen] = useState(false);
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -116,8 +117,6 @@ export default function ReplySearchItem({
     negativeFeedbackCount,
     ownVote,
   } = articleReply || {};
-
-  const classes = useStyles();
 
   return (
     <li className={classes.root}>

--- a/components/ReplySearchPageLayout.js
+++ b/components/ReplySearchPageLayout.js
@@ -203,7 +203,7 @@ function ReplySearchPageLayout() {
           onChange={time =>
             goToUrlQueryAndResetPagination({
               ...query,
-              start: time?.GT,
+              start: time?.GTE,
               end: time?.LTE,
             })
           }

--- a/components/TimeRange.js
+++ b/components/TimeRange.js
@@ -1,4 +1,4 @@
-import { useRef, useState, useEffect, useCallback, forwardRef } from 'react';
+import { useRef, useState, useEffect, forwardRef } from 'react';
 import DateRangeIcon from '@material-ui/icons/DateRange';
 import { makeStyles } from '@material-ui/core/styles';
 import { ButtonGroup, Button, Menu, MenuItem } from '@material-ui/core';
@@ -66,6 +66,18 @@ const options = [
   { value: 'custom', label: c('Time range dropdown').t`Custom` },
 ];
 
+/**
+ * @param {{GTE: string?, LTE: string?}} range
+ * @return {string} one of options' value
+ */
+function getSelectedFromRange(range) {
+  if (!range) return 'all';
+  if (range.LTE) return 'custom';
+
+  const option = options.find(o => o.value === range.GTE);
+  return option ? option.value : 'custom';
+}
+
 /*
   material ui actually passes down some non-DOM props to children,
   and this cause some warning on runtime.
@@ -84,9 +96,9 @@ Input.displayName = 'input';
 
 function TimeRange({ onChange = () => null, range }) {
   const [anchor, setAnchor] = useState(null);
-  const [selected, setSelected] = useState('all');
+  const [selected, setSelected] = useState(getSelectedFromRange(range));
   const [customValue, setCustomValue] = useState({
-    GT: range?.GT,
+    GTE: range?.GTE,
     LTE: range?.LTE,
   });
   const anchorEl = useRef(null);
@@ -97,7 +109,7 @@ function TimeRange({ onChange = () => null, range }) {
   const select = option => () => {
     setSelected(option);
     if (option !== 'custom') {
-      onChange(option === 'all' ? null : { GT: option });
+      onChange(option === 'all' ? null : { GTE: option });
     }
     closeMenu();
   };
@@ -107,23 +119,17 @@ function TimeRange({ onChange = () => null, range }) {
     onChange(value);
   };
 
-  // when props update, change value
+  // update state when range prop change
   useEffect(() => {
-    if (!range) return;
-    if (customValue.GT !== range.GT || customValue.LTE !== range.LTE) {
-      setAndUpdateValue(range);
+    setCustomValue(customValue => {
+      if (!range) return customValue;
+      return customValue.GTE !== range.GTE || customValue.LTE !== range.LTE
+        ? range
+        : customValue;
+    });
 
-      if (range.GT) {
-        const option = options.find(o => o.value === range.GT);
-        if (option) {
-          setSelected(option.value);
-        } else if (range.GT || range.LTE) {
-          // custom
-          setSelected('custom');
-        }
-      }
-    }
-  }, [range, customValue]);
+    setSelected(() => getSelectedFromRange(range));
+  }, [range]);
 
   const custom = selected === 'custom';
 
@@ -136,11 +142,11 @@ function TimeRange({ onChange = () => null, range }) {
         {custom ? (
           <Input
             ref={anchorEl}
-            value={customValue.GT}
+            value={customValue.GTE}
             className={classes.startDate}
             onChange={e => {
               e.persist();
-              const newValue = { ...customValue, GT: e.target.value };
+              const newValue = { ...customValue, GTE: e.target.value };
               setAndUpdateValue(newValue);
             }}
             type="date"

--- a/components/TimeRange.js
+++ b/components/TimeRange.js
@@ -94,16 +94,13 @@ function TimeRange({ onChange = () => null, range }) {
 
   const openMenu = () => setAnchor(anchorEl.current);
   const closeMenu = () => setAnchor(null);
-  const select = useCallback(
-    option => () => {
-      setSelected(option);
-      if (option !== 'custom') {
-        onChange(option === 'all' ? null : { GT: option });
-      }
-      closeMenu();
-    },
-    []
-  );
+  const select = option => () => {
+    setSelected(option);
+    if (option !== 'custom') {
+      onChange(option === 'all' ? null : { GT: option });
+    }
+    closeMenu();
+  };
 
   const setAndUpdateValue = value => {
     setCustomValue(value);
@@ -126,7 +123,7 @@ function TimeRange({ onChange = () => null, range }) {
         }
       }
     }
-  }, [range]);
+  }, [range, customValue]);
 
   const custom = selected === 'custom';
 

--- a/lib/gtm.js
+++ b/lib/gtm.js
@@ -19,8 +19,9 @@ export function pushToDataLayer(...args) {
  * @param {object} args - data to send to pushDataLayer on trigger change
  */
 export function usePushToDataLayer(trigger, args) {
+  const dontTrigger = !trigger;
   useEffect(() => {
-    if (!trigger) return;
+    if (dontTrigger) return;
     pushToDataLayer(args);
-  }, [!trigger]);
+  }, [dontTrigger, args]);
 }

--- a/lib/useCurrentUser.js
+++ b/lib/useCurrentUser.js
@@ -37,6 +37,9 @@ function useCurrentUser() {
       }, 10);
     },
   });
+
+  // Load user on mount
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => loadUser(), []);
 
   return data?.GetUser;

--- a/package-lock.json
+++ b/package-lock.json
@@ -11464,9 +11464,9 @@
       }
     },
     "eslint-plugin-react-hooks": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.0.1.tgz",
-      "integrity": "sha512-xir+3KHKo86AasxlCV8AHRtIZPHljqCRRUYgASkbatmt0fad4+5GgC7zkT7o/06hdKM6MIwp8giHVXqBPaarHQ==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.0.4.tgz",
+      "integrity": "sha512-equAdEIsUETLFNCmmCkiCGq6rkSK5MoJhXFPFYeUebcjKgBmWWcgVOqZyQC8Bv1BwVCnTq9tBxgJFgAJTWoJtA==",
       "dev": true
     },
     "eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "eslint-plugin-import": "^2.18.2",
     "eslint-plugin-prettier": "^3.1.0",
     "eslint-plugin-react": "^7.14.3",
-    "eslint-plugin-react-hooks": "^2.0.1",
+    "eslint-plugin-react-hooks": "^4.0.4",
     "jest": "^25.1.0",
     "prettier": "^1.18.2",
     "react-test-renderer": "^16.8.6",

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -193,12 +193,14 @@ function ArticlePage() {
   const replySectionRef = useRef(null);
   const classes = useStyles();
 
+  // Load user field when currentUser changes
   useEffect(() => {
     if (!articleForUserCalled) {
       loadArticleForUser();
     } else {
       refetchArticleForUser();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentUser]);
 
   const handleNewReplySubmit = useCallback(() => {

--- a/pages/instant.js
+++ b/pages/instant.js
@@ -335,6 +335,7 @@ function InstantPage() {
   useEffect(() => {
     // Kick-off data loading
     loadArticleCount();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   if (loading || !startFrom) {

--- a/pages/reply/[id].js
+++ b/pages/reply/[id].js
@@ -109,12 +109,14 @@ function ReplyPage() {
 
   const currentUser = useCurrentUser();
 
+  // Load user field when currentUser changes
   useEffect(() => {
     if (!replyForUserCalled) {
       loadReplyForUser();
     } else {
       refetchReplyForUser();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [currentUser]);
 
   const reply = data?.GetReply;

--- a/pages/search.js
+++ b/pages/search.js
@@ -118,9 +118,10 @@ function SearchPage() {
     });
   };
 
+  const { q } = query;
   useEffect(() => {
-    textareaRef.current.value = query.q;
-  }, [query.q]);
+    textareaRef.current.value = q;
+  }, [q]);
 
   return (
     <AppLayout>


### PR DESCRIPTION
This PR enables react-hooks eslint rules and fixes all errors.

All violation of `react-hooks/exhausive-deps` now triggers build failure and requires explicitly disabling it using line comments (also need to include a good reason in comment!).

Current violations are fixed using the following rules:

-  `useCallback`:
  1. curried callbacks (`item => () => {}`) should not put in `useCallback` because when it's used in event handlers, curry function is invoked and a new copy of handler is always returned. There is no use putting `useCallback` over curried callbacks.
  2. event handlers depending on other function that is not memoized: its dependency will change every render. I remove its `useCallback` in this case.
  3. otherwise, add dependency to array. 
- `useEffect`:
  1. If it's meant to be a `componentDidMount`, I disable the rule for that line.
  2. If it's meant to be invoked on dependency change, I add the remaining dependencies.

**Each code change in this PR may introduce hard-to-find bugs. Please inspect carefully and put a comment whenever in doubt.**