### PR TITLE
Storybook for TimeRange

### DIFF
--- a/.babelrc.js
+++ b/.babelrc.js
@@ -19,7 +19,7 @@ module.exports = {
     "@babel/plugin-proposal-class-properties", // ttag extraction & resolve needs it, even though it's included in next/babel...
     "@babel/plugin-proposal-optional-chaining",
     [ // Need to be put last so that it can replace all strings
-      'ttag', {resolve: {translations: `i18n/${process.env.LOCALE}.po`}}
+      'ttag', {resolve: {translations: `i18n/${process.env.LOCALE || 'en_US'}.po`}}
     ],
   ]
 }

--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -1,4 +1,4 @@
 module.exports = {
   stories: ['../components/*.stories.js'],
-  addons: ['@storybook/addon-actions', '@storybook/addon-links'],
+  addons: ['@storybook/addon-actions/register', '@storybook/addon-knobs/register'],
 };

--- a/Storyshots.test.js
+++ b/Storyshots.test.js
@@ -1,11 +1,11 @@
-import Enzyme from 'enzyme';
+import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import { createMount, createRender } from '@material-ui/core/test-utils';
 import initStoryshots from '@storybook/addon-storyshots';
+import { createSerializer } from 'enzyme-to-json';
 
 Enzyme.configure({ adapter: new Adapter() });
 
 initStoryshots({
-  renderer: createMount(),
-  // snapshotSerializers: [createRender()],
+  renderer: mount,
+  snapshotSerializers: [createSerializer()],
 });

--- a/Storyshots.test.js
+++ b/Storyshots.test.js
@@ -1,6 +1,8 @@
 import Enzyme, { mount } from 'enzyme';
 import Adapter from 'enzyme-adapter-react-16';
-import initStoryshots from '@storybook/addon-storyshots';
+import initStoryshots, {
+  multiSnapshotWithOptions,
+} from '@storybook/addon-storyshots';
 import { createSerializer } from 'enzyme-to-json';
 
 Enzyme.configure({ adapter: new Adapter() });
@@ -34,6 +36,8 @@ function removeMaterialUIInternals(json) {
 }
 
 initStoryshots({
-  renderer: mount,
+  test: multiSnapshotWithOptions({
+    renderer: mount,
+  }),
   snapshotSerializers: [createSerializer({ map: removeMaterialUIInternals })],
 });

--- a/Storyshots.test.js
+++ b/Storyshots.test.js
@@ -5,7 +5,35 @@ import { createSerializer } from 'enzyme-to-json';
 
 Enzyme.configure({ adapter: new Adapter() });
 
+function removeMaterialUIInternals(json) {
+  // Remove Portal containerInfo
+  if (json.type === 'Portal') {
+    return {
+      ...json,
+      props: {
+        ...json.props,
+        containerInfo: undefined,
+      },
+    };
+  }
+
+  // Remove all props of these components
+  if (['Transition', 'TrapFocus'].includes(json.type)) {
+    return {
+      ...json,
+      props: {},
+    };
+  }
+
+  // Skip HOC components (single children)
+  if (json.type.match(/^(ForwardRef|WithStyles)/)) {
+    return json.children && json.children[0];
+  }
+
+  return json;
+}
+
 initStoryshots({
   renderer: mount,
-  snapshotSerializers: [createSerializer()],
+  snapshotSerializers: [createSerializer({ map: removeMaterialUIInternals })],
 });

--- a/Storyshots.test.js
+++ b/Storyshots.test.js
@@ -1,3 +1,11 @@
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
+import { createMount, createRender } from '@material-ui/core/test-utils';
 import initStoryshots from '@storybook/addon-storyshots';
 
-initStoryshots();
+Enzyme.configure({ adapter: new Adapter() });
+
+initStoryshots({
+  renderer: createMount(),
+  // snapshotSerializers: [createRender()],
+});

--- a/__snapshots__/Storyshots.test.js.snap
+++ b/__snapshots__/Storyshots.test.js.snap
@@ -7,1459 +7,301 @@ exports[`Storyshots TimeRange No Range Given 1`] = `
   <div
     className="makeStyles-root-1"
   >
-    <WithStyles(ForwardRef(ButtonGroup))
-      classes={
-        Object {
-          "contained": "makeStyles-buttonGroup-2",
-        }
-      }
+    <div
+      className="MuiButtonGroup-root"
+      role="group"
     >
-      <ForwardRef(ButtonGroup)
-        classes={
-          Object {
-            "contained": "MuiButtonGroup-contained makeStyles-buttonGroup-2",
-            "disabled": "Mui-disabled",
-            "fullWidth": "MuiButtonGroup-fullWidth",
-            "grouped": "MuiButtonGroup-grouped",
-            "groupedContained": "MuiButtonGroup-groupedContained",
-            "groupedContainedHorizontal": "MuiButtonGroup-groupedContainedHorizontal",
-            "groupedContainedPrimary": "MuiButtonGroup-groupedContainedPrimary",
-            "groupedContainedSecondary": "MuiButtonGroup-groupedContainedSecondary",
-            "groupedContainedVertical": "MuiButtonGroup-groupedContainedVertical",
-            "groupedHorizontal": "MuiButtonGroup-groupedHorizontal",
-            "groupedOutlined": "MuiButtonGroup-groupedOutlined",
-            "groupedOutlinedHorizontal": "MuiButtonGroup-groupedOutlinedHorizontal",
-            "groupedOutlinedPrimary": "MuiButtonGroup-groupedOutlinedPrimary",
-            "groupedOutlinedSecondary": "MuiButtonGroup-groupedOutlinedSecondary",
-            "groupedOutlinedVertical": "MuiButtonGroup-groupedOutlinedVertical",
-            "groupedText": "MuiButtonGroup-groupedText",
-            "groupedTextHorizontal": "MuiButtonGroup-groupedTextHorizontal",
-            "groupedTextPrimary": "MuiButtonGroup-groupedTextPrimary",
-            "groupedTextSecondary": "MuiButtonGroup-groupedTextSecondary",
-            "groupedTextVertical": "MuiButtonGroup-groupedTextVertical",
-            "groupedVertical": "MuiButtonGroup-groupedVertical",
-            "root": "MuiButtonGroup-root",
-            "vertical": "MuiButtonGroup-vertical",
-          }
-        }
+      <button
+        className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-3"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
+        type="button"
       >
-        <div
-          className="MuiButtonGroup-root"
-          role="group"
+        <span
+          className="MuiButton-label"
         >
-          <WithStyles(ForwardRef(Button))
-            className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-3"
-            color="default"
-            disableFocusRipple={false}
-            disableRipple={false}
-            disabled={false}
-            fullWidth={false}
-            key=".0"
-            onClick={[Function]}
-            size="medium"
-            variant="outlined"
+          <svg
+            aria-hidden="true"
+            className="MuiSvgIcon-root makeStyles-calendarIcon-4"
+            focusable="false"
+            viewBox="0 0 24 24"
           >
-            <ForwardRef(Button)
-              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-3"
-              classes={
-                Object {
-                  "colorInherit": "MuiButton-colorInherit",
-                  "contained": "MuiButton-contained",
-                  "containedPrimary": "MuiButton-containedPrimary",
-                  "containedSecondary": "MuiButton-containedSecondary",
-                  "containedSizeLarge": "MuiButton-containedSizeLarge",
-                  "containedSizeSmall": "MuiButton-containedSizeSmall",
-                  "disableElevation": "MuiButton-disableElevation",
-                  "disabled": "Mui-disabled",
-                  "endIcon": "MuiButton-endIcon",
-                  "focusVisible": "Mui-focusVisible",
-                  "fullWidth": "MuiButton-fullWidth",
-                  "iconSizeLarge": "MuiButton-iconSizeLarge",
-                  "iconSizeMedium": "MuiButton-iconSizeMedium",
-                  "iconSizeSmall": "MuiButton-iconSizeSmall",
-                  "label": "MuiButton-label",
-                  "outlined": "MuiButton-outlined",
-                  "outlinedPrimary": "MuiButton-outlinedPrimary",
-                  "outlinedSecondary": "MuiButton-outlinedSecondary",
-                  "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                  "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                  "root": "MuiButton-root",
-                  "sizeLarge": "MuiButton-sizeLarge",
-                  "sizeSmall": "MuiButton-sizeSmall",
-                  "startIcon": "MuiButton-startIcon",
-                  "text": "MuiButton-text",
-                  "textPrimary": "MuiButton-textPrimary",
-                  "textSecondary": "MuiButton-textSecondary",
-                  "textSizeLarge": "MuiButton-textSizeLarge",
-                  "textSizeSmall": "MuiButton-textSizeSmall",
-                }
-              }
-              color="default"
-              disableFocusRipple={false}
-              disableRipple={false}
-              disabled={false}
-              fullWidth={false}
-              onClick={[Function]}
-              size="medium"
-              variant="outlined"
-            >
-              <WithStyles(ForwardRef(ButtonBase))
-                className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-3"
-                component="button"
-                disableRipple={false}
-                disabled={false}
-                focusRipple={true}
-                focusVisibleClassName="Mui-focusVisible"
-                onClick={[Function]}
-                type="button"
-              >
-                <ForwardRef(ButtonBase)
-                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-3"
-                  classes={
-                    Object {
-                      "disabled": "Mui-disabled",
-                      "focusVisible": "Mui-focusVisible",
-                      "root": "MuiButtonBase-root",
-                    }
-                  }
-                  component="button"
-                  disableRipple={false}
-                  disabled={false}
-                  focusRipple={true}
-                  focusVisibleClassName="Mui-focusVisible"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <button
-                    className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-3"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    <span
-                      className="MuiButton-label"
-                    >
-                      <ForwardRef
-                        className="makeStyles-calendarIcon-4"
-                      >
-                        <WithStyles(ForwardRef(SvgIcon))
-                          className="makeStyles-calendarIcon-4"
-                        >
-                          <ForwardRef(SvgIcon)
-                            className="makeStyles-calendarIcon-4"
-                            classes={
-                              Object {
-                                "colorAction": "MuiSvgIcon-colorAction",
-                                "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                "colorError": "MuiSvgIcon-colorError",
-                                "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                "root": "MuiSvgIcon-root",
-                              }
-                            }
-                          >
-                            <svg
-                              aria-hidden="true"
-                              className="MuiSvgIcon-root makeStyles-calendarIcon-4"
-                              focusable="false"
-                              viewBox="0 0 24 24"
-                            >
-                              <path
-                                d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"
-                              />
-                            </svg>
-                          </ForwardRef(SvgIcon)>
-                        </WithStyles(ForwardRef(SvgIcon))>
-                      </ForwardRef>
-                    </span>
-                    <NoSsr>
-                      <WithStyles(memo)
-                        center={false}
-                      >
-                        <ForwardRef(TouchRipple)
-                          center={false}
-                          classes={
-                            Object {
-                              "child": "MuiTouchRipple-child",
-                              "childLeaving": "MuiTouchRipple-childLeaving",
-                              "childPulsate": "MuiTouchRipple-childPulsate",
-                              "ripple": "MuiTouchRipple-ripple",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible",
-                              "root": "MuiTouchRipple-root",
-                            }
-                          }
-                        >
-                          <span
-                            className="MuiTouchRipple-root"
-                          >
-                            <TransitionGroup
-                              childFactory={[Function]}
-                              component={null}
-                              exit={true}
-                            />
-                          </span>
-                        </ForwardRef(TouchRipple)>
-                      </WithStyles(memo)>
-                    </NoSsr>
-                  </button>
-                </ForwardRef(ButtonBase)>
-              </WithStyles(ForwardRef(ButtonBase))>
-            </ForwardRef(Button)>
-          </WithStyles(ForwardRef(Button))>
-          <WithStyles(ForwardRef(Button))
-            className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-5"
-            color="default"
-            disableFocusRipple={false}
-            disableRipple={false}
-            disabled={false}
-            fullWidth={false}
-            key=".1"
-            onClick={[Function]}
-            size="medium"
-            variant="outlined"
+            <path
+              d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"
+            />
+          </svg>
+        </span>
+        <NoSsr>
+          <span
+            className="MuiTouchRipple-root"
           >
-            <ForwardRef(Button)
-              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-5"
-              classes={
-                Object {
-                  "colorInherit": "MuiButton-colorInherit",
-                  "contained": "MuiButton-contained",
-                  "containedPrimary": "MuiButton-containedPrimary",
-                  "containedSecondary": "MuiButton-containedSecondary",
-                  "containedSizeLarge": "MuiButton-containedSizeLarge",
-                  "containedSizeSmall": "MuiButton-containedSizeSmall",
-                  "disableElevation": "MuiButton-disableElevation",
-                  "disabled": "Mui-disabled",
-                  "endIcon": "MuiButton-endIcon",
-                  "focusVisible": "Mui-focusVisible",
-                  "fullWidth": "MuiButton-fullWidth",
-                  "iconSizeLarge": "MuiButton-iconSizeLarge",
-                  "iconSizeMedium": "MuiButton-iconSizeMedium",
-                  "iconSizeSmall": "MuiButton-iconSizeSmall",
-                  "label": "MuiButton-label",
-                  "outlined": "MuiButton-outlined",
-                  "outlinedPrimary": "MuiButton-outlinedPrimary",
-                  "outlinedSecondary": "MuiButton-outlinedSecondary",
-                  "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                  "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                  "root": "MuiButton-root",
-                  "sizeLarge": "MuiButton-sizeLarge",
-                  "sizeSmall": "MuiButton-sizeSmall",
-                  "startIcon": "MuiButton-startIcon",
-                  "text": "MuiButton-text",
-                  "textPrimary": "MuiButton-textPrimary",
-                  "textSecondary": "MuiButton-textSecondary",
-                  "textSizeLarge": "MuiButton-textSizeLarge",
-                  "textSizeSmall": "MuiButton-textSizeSmall",
-                }
-              }
-              color="default"
-              disableFocusRipple={false}
-              disableRipple={false}
-              disabled={false}
-              fullWidth={false}
-              onClick={[Function]}
-              size="medium"
-              variant="outlined"
-            >
-              <WithStyles(ForwardRef(ButtonBase))
-                className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-5"
-                component="button"
-                disableRipple={false}
-                disabled={false}
-                focusRipple={true}
-                focusVisibleClassName="Mui-focusVisible"
-                onClick={[Function]}
-                type="button"
-              >
-                <ForwardRef(ButtonBase)
-                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-5"
-                  classes={
-                    Object {
-                      "disabled": "Mui-disabled",
-                      "focusVisible": "Mui-focusVisible",
-                      "root": "MuiButtonBase-root",
-                    }
-                  }
-                  component="button"
-                  disableRipple={false}
-                  disabled={false}
-                  focusRipple={true}
-                  focusVisibleClassName="Mui-focusVisible"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <button
-                    className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-5"
-                    disabled={false}
-                    onBlur={[Function]}
-                    onClick={[Function]}
-                    onDragLeave={[Function]}
-                    onFocus={[Function]}
-                    onKeyDown={[Function]}
-                    onKeyUp={[Function]}
-                    onMouseDown={[Function]}
-                    onMouseLeave={[Function]}
-                    onMouseUp={[Function]}
-                    onTouchEnd={[Function]}
-                    onTouchMove={[Function]}
-                    onTouchStart={[Function]}
-                    tabIndex={0}
-                    type="button"
-                  >
-                    <span
-                      className="MuiButton-label"
-                    >
-                      時間不限
-                    </span>
-                    <NoSsr>
-                      <WithStyles(memo)
-                        center={false}
-                      >
-                        <ForwardRef(TouchRipple)
-                          center={false}
-                          classes={
-                            Object {
-                              "child": "MuiTouchRipple-child",
-                              "childLeaving": "MuiTouchRipple-childLeaving",
-                              "childPulsate": "MuiTouchRipple-childPulsate",
-                              "ripple": "MuiTouchRipple-ripple",
-                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                              "rippleVisible": "MuiTouchRipple-rippleVisible",
-                              "root": "MuiTouchRipple-root",
-                            }
-                          }
-                        >
-                          <span
-                            className="MuiTouchRipple-root"
-                          >
-                            <TransitionGroup
-                              childFactory={[Function]}
-                              component={null}
-                              exit={true}
-                            />
-                          </span>
-                        </ForwardRef(TouchRipple)>
-                      </WithStyles(memo)>
-                    </NoSsr>
-                  </button>
-                </ForwardRef(ButtonBase)>
-              </WithStyles(ForwardRef(ButtonBase))>
-            </ForwardRef(Button)>
-          </WithStyles(ForwardRef(Button))>
-        </div>
-      </ForwardRef(ButtonGroup)>
-    </WithStyles(ForwardRef(ButtonGroup))>
-    <WithStyles(ForwardRef(Menu))
-      anchorEl={null}
-      id="time-range"
-      keepMounted={true}
-      onClose={[Function]}
-      open={false}
-    >
-      <ForwardRef(Menu)
-        anchorEl={null}
-        classes={
-          Object {
-            "list": "MuiMenu-list",
-            "paper": "MuiMenu-paper",
-          }
-        }
+            <TransitionGroup
+              childFactory={[Function]}
+              component={null}
+              exit={true}
+            />
+          </span>
+        </NoSsr>
+      </button>
+      <button
+        className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-5"
+        disabled={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        tabIndex={0}
+        type="button"
+      >
+        <span
+          className="MuiButton-label"
+        >
+          時間不限
+        </span>
+        <NoSsr>
+          <span
+            className="MuiTouchRipple-root"
+          >
+            <TransitionGroup
+              childFactory={[Function]}
+              component={null}
+              exit={true}
+            />
+          </span>
+        </NoSsr>
+      </button>
+    </div>
+    <Portal>
+      <div
+        className="MuiPopover-root"
         id="time-range"
-        keepMounted={true}
-        onClose={[Function]}
-        open={false}
+        onKeyDown={[Function]}
+        role="presentation"
+        style={
+          Object {
+            "bottom": 0,
+            "left": 0,
+            "position": "fixed",
+            "right": 0,
+            "top": 0,
+            "visibility": "hidden",
+            "zIndex": 1300,
+          }
+        }
       >
-        <WithStyles(ForwardRef(Popover))
-          PaperProps={
-            Object {
-              "classes": Object {
-                "root": "MuiMenu-paper",
-              },
-            }
-          }
-          anchorEl={null}
-          anchorOrigin={
-            Object {
-              "horizontal": "left",
-              "vertical": "top",
-            }
-          }
-          getContentAnchorEl={[Function]}
-          id="time-range"
-          keepMounted={true}
-          onClose={[Function]}
-          onEntering={[Function]}
-          open={false}
-          transformOrigin={
-            Object {
-              "horizontal": "left",
-              "vertical": "top",
-            }
-          }
-          transitionDuration="auto"
-        >
-          <ForwardRef(Popover)
-            PaperProps={
-              Object {
-                "classes": Object {
-                  "root": "MuiMenu-paper",
-                },
-              }
-            }
-            anchorEl={null}
-            anchorOrigin={
-              Object {
-                "horizontal": "left",
-                "vertical": "top",
-              }
-            }
-            classes={
-              Object {
-                "paper": "MuiPopover-paper",
-                "root": "MuiPopover-root",
-              }
-            }
-            getContentAnchorEl={[Function]}
-            id="time-range"
-            keepMounted={true}
-            onClose={[Function]}
-            onEntering={[Function]}
-            open={false}
-            transformOrigin={
-              Object {
-                "horizontal": "left",
-                "vertical": "top",
-              }
-            }
-            transitionDuration="auto"
-          >
-            <ForwardRef(Modal)
-              BackdropProps={
+        <TrapFocus>
+          <div
+            data-test="sentinelStart"
+            tabIndex={0}
+          />
+          <Transition>
+            <div
+              className="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+              style={
                 Object {
-                  "invisible": true,
+                  "opacity": 0,
+                  "transform": "scale(0.75, 0.5625)",
+                  "visibility": "hidden",
                 }
               }
-              className="MuiPopover-root"
-              id="time-range"
-              keepMounted={true}
-              onClose={[Function]}
-              open={false}
+              tabIndex="-1"
             >
-              <ForwardRef(Portal)
-                disablePortal={false}
+              <ul
+                className="MuiList-root MuiMenu-list MuiList-padding"
+                onKeyDown={[Function]}
+                role="menu"
+                tabIndex={-1}
               >
-                <Portal
-                  containerInfo={
-                    <body>
-                      <div
-                        aria-hidden="true"
-                        class="MuiPopover-root"
-                        id="time-range"
-                        role="presentation"
-                        style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
-                      >
-                        <div
-                          data-test="sentinelStart"
-                          tabindex="0"
-                        />
-                        <div
-                          class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                          style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
-                          tabindex="-1"
-                        >
-                          <ul
-                            class="MuiList-root MuiMenu-list MuiList-padding"
-                            role="menu"
-                            tabindex="-1"
-                          >
-                            <li
-                              aria-disabled="false"
-                              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                              data-ga="MenuItem(all)"
-                              role="menuitem"
-                              tabindex="0"
-                            >
-                              時間不限
-                              <span
-                                class="MuiTouchRipple-root"
-                              />
-                            </li>
-                            <li
-                              aria-disabled="false"
-                              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                              data-ga="MenuItem(now-1d/d)"
-                              role="menuitem"
-                              tabindex="-1"
-                            >
-                              一天內
-                              <span
-                                class="MuiTouchRipple-root"
-                              />
-                            </li>
-                            <li
-                              aria-disabled="false"
-                              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                              data-ga="MenuItem(now-1w/d)"
-                              role="menuitem"
-                              tabindex="-1"
-                            >
-                              一週內
-                              <span
-                                class="MuiTouchRipple-root"
-                              />
-                            </li>
-                            <li
-                              aria-disabled="false"
-                              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                              data-ga="MenuItem(now-1m/d)"
-                              role="menuitem"
-                              tabindex="-1"
-                            >
-                              一個月內
-                              <span
-                                class="MuiTouchRipple-root"
-                              />
-                            </li>
-                            <li
-                              aria-disabled="false"
-                              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                              data-ga="MenuItem(custom)"
-                              role="menuitem"
-                              tabindex="-1"
-                            >
-                              自訂範圍
-                              <span
-                                class="MuiTouchRipple-root"
-                              />
-                            </li>
-                          </ul>
-                        </div>
-                        <div
-                          data-test="sentinelEnd"
-                          tabindex="0"
-                        />
-                      </div>
-                    </body>
-                  }
+                <li
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                  data-ga="MenuItem(all)"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="menuitem"
+                  tabIndex={0}
                 >
-                  <div
-                    className="MuiPopover-root"
-                    id="time-range"
-                    onKeyDown={[Function]}
-                    role="presentation"
-                    style={
-                      Object {
-                        "bottom": 0,
-                        "left": 0,
-                        "position": "fixed",
-                        "right": 0,
-                        "top": 0,
-                        "visibility": "hidden",
-                        "zIndex": 1300,
-                      }
-                    }
-                  >
-                    <ForwardRef(SimpleBackdrop)
-                      invisible={true}
-                      onClick={[Function]}
-                      open={false}
-                    />
-                    <TrapFocus
-                      disableAutoFocus={false}
-                      disableEnforceFocus={false}
-                      disableRestoreFocus={false}
-                      getDoc={[Function]}
-                      isEnabled={[Function]}
-                      open={false}
+                  時間不限
+                  <NoSsr>
+                    <span
+                      className="MuiTouchRipple-root"
                     >
-                      <div
-                        data-test="sentinelStart"
-                        tabIndex={0}
+                      <TransitionGroup
+                        childFactory={[Function]}
+                        component={null}
+                        exit={true}
                       />
-                      <ForwardRef(Grow)
-                        appear={true}
-                        in={false}
-                        onEnter={[Function]}
-                        onEntering={[Function]}
-                        onExited={[Function]}
-                        tabIndex="-1"
-                        timeout="auto"
-                      >
-                        <Transition
-                          addEndListener={[Function]}
-                          appear={true}
-                          enter={true}
-                          exit={true}
-                          in={false}
-                          mountOnEnter={false}
-                          onEnter={[Function]}
-                          onEntered={[Function]}
-                          onEntering={[Function]}
-                          onExit={[Function]}
-                          onExited={[Function]}
-                          onExiting={[Function]}
-                          tabIndex="-1"
-                          timeout={null}
-                          unmountOnExit={false}
-                        >
-                          <WithStyles(ForwardRef(Paper))
-                            className="MuiPopover-paper"
-                            classes={
-                              Object {
-                                "root": "MuiMenu-paper",
-                              }
-                            }
-                            elevation={8}
-                            style={
-                              Object {
-                                "opacity": 0,
-                                "transform": "scale(0.75, 0.5625)",
-                                "visibility": "hidden",
-                              }
-                            }
-                            tabIndex="-1"
-                          >
-                            <ForwardRef(Paper)
-                              className="MuiPopover-paper"
-                              classes={
-                                Object {
-                                  "elevation0": "MuiPaper-elevation0",
-                                  "elevation1": "MuiPaper-elevation1",
-                                  "elevation10": "MuiPaper-elevation10",
-                                  "elevation11": "MuiPaper-elevation11",
-                                  "elevation12": "MuiPaper-elevation12",
-                                  "elevation13": "MuiPaper-elevation13",
-                                  "elevation14": "MuiPaper-elevation14",
-                                  "elevation15": "MuiPaper-elevation15",
-                                  "elevation16": "MuiPaper-elevation16",
-                                  "elevation17": "MuiPaper-elevation17",
-                                  "elevation18": "MuiPaper-elevation18",
-                                  "elevation19": "MuiPaper-elevation19",
-                                  "elevation2": "MuiPaper-elevation2",
-                                  "elevation20": "MuiPaper-elevation20",
-                                  "elevation21": "MuiPaper-elevation21",
-                                  "elevation22": "MuiPaper-elevation22",
-                                  "elevation23": "MuiPaper-elevation23",
-                                  "elevation24": "MuiPaper-elevation24",
-                                  "elevation3": "MuiPaper-elevation3",
-                                  "elevation4": "MuiPaper-elevation4",
-                                  "elevation5": "MuiPaper-elevation5",
-                                  "elevation6": "MuiPaper-elevation6",
-                                  "elevation7": "MuiPaper-elevation7",
-                                  "elevation8": "MuiPaper-elevation8",
-                                  "elevation9": "MuiPaper-elevation9",
-                                  "outlined": "MuiPaper-outlined",
-                                  "root": "MuiPaper-root MuiMenu-paper",
-                                  "rounded": "MuiPaper-rounded",
-                                }
-                              }
-                              elevation={8}
-                              style={
-                                Object {
-                                  "opacity": 0,
-                                  "transform": "scale(0.75, 0.5625)",
-                                  "visibility": "hidden",
-                                }
-                              }
-                              tabIndex="-1"
-                            >
-                              <div
-                                className="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                                style={
-                                  Object {
-                                    "opacity": 0,
-                                    "transform": "scale(0.75, 0.5625)",
-                                    "visibility": "hidden",
-                                  }
-                                }
-                                tabIndex="-1"
-                              >
-                                <ForwardRef(MenuList)
-                                  actions={
-                                    Object {
-                                      "current": Object {
-                                        "adjustStyleForScrollbar": [Function],
-                                      },
-                                    }
-                                  }
-                                  autoFocus={false}
-                                  autoFocusItem={false}
-                                  className="MuiMenu-list"
-                                  onKeyDown={[Function]}
-                                  variant="selectedMenu"
-                                >
-                                  <WithStyles(ForwardRef(List))
-                                    className="MuiMenu-list"
-                                    onKeyDown={[Function]}
-                                    role="menu"
-                                    tabIndex={-1}
-                                  >
-                                    <ForwardRef(List)
-                                      className="MuiMenu-list"
-                                      classes={
-                                        Object {
-                                          "dense": "MuiList-dense",
-                                          "padding": "MuiList-padding",
-                                          "root": "MuiList-root",
-                                          "subheader": "MuiList-subheader",
-                                        }
-                                      }
-                                      onKeyDown={[Function]}
-                                      role="menu"
-                                      tabIndex={-1}
-                                    >
-                                      <ul
-                                        className="MuiList-root MuiMenu-list MuiList-padding"
-                                        onKeyDown={[Function]}
-                                        role="menu"
-                                        tabIndex={-1}
-                                      >
-                                        <WithStyles(ForwardRef(MenuItem))
-                                          data-ga="MenuItem(all)"
-                                          key=".$.$all"
-                                          onClick={[Function]}
-                                          tabIndex={0}
-                                        >
-                                          <ForwardRef(MenuItem)
-                                            classes={
-                                              Object {
-                                                "dense": "MuiMenuItem-dense",
-                                                "gutters": "MuiMenuItem-gutters",
-                                                "root": "MuiMenuItem-root",
-                                                "selected": "Mui-selected",
-                                              }
-                                            }
-                                            data-ga="MenuItem(all)"
-                                            onClick={[Function]}
-                                            tabIndex={0}
-                                          >
-                                            <WithStyles(ForwardRef(ListItem))
-                                              button={true}
-                                              className="MuiMenuItem-root MuiMenuItem-gutters"
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                }
-                                              }
-                                              component="li"
-                                              data-ga="MenuItem(all)"
-                                              disableGutters={false}
-                                              onClick={[Function]}
-                                              role="menuitem"
-                                              tabIndex={0}
-                                            >
-                                              <ForwardRef(ListItem)
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                    "button": "MuiListItem-button",
-                                                    "container": "MuiListItem-container",
-                                                    "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                    "disabled": "Mui-disabled",
-                                                    "divider": "MuiListItem-divider",
-                                                    "focusVisible": "Mui-focusVisible",
-                                                    "gutters": "MuiListItem-gutters",
-                                                    "root": "MuiListItem-root",
-                                                    "secondaryAction": "MuiListItem-secondaryAction",
-                                                    "selected": "Mui-selected",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(all)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={0}
-                                              >
-                                                <WithStyles(ForwardRef(ButtonBase))
-                                                  className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                  component="li"
-                                                  data-ga="MenuItem(all)"
-                                                  disabled={false}
-                                                  focusVisibleClassName="Mui-focusVisible"
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={0}
-                                                >
-                                                  <ForwardRef(ButtonBase)
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    classes={
-                                                      Object {
-                                                        "disabled": "Mui-disabled",
-                                                        "focusVisible": "Mui-focusVisible",
-                                                        "root": "MuiButtonBase-root",
-                                                      }
-                                                    }
-                                                    component="li"
-                                                    data-ga="MenuItem(all)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={0}
-                                                  >
-                                                    <li
-                                                      aria-disabled={false}
-                                                      className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      data-ga="MenuItem(all)"
-                                                      onBlur={[Function]}
-                                                      onClick={[Function]}
-                                                      onDragLeave={[Function]}
-                                                      onFocus={[Function]}
-                                                      onKeyDown={[Function]}
-                                                      onKeyUp={[Function]}
-                                                      onMouseDown={[Function]}
-                                                      onMouseLeave={[Function]}
-                                                      onMouseUp={[Function]}
-                                                      onTouchEnd={[Function]}
-                                                      onTouchMove={[Function]}
-                                                      onTouchStart={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={0}
-                                                    >
-                                                      時間不限
-                                                      <NoSsr>
-                                                        <WithStyles(memo)
-                                                          center={false}
-                                                        >
-                                                          <ForwardRef(TouchRipple)
-                                                            center={false}
-                                                            classes={
-                                                              Object {
-                                                                "child": "MuiTouchRipple-child",
-                                                                "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                "ripple": "MuiTouchRipple-ripple",
-                                                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                "root": "MuiTouchRipple-root",
-                                                              }
-                                                            }
-                                                          >
-                                                            <span
-                                                              className="MuiTouchRipple-root"
-                                                            >
-                                                              <TransitionGroup
-                                                                childFactory={[Function]}
-                                                                component={null}
-                                                                exit={true}
-                                                              />
-                                                            </span>
-                                                          </ForwardRef(TouchRipple)>
-                                                        </WithStyles(memo)>
-                                                      </NoSsr>
-                                                    </li>
-                                                  </ForwardRef(ButtonBase)>
-                                                </WithStyles(ForwardRef(ButtonBase))>
-                                              </ForwardRef(ListItem)>
-                                            </WithStyles(ForwardRef(ListItem))>
-                                          </ForwardRef(MenuItem)>
-                                        </WithStyles(ForwardRef(MenuItem))>
-                                        <WithStyles(ForwardRef(MenuItem))
-                                          data-ga="MenuItem(now-1d/d)"
-                                          key=".$.$now-1d/d"
-                                          onClick={[Function]}
-                                        >
-                                          <ForwardRef(MenuItem)
-                                            classes={
-                                              Object {
-                                                "dense": "MuiMenuItem-dense",
-                                                "gutters": "MuiMenuItem-gutters",
-                                                "root": "MuiMenuItem-root",
-                                                "selected": "Mui-selected",
-                                              }
-                                            }
-                                            data-ga="MenuItem(now-1d/d)"
-                                            onClick={[Function]}
-                                          >
-                                            <WithStyles(ForwardRef(ListItem))
-                                              button={true}
-                                              className="MuiMenuItem-root MuiMenuItem-gutters"
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                }
-                                              }
-                                              component="li"
-                                              data-ga="MenuItem(now-1d/d)"
-                                              disableGutters={false}
-                                              onClick={[Function]}
-                                              role="menuitem"
-                                              tabIndex={-1}
-                                            >
-                                              <ForwardRef(ListItem)
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                    "button": "MuiListItem-button",
-                                                    "container": "MuiListItem-container",
-                                                    "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                    "disabled": "Mui-disabled",
-                                                    "divider": "MuiListItem-divider",
-                                                    "focusVisible": "Mui-focusVisible",
-                                                    "gutters": "MuiListItem-gutters",
-                                                    "root": "MuiListItem-root",
-                                                    "secondaryAction": "MuiListItem-secondaryAction",
-                                                    "selected": "Mui-selected",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(now-1d/d)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <WithStyles(ForwardRef(ButtonBase))
-                                                  className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                  component="li"
-                                                  data-ga="MenuItem(now-1d/d)"
-                                                  disabled={false}
-                                                  focusVisibleClassName="Mui-focusVisible"
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <ForwardRef(ButtonBase)
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    classes={
-                                                      Object {
-                                                        "disabled": "Mui-disabled",
-                                                        "focusVisible": "Mui-focusVisible",
-                                                        "root": "MuiButtonBase-root",
-                                                      }
-                                                    }
-                                                    component="li"
-                                                    data-ga="MenuItem(now-1d/d)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <li
-                                                      aria-disabled={false}
-                                                      className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      data-ga="MenuItem(now-1d/d)"
-                                                      onBlur={[Function]}
-                                                      onClick={[Function]}
-                                                      onDragLeave={[Function]}
-                                                      onFocus={[Function]}
-                                                      onKeyDown={[Function]}
-                                                      onKeyUp={[Function]}
-                                                      onMouseDown={[Function]}
-                                                      onMouseLeave={[Function]}
-                                                      onMouseUp={[Function]}
-                                                      onTouchEnd={[Function]}
-                                                      onTouchMove={[Function]}
-                                                      onTouchStart={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      一天內
-                                                      <NoSsr>
-                                                        <WithStyles(memo)
-                                                          center={false}
-                                                        >
-                                                          <ForwardRef(TouchRipple)
-                                                            center={false}
-                                                            classes={
-                                                              Object {
-                                                                "child": "MuiTouchRipple-child",
-                                                                "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                "ripple": "MuiTouchRipple-ripple",
-                                                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                "root": "MuiTouchRipple-root",
-                                                              }
-                                                            }
-                                                          >
-                                                            <span
-                                                              className="MuiTouchRipple-root"
-                                                            >
-                                                              <TransitionGroup
-                                                                childFactory={[Function]}
-                                                                component={null}
-                                                                exit={true}
-                                                              />
-                                                            </span>
-                                                          </ForwardRef(TouchRipple)>
-                                                        </WithStyles(memo)>
-                                                      </NoSsr>
-                                                    </li>
-                                                  </ForwardRef(ButtonBase)>
-                                                </WithStyles(ForwardRef(ButtonBase))>
-                                              </ForwardRef(ListItem)>
-                                            </WithStyles(ForwardRef(ListItem))>
-                                          </ForwardRef(MenuItem)>
-                                        </WithStyles(ForwardRef(MenuItem))>
-                                        <WithStyles(ForwardRef(MenuItem))
-                                          data-ga="MenuItem(now-1w/d)"
-                                          key=".$.$now-1w/d"
-                                          onClick={[Function]}
-                                        >
-                                          <ForwardRef(MenuItem)
-                                            classes={
-                                              Object {
-                                                "dense": "MuiMenuItem-dense",
-                                                "gutters": "MuiMenuItem-gutters",
-                                                "root": "MuiMenuItem-root",
-                                                "selected": "Mui-selected",
-                                              }
-                                            }
-                                            data-ga="MenuItem(now-1w/d)"
-                                            onClick={[Function]}
-                                          >
-                                            <WithStyles(ForwardRef(ListItem))
-                                              button={true}
-                                              className="MuiMenuItem-root MuiMenuItem-gutters"
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                }
-                                              }
-                                              component="li"
-                                              data-ga="MenuItem(now-1w/d)"
-                                              disableGutters={false}
-                                              onClick={[Function]}
-                                              role="menuitem"
-                                              tabIndex={-1}
-                                            >
-                                              <ForwardRef(ListItem)
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                    "button": "MuiListItem-button",
-                                                    "container": "MuiListItem-container",
-                                                    "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                    "disabled": "Mui-disabled",
-                                                    "divider": "MuiListItem-divider",
-                                                    "focusVisible": "Mui-focusVisible",
-                                                    "gutters": "MuiListItem-gutters",
-                                                    "root": "MuiListItem-root",
-                                                    "secondaryAction": "MuiListItem-secondaryAction",
-                                                    "selected": "Mui-selected",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(now-1w/d)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <WithStyles(ForwardRef(ButtonBase))
-                                                  className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                  component="li"
-                                                  data-ga="MenuItem(now-1w/d)"
-                                                  disabled={false}
-                                                  focusVisibleClassName="Mui-focusVisible"
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <ForwardRef(ButtonBase)
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    classes={
-                                                      Object {
-                                                        "disabled": "Mui-disabled",
-                                                        "focusVisible": "Mui-focusVisible",
-                                                        "root": "MuiButtonBase-root",
-                                                      }
-                                                    }
-                                                    component="li"
-                                                    data-ga="MenuItem(now-1w/d)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <li
-                                                      aria-disabled={false}
-                                                      className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      data-ga="MenuItem(now-1w/d)"
-                                                      onBlur={[Function]}
-                                                      onClick={[Function]}
-                                                      onDragLeave={[Function]}
-                                                      onFocus={[Function]}
-                                                      onKeyDown={[Function]}
-                                                      onKeyUp={[Function]}
-                                                      onMouseDown={[Function]}
-                                                      onMouseLeave={[Function]}
-                                                      onMouseUp={[Function]}
-                                                      onTouchEnd={[Function]}
-                                                      onTouchMove={[Function]}
-                                                      onTouchStart={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      一週內
-                                                      <NoSsr>
-                                                        <WithStyles(memo)
-                                                          center={false}
-                                                        >
-                                                          <ForwardRef(TouchRipple)
-                                                            center={false}
-                                                            classes={
-                                                              Object {
-                                                                "child": "MuiTouchRipple-child",
-                                                                "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                "ripple": "MuiTouchRipple-ripple",
-                                                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                "root": "MuiTouchRipple-root",
-                                                              }
-                                                            }
-                                                          >
-                                                            <span
-                                                              className="MuiTouchRipple-root"
-                                                            >
-                                                              <TransitionGroup
-                                                                childFactory={[Function]}
-                                                                component={null}
-                                                                exit={true}
-                                                              />
-                                                            </span>
-                                                          </ForwardRef(TouchRipple)>
-                                                        </WithStyles(memo)>
-                                                      </NoSsr>
-                                                    </li>
-                                                  </ForwardRef(ButtonBase)>
-                                                </WithStyles(ForwardRef(ButtonBase))>
-                                              </ForwardRef(ListItem)>
-                                            </WithStyles(ForwardRef(ListItem))>
-                                          </ForwardRef(MenuItem)>
-                                        </WithStyles(ForwardRef(MenuItem))>
-                                        <WithStyles(ForwardRef(MenuItem))
-                                          data-ga="MenuItem(now-1m/d)"
-                                          key=".$.$now-1m/d"
-                                          onClick={[Function]}
-                                        >
-                                          <ForwardRef(MenuItem)
-                                            classes={
-                                              Object {
-                                                "dense": "MuiMenuItem-dense",
-                                                "gutters": "MuiMenuItem-gutters",
-                                                "root": "MuiMenuItem-root",
-                                                "selected": "Mui-selected",
-                                              }
-                                            }
-                                            data-ga="MenuItem(now-1m/d)"
-                                            onClick={[Function]}
-                                          >
-                                            <WithStyles(ForwardRef(ListItem))
-                                              button={true}
-                                              className="MuiMenuItem-root MuiMenuItem-gutters"
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                }
-                                              }
-                                              component="li"
-                                              data-ga="MenuItem(now-1m/d)"
-                                              disableGutters={false}
-                                              onClick={[Function]}
-                                              role="menuitem"
-                                              tabIndex={-1}
-                                            >
-                                              <ForwardRef(ListItem)
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                    "button": "MuiListItem-button",
-                                                    "container": "MuiListItem-container",
-                                                    "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                    "disabled": "Mui-disabled",
-                                                    "divider": "MuiListItem-divider",
-                                                    "focusVisible": "Mui-focusVisible",
-                                                    "gutters": "MuiListItem-gutters",
-                                                    "root": "MuiListItem-root",
-                                                    "secondaryAction": "MuiListItem-secondaryAction",
-                                                    "selected": "Mui-selected",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(now-1m/d)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <WithStyles(ForwardRef(ButtonBase))
-                                                  className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                  component="li"
-                                                  data-ga="MenuItem(now-1m/d)"
-                                                  disabled={false}
-                                                  focusVisibleClassName="Mui-focusVisible"
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <ForwardRef(ButtonBase)
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    classes={
-                                                      Object {
-                                                        "disabled": "Mui-disabled",
-                                                        "focusVisible": "Mui-focusVisible",
-                                                        "root": "MuiButtonBase-root",
-                                                      }
-                                                    }
-                                                    component="li"
-                                                    data-ga="MenuItem(now-1m/d)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <li
-                                                      aria-disabled={false}
-                                                      className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      data-ga="MenuItem(now-1m/d)"
-                                                      onBlur={[Function]}
-                                                      onClick={[Function]}
-                                                      onDragLeave={[Function]}
-                                                      onFocus={[Function]}
-                                                      onKeyDown={[Function]}
-                                                      onKeyUp={[Function]}
-                                                      onMouseDown={[Function]}
-                                                      onMouseLeave={[Function]}
-                                                      onMouseUp={[Function]}
-                                                      onTouchEnd={[Function]}
-                                                      onTouchMove={[Function]}
-                                                      onTouchStart={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      一個月內
-                                                      <NoSsr>
-                                                        <WithStyles(memo)
-                                                          center={false}
-                                                        >
-                                                          <ForwardRef(TouchRipple)
-                                                            center={false}
-                                                            classes={
-                                                              Object {
-                                                                "child": "MuiTouchRipple-child",
-                                                                "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                "ripple": "MuiTouchRipple-ripple",
-                                                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                "root": "MuiTouchRipple-root",
-                                                              }
-                                                            }
-                                                          >
-                                                            <span
-                                                              className="MuiTouchRipple-root"
-                                                            >
-                                                              <TransitionGroup
-                                                                childFactory={[Function]}
-                                                                component={null}
-                                                                exit={true}
-                                                              />
-                                                            </span>
-                                                          </ForwardRef(TouchRipple)>
-                                                        </WithStyles(memo)>
-                                                      </NoSsr>
-                                                    </li>
-                                                  </ForwardRef(ButtonBase)>
-                                                </WithStyles(ForwardRef(ButtonBase))>
-                                              </ForwardRef(ListItem)>
-                                            </WithStyles(ForwardRef(ListItem))>
-                                          </ForwardRef(MenuItem)>
-                                        </WithStyles(ForwardRef(MenuItem))>
-                                        <WithStyles(ForwardRef(MenuItem))
-                                          data-ga="MenuItem(custom)"
-                                          key=".$.$custom"
-                                          onClick={[Function]}
-                                        >
-                                          <ForwardRef(MenuItem)
-                                            classes={
-                                              Object {
-                                                "dense": "MuiMenuItem-dense",
-                                                "gutters": "MuiMenuItem-gutters",
-                                                "root": "MuiMenuItem-root",
-                                                "selected": "Mui-selected",
-                                              }
-                                            }
-                                            data-ga="MenuItem(custom)"
-                                            onClick={[Function]}
-                                          >
-                                            <WithStyles(ForwardRef(ListItem))
-                                              button={true}
-                                              className="MuiMenuItem-root MuiMenuItem-gutters"
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                }
-                                              }
-                                              component="li"
-                                              data-ga="MenuItem(custom)"
-                                              disableGutters={false}
-                                              onClick={[Function]}
-                                              role="menuitem"
-                                              tabIndex={-1}
-                                            >
-                                              <ForwardRef(ListItem)
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                    "button": "MuiListItem-button",
-                                                    "container": "MuiListItem-container",
-                                                    "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                    "disabled": "Mui-disabled",
-                                                    "divider": "MuiListItem-divider",
-                                                    "focusVisible": "Mui-focusVisible",
-                                                    "gutters": "MuiListItem-gutters",
-                                                    "root": "MuiListItem-root",
-                                                    "secondaryAction": "MuiListItem-secondaryAction",
-                                                    "selected": "Mui-selected",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(custom)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <WithStyles(ForwardRef(ButtonBase))
-                                                  className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                  component="li"
-                                                  data-ga="MenuItem(custom)"
-                                                  disabled={false}
-                                                  focusVisibleClassName="Mui-focusVisible"
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <ForwardRef(ButtonBase)
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    classes={
-                                                      Object {
-                                                        "disabled": "Mui-disabled",
-                                                        "focusVisible": "Mui-focusVisible",
-                                                        "root": "MuiButtonBase-root",
-                                                      }
-                                                    }
-                                                    component="li"
-                                                    data-ga="MenuItem(custom)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <li
-                                                      aria-disabled={false}
-                                                      className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      data-ga="MenuItem(custom)"
-                                                      onBlur={[Function]}
-                                                      onClick={[Function]}
-                                                      onDragLeave={[Function]}
-                                                      onFocus={[Function]}
-                                                      onKeyDown={[Function]}
-                                                      onKeyUp={[Function]}
-                                                      onMouseDown={[Function]}
-                                                      onMouseLeave={[Function]}
-                                                      onMouseUp={[Function]}
-                                                      onTouchEnd={[Function]}
-                                                      onTouchMove={[Function]}
-                                                      onTouchStart={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      自訂範圍
-                                                      <NoSsr>
-                                                        <WithStyles(memo)
-                                                          center={false}
-                                                        >
-                                                          <ForwardRef(TouchRipple)
-                                                            center={false}
-                                                            classes={
-                                                              Object {
-                                                                "child": "MuiTouchRipple-child",
-                                                                "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                "ripple": "MuiTouchRipple-ripple",
-                                                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                "root": "MuiTouchRipple-root",
-                                                              }
-                                                            }
-                                                          >
-                                                            <span
-                                                              className="MuiTouchRipple-root"
-                                                            >
-                                                              <TransitionGroup
-                                                                childFactory={[Function]}
-                                                                component={null}
-                                                                exit={true}
-                                                              />
-                                                            </span>
-                                                          </ForwardRef(TouchRipple)>
-                                                        </WithStyles(memo)>
-                                                      </NoSsr>
-                                                    </li>
-                                                  </ForwardRef(ButtonBase)>
-                                                </WithStyles(ForwardRef(ButtonBase))>
-                                              </ForwardRef(ListItem)>
-                                            </WithStyles(ForwardRef(ListItem))>
-                                          </ForwardRef(MenuItem)>
-                                        </WithStyles(ForwardRef(MenuItem))>
-                                      </ul>
-                                    </ForwardRef(List)>
-                                  </WithStyles(ForwardRef(List))>
-                                </ForwardRef(MenuList)>
-                              </div>
-                            </ForwardRef(Paper)>
-                          </WithStyles(ForwardRef(Paper))>
-                        </Transition>
-                      </ForwardRef(Grow)>
-                      <div
-                        data-test="sentinelEnd"
-                        tabIndex={0}
+                    </span>
+                  </NoSsr>
+                </li>
+                <li
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                  data-ga="MenuItem(now-1d/d)"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="menuitem"
+                  tabIndex={-1}
+                >
+                  一天內
+                  <NoSsr>
+                    <span
+                      className="MuiTouchRipple-root"
+                    >
+                      <TransitionGroup
+                        childFactory={[Function]}
+                        component={null}
+                        exit={true}
                       />
-                    </TrapFocus>
-                  </div>
-                </Portal>
-              </ForwardRef(Portal)>
-            </ForwardRef(Modal)>
-          </ForwardRef(Popover)>
-        </WithStyles(ForwardRef(Popover))>
-      </ForwardRef(Menu)>
-    </WithStyles(ForwardRef(Menu))>
+                    </span>
+                  </NoSsr>
+                </li>
+                <li
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                  data-ga="MenuItem(now-1w/d)"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="menuitem"
+                  tabIndex={-1}
+                >
+                  一週內
+                  <NoSsr>
+                    <span
+                      className="MuiTouchRipple-root"
+                    >
+                      <TransitionGroup
+                        childFactory={[Function]}
+                        component={null}
+                        exit={true}
+                      />
+                    </span>
+                  </NoSsr>
+                </li>
+                <li
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                  data-ga="MenuItem(now-1m/d)"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="menuitem"
+                  tabIndex={-1}
+                >
+                  一個月內
+                  <NoSsr>
+                    <span
+                      className="MuiTouchRipple-root"
+                    >
+                      <TransitionGroup
+                        childFactory={[Function]}
+                        component={null}
+                        exit={true}
+                      />
+                    </span>
+                  </NoSsr>
+                </li>
+                <li
+                  aria-disabled={false}
+                  className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                  data-ga="MenuItem(custom)"
+                  onBlur={[Function]}
+                  onClick={[Function]}
+                  onDragLeave={[Function]}
+                  onFocus={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseLeave={[Function]}
+                  onMouseUp={[Function]}
+                  onTouchEnd={[Function]}
+                  onTouchMove={[Function]}
+                  onTouchStart={[Function]}
+                  role="menuitem"
+                  tabIndex={-1}
+                >
+                  自訂範圍
+                  <NoSsr>
+                    <span
+                      className="MuiTouchRipple-root"
+                    >
+                      <TransitionGroup
+                        childFactory={[Function]}
+                        component={null}
+                        exit={true}
+                      />
+                    </span>
+                  </NoSsr>
+                </li>
+              </ul>
+            </div>
+          </Transition>
+          <div
+            data-test="sentinelEnd"
+            tabIndex={0}
+          />
+        </TrapFocus>
+      </div>
+    </Portal>
   </div>
 </TimeRange>
 `;
@@ -1476,1635 +318,301 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
     <div
       className="makeStyles-root-134"
     >
-      <WithStyles(ForwardRef(ButtonGroup))
-        classes={
-          Object {
-            "contained": "makeStyles-buttonGroup-135",
-          }
-        }
+      <div
+        className="MuiButtonGroup-root"
+        role="group"
       >
-        <ForwardRef(ButtonGroup)
-          classes={
-            Object {
-              "contained": "MuiButtonGroup-contained makeStyles-buttonGroup-135",
-              "disabled": "Mui-disabled",
-              "fullWidth": "MuiButtonGroup-fullWidth",
-              "grouped": "MuiButtonGroup-grouped",
-              "groupedContained": "MuiButtonGroup-groupedContained",
-              "groupedContainedHorizontal": "MuiButtonGroup-groupedContainedHorizontal",
-              "groupedContainedPrimary": "MuiButtonGroup-groupedContainedPrimary",
-              "groupedContainedSecondary": "MuiButtonGroup-groupedContainedSecondary",
-              "groupedContainedVertical": "MuiButtonGroup-groupedContainedVertical",
-              "groupedHorizontal": "MuiButtonGroup-groupedHorizontal",
-              "groupedOutlined": "MuiButtonGroup-groupedOutlined",
-              "groupedOutlinedHorizontal": "MuiButtonGroup-groupedOutlinedHorizontal",
-              "groupedOutlinedPrimary": "MuiButtonGroup-groupedOutlinedPrimary",
-              "groupedOutlinedSecondary": "MuiButtonGroup-groupedOutlinedSecondary",
-              "groupedOutlinedVertical": "MuiButtonGroup-groupedOutlinedVertical",
-              "groupedText": "MuiButtonGroup-groupedText",
-              "groupedTextHorizontal": "MuiButtonGroup-groupedTextHorizontal",
-              "groupedTextPrimary": "MuiButtonGroup-groupedTextPrimary",
-              "groupedTextSecondary": "MuiButtonGroup-groupedTextSecondary",
-              "groupedTextVertical": "MuiButtonGroup-groupedTextVertical",
-              "groupedVertical": "MuiButtonGroup-groupedVertical",
-              "root": "MuiButtonGroup-root",
-              "vertical": "MuiButtonGroup-vertical",
-            }
-          }
+        <button
+          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
         >
-          <div
-            className="MuiButtonGroup-root"
-            role="group"
+          <span
+            className="MuiButton-label"
           >
-            <WithStyles(ForwardRef(Button))
-              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-              color="default"
-              disableFocusRipple={false}
-              disableRipple={false}
-              disabled={false}
-              fullWidth={false}
-              key=".0"
-              onClick={[Function]}
-              size="medium"
-              variant="outlined"
+            <svg
+              aria-hidden="true"
+              className="MuiSvgIcon-root makeStyles-calendarIcon-137"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              <ForwardRef(Button)
-                className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-                classes={
-                  Object {
-                    "colorInherit": "MuiButton-colorInherit",
-                    "contained": "MuiButton-contained",
-                    "containedPrimary": "MuiButton-containedPrimary",
-                    "containedSecondary": "MuiButton-containedSecondary",
-                    "containedSizeLarge": "MuiButton-containedSizeLarge",
-                    "containedSizeSmall": "MuiButton-containedSizeSmall",
-                    "disableElevation": "MuiButton-disableElevation",
-                    "disabled": "Mui-disabled",
-                    "endIcon": "MuiButton-endIcon",
-                    "focusVisible": "Mui-focusVisible",
-                    "fullWidth": "MuiButton-fullWidth",
-                    "iconSizeLarge": "MuiButton-iconSizeLarge",
-                    "iconSizeMedium": "MuiButton-iconSizeMedium",
-                    "iconSizeSmall": "MuiButton-iconSizeSmall",
-                    "label": "MuiButton-label",
-                    "outlined": "MuiButton-outlined",
-                    "outlinedPrimary": "MuiButton-outlinedPrimary",
-                    "outlinedSecondary": "MuiButton-outlinedSecondary",
-                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                    "root": "MuiButton-root",
-                    "sizeLarge": "MuiButton-sizeLarge",
-                    "sizeSmall": "MuiButton-sizeSmall",
-                    "startIcon": "MuiButton-startIcon",
-                    "text": "MuiButton-text",
-                    "textPrimary": "MuiButton-textPrimary",
-                    "textSecondary": "MuiButton-textSecondary",
-                    "textSizeLarge": "MuiButton-textSizeLarge",
-                    "textSizeSmall": "MuiButton-textSizeSmall",
-                  }
-                }
-                color="default"
-                disableFocusRipple={false}
-                disableRipple={false}
-                disabled={false}
-                fullWidth={false}
-                onClick={[Function]}
-                size="medium"
-                variant="outlined"
-              >
-                <WithStyles(ForwardRef(ButtonBase))
-                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-                  component="button"
-                  disableRipple={false}
-                  disabled={false}
-                  focusRipple={true}
-                  focusVisibleClassName="Mui-focusVisible"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <ForwardRef(ButtonBase)
-                    className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-                    classes={
-                      Object {
-                        "disabled": "Mui-disabled",
-                        "focusVisible": "Mui-focusVisible",
-                        "root": "MuiButtonBase-root",
-                      }
-                    }
-                    component="button"
-                    disableRipple={false}
-                    disabled={false}
-                    focusRipple={true}
-                    focusVisibleClassName="Mui-focusVisible"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <button
-                      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-                      disabled={false}
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onDragLeave={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyUp={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="MuiButton-label"
-                      >
-                        <ForwardRef
-                          className="makeStyles-calendarIcon-137"
-                        >
-                          <WithStyles(ForwardRef(SvgIcon))
-                            className="makeStyles-calendarIcon-137"
-                          >
-                            <ForwardRef(SvgIcon)
-                              className="makeStyles-calendarIcon-137"
-                              classes={
-                                Object {
-                                  "colorAction": "MuiSvgIcon-colorAction",
-                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                  "colorError": "MuiSvgIcon-colorError",
-                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                  "root": "MuiSvgIcon-root",
-                                }
-                              }
-                            >
-                              <svg
-                                aria-hidden="true"
-                                className="MuiSvgIcon-root makeStyles-calendarIcon-137"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"
-                                />
-                              </svg>
-                            </ForwardRef(SvgIcon)>
-                          </WithStyles(ForwardRef(SvgIcon))>
-                        </ForwardRef>
-                      </span>
-                      <NoSsr>
-                        <WithStyles(memo)
-                          center={false}
-                        >
-                          <ForwardRef(TouchRipple)
-                            center={false}
-                            classes={
-                              Object {
-                                "child": "MuiTouchRipple-child",
-                                "childLeaving": "MuiTouchRipple-childLeaving",
-                                "childPulsate": "MuiTouchRipple-childPulsate",
-                                "ripple": "MuiTouchRipple-ripple",
-                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                "root": "MuiTouchRipple-root",
-                              }
-                            }
-                          >
-                            <span
-                              className="MuiTouchRipple-root"
-                            >
-                              <TransitionGroup
-                                childFactory={[Function]}
-                                component={null}
-                                exit={true}
-                              />
-                            </span>
-                          </ForwardRef(TouchRipple)>
-                        </WithStyles(memo)>
-                      </NoSsr>
-                    </button>
-                  </ForwardRef(ButtonBase)>
-                </WithStyles(ForwardRef(ButtonBase))>
-              </ForwardRef(Button)>
-            </WithStyles(ForwardRef(Button))>
-            <WithStyles(ForwardRef(Button))
-              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
-              color="default"
-              disableFocusRipple={false}
-              disableRipple={false}
-              disabled={false}
-              fullWidth={false}
-              key=".1"
-              onClick={[Function]}
-              size="medium"
-              variant="outlined"
+              <path
+                d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"
+              />
+            </svg>
+          </span>
+          <NoSsr>
+            <span
+              className="MuiTouchRipple-root"
             >
-              <ForwardRef(Button)
-                className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
-                classes={
-                  Object {
-                    "colorInherit": "MuiButton-colorInherit",
-                    "contained": "MuiButton-contained",
-                    "containedPrimary": "MuiButton-containedPrimary",
-                    "containedSecondary": "MuiButton-containedSecondary",
-                    "containedSizeLarge": "MuiButton-containedSizeLarge",
-                    "containedSizeSmall": "MuiButton-containedSizeSmall",
-                    "disableElevation": "MuiButton-disableElevation",
-                    "disabled": "Mui-disabled",
-                    "endIcon": "MuiButton-endIcon",
-                    "focusVisible": "Mui-focusVisible",
-                    "fullWidth": "MuiButton-fullWidth",
-                    "iconSizeLarge": "MuiButton-iconSizeLarge",
-                    "iconSizeMedium": "MuiButton-iconSizeMedium",
-                    "iconSizeSmall": "MuiButton-iconSizeSmall",
-                    "label": "MuiButton-label",
-                    "outlined": "MuiButton-outlined",
-                    "outlinedPrimary": "MuiButton-outlinedPrimary",
-                    "outlinedSecondary": "MuiButton-outlinedSecondary",
-                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                    "root": "MuiButton-root",
-                    "sizeLarge": "MuiButton-sizeLarge",
-                    "sizeSmall": "MuiButton-sizeSmall",
-                    "startIcon": "MuiButton-startIcon",
-                    "text": "MuiButton-text",
-                    "textPrimary": "MuiButton-textPrimary",
-                    "textSecondary": "MuiButton-textSecondary",
-                    "textSizeLarge": "MuiButton-textSizeLarge",
-                    "textSizeSmall": "MuiButton-textSizeSmall",
-                  }
-                }
-                color="default"
-                disableFocusRipple={false}
-                disableRipple={false}
-                disabled={false}
-                fullWidth={false}
-                onClick={[Function]}
-                size="medium"
-                variant="outlined"
-              >
-                <WithStyles(ForwardRef(ButtonBase))
-                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
-                  component="button"
-                  disableRipple={false}
-                  disabled={false}
-                  focusRipple={true}
-                  focusVisibleClassName="Mui-focusVisible"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <ForwardRef(ButtonBase)
-                    className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
-                    classes={
-                      Object {
-                        "disabled": "Mui-disabled",
-                        "focusVisible": "Mui-focusVisible",
-                        "root": "MuiButtonBase-root",
-                      }
-                    }
-                    component="button"
-                    disableRipple={false}
-                    disabled={false}
-                    focusRipple={true}
-                    focusVisibleClassName="Mui-focusVisible"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <button
-                      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
-                      disabled={false}
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onDragLeave={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyUp={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="MuiButton-label"
-                      >
-                        時間不限
-                      </span>
-                      <NoSsr>
-                        <WithStyles(memo)
-                          center={false}
-                        >
-                          <ForwardRef(TouchRipple)
-                            center={false}
-                            classes={
-                              Object {
-                                "child": "MuiTouchRipple-child",
-                                "childLeaving": "MuiTouchRipple-childLeaving",
-                                "childPulsate": "MuiTouchRipple-childPulsate",
-                                "ripple": "MuiTouchRipple-ripple",
-                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                "root": "MuiTouchRipple-root",
-                              }
-                            }
-                          >
-                            <span
-                              className="MuiTouchRipple-root"
-                            >
-                              <TransitionGroup
-                                childFactory={[Function]}
-                                component={null}
-                                exit={true}
-                              />
-                            </span>
-                          </ForwardRef(TouchRipple)>
-                        </WithStyles(memo)>
-                      </NoSsr>
-                    </button>
-                  </ForwardRef(ButtonBase)>
-                </WithStyles(ForwardRef(ButtonBase))>
-              </ForwardRef(Button)>
-            </WithStyles(ForwardRef(Button))>
-          </div>
-        </ForwardRef(ButtonGroup)>
-      </WithStyles(ForwardRef(ButtonGroup))>
-      <WithStyles(ForwardRef(Menu))
-        anchorEl={null}
-        id="time-range"
-        keepMounted={true}
-        onClose={[Function]}
-        open={false}
-      >
-        <ForwardRef(Menu)
-          anchorEl={null}
-          classes={
-            Object {
-              "list": "MuiMenu-list",
-              "paper": "MuiMenu-paper",
-            }
-          }
+              <TransitionGroup
+                childFactory={[Function]}
+                component={null}
+                exit={true}
+              />
+            </span>
+          </NoSsr>
+        </button>
+        <button
+          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="MuiButton-label"
+          >
+            時間不限
+          </span>
+          <NoSsr>
+            <span
+              className="MuiTouchRipple-root"
+            >
+              <TransitionGroup
+                childFactory={[Function]}
+                component={null}
+                exit={true}
+              />
+            </span>
+          </NoSsr>
+        </button>
+      </div>
+      <Portal>
+        <div
+          className="MuiPopover-root"
           id="time-range"
-          keepMounted={true}
-          onClose={[Function]}
-          open={false}
+          onKeyDown={[Function]}
+          role="presentation"
+          style={
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "position": "fixed",
+              "right": 0,
+              "top": 0,
+              "visibility": "hidden",
+              "zIndex": 1300,
+            }
+          }
         >
-          <WithStyles(ForwardRef(Popover))
-            PaperProps={
-              Object {
-                "classes": Object {
-                  "root": "MuiMenu-paper",
-                },
-              }
-            }
-            anchorEl={null}
-            anchorOrigin={
-              Object {
-                "horizontal": "left",
-                "vertical": "top",
-              }
-            }
-            getContentAnchorEl={[Function]}
-            id="time-range"
-            keepMounted={true}
-            onClose={[Function]}
-            onEntering={[Function]}
-            open={false}
-            transformOrigin={
-              Object {
-                "horizontal": "left",
-                "vertical": "top",
-              }
-            }
-            transitionDuration="auto"
-          >
-            <ForwardRef(Popover)
-              PaperProps={
-                Object {
-                  "classes": Object {
-                    "root": "MuiMenu-paper",
-                  },
-                }
-              }
-              anchorEl={null}
-              anchorOrigin={
-                Object {
-                  "horizontal": "left",
-                  "vertical": "top",
-                }
-              }
-              classes={
-                Object {
-                  "paper": "MuiPopover-paper",
-                  "root": "MuiPopover-root",
-                }
-              }
-              getContentAnchorEl={[Function]}
-              id="time-range"
-              keepMounted={true}
-              onClose={[Function]}
-              onEntering={[Function]}
-              open={false}
-              transformOrigin={
-                Object {
-                  "horizontal": "left",
-                  "vertical": "top",
-                }
-              }
-              transitionDuration="auto"
-            >
-              <ForwardRef(Modal)
-                BackdropProps={
+          <TrapFocus>
+            <div
+              data-test="sentinelStart"
+              tabIndex={0}
+            />
+            <Transition>
+              <div
+                className="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                style={
                   Object {
-                    "invisible": true,
+                    "opacity": 0,
+                    "transform": "scale(0.75, 0.5625)",
+                    "visibility": "hidden",
                   }
                 }
-                className="MuiPopover-root"
-                id="time-range"
-                keepMounted={true}
-                onClose={[Function]}
-                open={false}
+                tabIndex="-1"
               >
-                <ForwardRef(Portal)
-                  disablePortal={false}
+                <ul
+                  className="MuiList-root MuiMenu-list MuiList-padding"
+                  onKeyDown={[Function]}
+                  role="menu"
+                  tabIndex={-1}
                 >
-                  <Portal
-                    containerInfo={
-                      <body>
-                        <div
-                          aria-hidden="true"
-                          class="MuiPopover-root"
-                          id="time-range"
-                          role="presentation"
-                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
-                        >
-                          <div
-                            data-test="sentinelStart"
-                            tabindex="0"
-                          />
-                          <div
-                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
-                            tabindex="-1"
-                          >
-                            <ul
-                              class="MuiList-root MuiMenu-list MuiList-padding"
-                              role="menu"
-                              tabindex="-1"
-                            >
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(all)"
-                                role="menuitem"
-                                tabindex="0"
-                              >
-                                時間不限
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1d/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一天內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1w/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一週內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1m/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一個月內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(custom)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                自訂範圍
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                            </ul>
-                          </div>
-                          <div
-                            data-test="sentinelEnd"
-                            tabindex="0"
-                          />
-                        </div>
-                        <div
-                          aria-hidden="true"
-                          class="MuiPopover-root"
-                          id="time-range"
-                          role="presentation"
-                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
-                        >
-                          <div
-                            data-test="sentinelStart"
-                            tabindex="0"
-                          />
-                          <div
-                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
-                            tabindex="-1"
-                          >
-                            <ul
-                              class="MuiList-root MuiMenu-list MuiList-padding"
-                              role="menu"
-                              tabindex="-1"
-                            >
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(all)"
-                                role="menuitem"
-                                tabindex="0"
-                              >
-                                時間不限
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1d/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一天內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1w/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一週內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1m/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一個月內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(custom)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                自訂範圍
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                            </ul>
-                          </div>
-                          <div
-                            data-test="sentinelEnd"
-                            tabindex="0"
-                          />
-                        </div>
-                        <div
-                          aria-hidden="true"
-                          class="MuiPopover-root"
-                          id="time-range"
-                          role="presentation"
-                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
-                        >
-                          <div
-                            data-test="sentinelStart"
-                            tabindex="0"
-                          />
-                          <div
-                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
-                            tabindex="-1"
-                          >
-                            <ul
-                              class="MuiList-root MuiMenu-list MuiList-padding"
-                              role="menu"
-                              tabindex="-1"
-                            >
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(all)"
-                                role="menuitem"
-                                tabindex="0"
-                              >
-                                時間不限
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1d/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一天內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1w/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一週內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1m/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一個月內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(custom)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                自訂範圍
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                            </ul>
-                          </div>
-                          <div
-                            data-test="sentinelEnd"
-                            tabindex="0"
-                          />
-                        </div>
-                      </body>
-                    }
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(all)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={0}
                   >
-                    <div
-                      className="MuiPopover-root"
-                      id="time-range"
-                      onKeyDown={[Function]}
-                      role="presentation"
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "left": 0,
-                          "position": "fixed",
-                          "right": 0,
-                          "top": 0,
-                          "visibility": "hidden",
-                          "zIndex": 1300,
-                        }
-                      }
-                    >
-                      <ForwardRef(SimpleBackdrop)
-                        invisible={true}
-                        onClick={[Function]}
-                        open={false}
-                      />
-                      <TrapFocus
-                        disableAutoFocus={false}
-                        disableEnforceFocus={false}
-                        disableRestoreFocus={false}
-                        getDoc={[Function]}
-                        isEnabled={[Function]}
-                        open={false}
+                    時間不限
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
                       >
-                        <div
-                          data-test="sentinelStart"
-                          tabIndex={0}
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
                         />
-                        <ForwardRef(Grow)
-                          appear={true}
-                          in={false}
-                          onEnter={[Function]}
-                          onEntering={[Function]}
-                          onExited={[Function]}
-                          tabIndex="-1"
-                          timeout="auto"
-                        >
-                          <Transition
-                            addEndListener={[Function]}
-                            appear={true}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            tabIndex="-1"
-                            timeout={null}
-                            unmountOnExit={false}
-                          >
-                            <WithStyles(ForwardRef(Paper))
-                              className="MuiPopover-paper"
-                              classes={
-                                Object {
-                                  "root": "MuiMenu-paper",
-                                }
-                              }
-                              elevation={8}
-                              style={
-                                Object {
-                                  "opacity": 0,
-                                  "transform": "scale(0.75, 0.5625)",
-                                  "visibility": "hidden",
-                                }
-                              }
-                              tabIndex="-1"
-                            >
-                              <ForwardRef(Paper)
-                                className="MuiPopover-paper"
-                                classes={
-                                  Object {
-                                    "elevation0": "MuiPaper-elevation0",
-                                    "elevation1": "MuiPaper-elevation1",
-                                    "elevation10": "MuiPaper-elevation10",
-                                    "elevation11": "MuiPaper-elevation11",
-                                    "elevation12": "MuiPaper-elevation12",
-                                    "elevation13": "MuiPaper-elevation13",
-                                    "elevation14": "MuiPaper-elevation14",
-                                    "elevation15": "MuiPaper-elevation15",
-                                    "elevation16": "MuiPaper-elevation16",
-                                    "elevation17": "MuiPaper-elevation17",
-                                    "elevation18": "MuiPaper-elevation18",
-                                    "elevation19": "MuiPaper-elevation19",
-                                    "elevation2": "MuiPaper-elevation2",
-                                    "elevation20": "MuiPaper-elevation20",
-                                    "elevation21": "MuiPaper-elevation21",
-                                    "elevation22": "MuiPaper-elevation22",
-                                    "elevation23": "MuiPaper-elevation23",
-                                    "elevation24": "MuiPaper-elevation24",
-                                    "elevation3": "MuiPaper-elevation3",
-                                    "elevation4": "MuiPaper-elevation4",
-                                    "elevation5": "MuiPaper-elevation5",
-                                    "elevation6": "MuiPaper-elevation6",
-                                    "elevation7": "MuiPaper-elevation7",
-                                    "elevation8": "MuiPaper-elevation8",
-                                    "elevation9": "MuiPaper-elevation9",
-                                    "outlined": "MuiPaper-outlined",
-                                    "root": "MuiPaper-root MuiMenu-paper",
-                                    "rounded": "MuiPaper-rounded",
-                                  }
-                                }
-                                elevation={8}
-                                style={
-                                  Object {
-                                    "opacity": 0,
-                                    "transform": "scale(0.75, 0.5625)",
-                                    "visibility": "hidden",
-                                  }
-                                }
-                                tabIndex="-1"
-                              >
-                                <div
-                                  className="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                                  style={
-                                    Object {
-                                      "opacity": 0,
-                                      "transform": "scale(0.75, 0.5625)",
-                                      "visibility": "hidden",
-                                    }
-                                  }
-                                  tabIndex="-1"
-                                >
-                                  <ForwardRef(MenuList)
-                                    actions={
-                                      Object {
-                                        "current": Object {
-                                          "adjustStyleForScrollbar": [Function],
-                                        },
-                                      }
-                                    }
-                                    autoFocus={false}
-                                    autoFocusItem={false}
-                                    className="MuiMenu-list"
-                                    onKeyDown={[Function]}
-                                    variant="selectedMenu"
-                                  >
-                                    <WithStyles(ForwardRef(List))
-                                      className="MuiMenu-list"
-                                      onKeyDown={[Function]}
-                                      role="menu"
-                                      tabIndex={-1}
-                                    >
-                                      <ForwardRef(List)
-                                        className="MuiMenu-list"
-                                        classes={
-                                          Object {
-                                            "dense": "MuiList-dense",
-                                            "padding": "MuiList-padding",
-                                            "root": "MuiList-root",
-                                            "subheader": "MuiList-subheader",
-                                          }
-                                        }
-                                        onKeyDown={[Function]}
-                                        role="menu"
-                                        tabIndex={-1}
-                                      >
-                                        <ul
-                                          className="MuiList-root MuiMenu-list MuiList-padding"
-                                          onKeyDown={[Function]}
-                                          role="menu"
-                                          tabIndex={-1}
-                                        >
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(all)"
-                                            key=".$.$all"
-                                            onClick={[Function]}
-                                            tabIndex={0}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(all)"
-                                              onClick={[Function]}
-                                              tabIndex={0}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(all)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={0}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(all)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={0}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(all)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={0}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(all)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={0}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(all)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={0}
-                                                      >
-                                                        時間不限
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(now-1d/d)"
-                                            key=".$.$now-1d/d"
-                                            onClick={[Function]}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(now-1d/d)"
-                                              onClick={[Function]}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(now-1d/d)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(now-1d/d)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(now-1d/d)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(now-1d/d)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(now-1d/d)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={-1}
-                                                      >
-                                                        一天內
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(now-1w/d)"
-                                            key=".$.$now-1w/d"
-                                            onClick={[Function]}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(now-1w/d)"
-                                              onClick={[Function]}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(now-1w/d)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(now-1w/d)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(now-1w/d)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(now-1w/d)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(now-1w/d)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={-1}
-                                                      >
-                                                        一週內
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(now-1m/d)"
-                                            key=".$.$now-1m/d"
-                                            onClick={[Function]}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(now-1m/d)"
-                                              onClick={[Function]}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(now-1m/d)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(now-1m/d)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(now-1m/d)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(now-1m/d)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(now-1m/d)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={-1}
-                                                      >
-                                                        一個月內
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(custom)"
-                                            key=".$.$custom"
-                                            onClick={[Function]}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(custom)"
-                                              onClick={[Function]}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(custom)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(custom)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(custom)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(custom)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(custom)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={-1}
-                                                      >
-                                                        自訂範圍
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                        </ul>
-                                      </ForwardRef(List)>
-                                    </WithStyles(ForwardRef(List))>
-                                  </ForwardRef(MenuList)>
-                                </div>
-                              </ForwardRef(Paper)>
-                            </WithStyles(ForwardRef(Paper))>
-                          </Transition>
-                        </ForwardRef(Grow)>
-                        <div
-                          data-test="sentinelEnd"
-                          tabIndex={0}
+                      </span>
+                    </NoSsr>
+                  </li>
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(now-1d/d)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                  >
+                    一天內
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
+                      >
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
                         />
-                      </TrapFocus>
-                    </div>
-                  </Portal>
-                </ForwardRef(Portal)>
-              </ForwardRef(Modal)>
-            </ForwardRef(Popover)>
-          </WithStyles(ForwardRef(Popover))>
-        </ForwardRef(Menu)>
-      </WithStyles(ForwardRef(Menu))>
+                      </span>
+                    </NoSsr>
+                  </li>
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(now-1w/d)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                  >
+                    一週內
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
+                      >
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
+                        />
+                      </span>
+                    </NoSsr>
+                  </li>
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(now-1m/d)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                  >
+                    一個月內
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
+                      >
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
+                        />
+                      </span>
+                    </NoSsr>
+                  </li>
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(custom)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                  >
+                    自訂範圍
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
+                      >
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
+                        />
+                      </span>
+                    </NoSsr>
+                  </li>
+                </ul>
+              </div>
+            </Transition>
+            <div
+              data-test="sentinelEnd"
+              tabIndex={0}
+            />
+          </TrapFocus>
+        </div>
+      </Portal>
     </div>
   </TimeRange>
   <p>
@@ -3121,1635 +629,301 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
     <div
       className="makeStyles-root-134"
     >
-      <WithStyles(ForwardRef(ButtonGroup))
-        classes={
-          Object {
-            "contained": "makeStyles-buttonGroup-135",
-          }
-        }
+      <div
+        className="MuiButtonGroup-root"
+        role="group"
       >
-        <ForwardRef(ButtonGroup)
-          classes={
-            Object {
-              "contained": "MuiButtonGroup-contained makeStyles-buttonGroup-135",
-              "disabled": "Mui-disabled",
-              "fullWidth": "MuiButtonGroup-fullWidth",
-              "grouped": "MuiButtonGroup-grouped",
-              "groupedContained": "MuiButtonGroup-groupedContained",
-              "groupedContainedHorizontal": "MuiButtonGroup-groupedContainedHorizontal",
-              "groupedContainedPrimary": "MuiButtonGroup-groupedContainedPrimary",
-              "groupedContainedSecondary": "MuiButtonGroup-groupedContainedSecondary",
-              "groupedContainedVertical": "MuiButtonGroup-groupedContainedVertical",
-              "groupedHorizontal": "MuiButtonGroup-groupedHorizontal",
-              "groupedOutlined": "MuiButtonGroup-groupedOutlined",
-              "groupedOutlinedHorizontal": "MuiButtonGroup-groupedOutlinedHorizontal",
-              "groupedOutlinedPrimary": "MuiButtonGroup-groupedOutlinedPrimary",
-              "groupedOutlinedSecondary": "MuiButtonGroup-groupedOutlinedSecondary",
-              "groupedOutlinedVertical": "MuiButtonGroup-groupedOutlinedVertical",
-              "groupedText": "MuiButtonGroup-groupedText",
-              "groupedTextHorizontal": "MuiButtonGroup-groupedTextHorizontal",
-              "groupedTextPrimary": "MuiButtonGroup-groupedTextPrimary",
-              "groupedTextSecondary": "MuiButtonGroup-groupedTextSecondary",
-              "groupedTextVertical": "MuiButtonGroup-groupedTextVertical",
-              "groupedVertical": "MuiButtonGroup-groupedVertical",
-              "root": "MuiButtonGroup-root",
-              "vertical": "MuiButtonGroup-vertical",
-            }
-          }
+        <button
+          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
         >
-          <div
-            className="MuiButtonGroup-root"
-            role="group"
+          <span
+            className="MuiButton-label"
           >
-            <WithStyles(ForwardRef(Button))
-              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-              color="default"
-              disableFocusRipple={false}
-              disableRipple={false}
-              disabled={false}
-              fullWidth={false}
-              key=".0"
-              onClick={[Function]}
-              size="medium"
-              variant="outlined"
+            <svg
+              aria-hidden="true"
+              className="MuiSvgIcon-root makeStyles-calendarIcon-137"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              <ForwardRef(Button)
-                className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-                classes={
-                  Object {
-                    "colorInherit": "MuiButton-colorInherit",
-                    "contained": "MuiButton-contained",
-                    "containedPrimary": "MuiButton-containedPrimary",
-                    "containedSecondary": "MuiButton-containedSecondary",
-                    "containedSizeLarge": "MuiButton-containedSizeLarge",
-                    "containedSizeSmall": "MuiButton-containedSizeSmall",
-                    "disableElevation": "MuiButton-disableElevation",
-                    "disabled": "Mui-disabled",
-                    "endIcon": "MuiButton-endIcon",
-                    "focusVisible": "Mui-focusVisible",
-                    "fullWidth": "MuiButton-fullWidth",
-                    "iconSizeLarge": "MuiButton-iconSizeLarge",
-                    "iconSizeMedium": "MuiButton-iconSizeMedium",
-                    "iconSizeSmall": "MuiButton-iconSizeSmall",
-                    "label": "MuiButton-label",
-                    "outlined": "MuiButton-outlined",
-                    "outlinedPrimary": "MuiButton-outlinedPrimary",
-                    "outlinedSecondary": "MuiButton-outlinedSecondary",
-                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                    "root": "MuiButton-root",
-                    "sizeLarge": "MuiButton-sizeLarge",
-                    "sizeSmall": "MuiButton-sizeSmall",
-                    "startIcon": "MuiButton-startIcon",
-                    "text": "MuiButton-text",
-                    "textPrimary": "MuiButton-textPrimary",
-                    "textSecondary": "MuiButton-textSecondary",
-                    "textSizeLarge": "MuiButton-textSizeLarge",
-                    "textSizeSmall": "MuiButton-textSizeSmall",
-                  }
-                }
-                color="default"
-                disableFocusRipple={false}
-                disableRipple={false}
-                disabled={false}
-                fullWidth={false}
-                onClick={[Function]}
-                size="medium"
-                variant="outlined"
-              >
-                <WithStyles(ForwardRef(ButtonBase))
-                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-                  component="button"
-                  disableRipple={false}
-                  disabled={false}
-                  focusRipple={true}
-                  focusVisibleClassName="Mui-focusVisible"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <ForwardRef(ButtonBase)
-                    className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-                    classes={
-                      Object {
-                        "disabled": "Mui-disabled",
-                        "focusVisible": "Mui-focusVisible",
-                        "root": "MuiButtonBase-root",
-                      }
-                    }
-                    component="button"
-                    disableRipple={false}
-                    disabled={false}
-                    focusRipple={true}
-                    focusVisibleClassName="Mui-focusVisible"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <button
-                      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-                      disabled={false}
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onDragLeave={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyUp={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="MuiButton-label"
-                      >
-                        <ForwardRef
-                          className="makeStyles-calendarIcon-137"
-                        >
-                          <WithStyles(ForwardRef(SvgIcon))
-                            className="makeStyles-calendarIcon-137"
-                          >
-                            <ForwardRef(SvgIcon)
-                              className="makeStyles-calendarIcon-137"
-                              classes={
-                                Object {
-                                  "colorAction": "MuiSvgIcon-colorAction",
-                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                  "colorError": "MuiSvgIcon-colorError",
-                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                  "root": "MuiSvgIcon-root",
-                                }
-                              }
-                            >
-                              <svg
-                                aria-hidden="true"
-                                className="MuiSvgIcon-root makeStyles-calendarIcon-137"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"
-                                />
-                              </svg>
-                            </ForwardRef(SvgIcon)>
-                          </WithStyles(ForwardRef(SvgIcon))>
-                        </ForwardRef>
-                      </span>
-                      <NoSsr>
-                        <WithStyles(memo)
-                          center={false}
-                        >
-                          <ForwardRef(TouchRipple)
-                            center={false}
-                            classes={
-                              Object {
-                                "child": "MuiTouchRipple-child",
-                                "childLeaving": "MuiTouchRipple-childLeaving",
-                                "childPulsate": "MuiTouchRipple-childPulsate",
-                                "ripple": "MuiTouchRipple-ripple",
-                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                "root": "MuiTouchRipple-root",
-                              }
-                            }
-                          >
-                            <span
-                              className="MuiTouchRipple-root"
-                            >
-                              <TransitionGroup
-                                childFactory={[Function]}
-                                component={null}
-                                exit={true}
-                              />
-                            </span>
-                          </ForwardRef(TouchRipple)>
-                        </WithStyles(memo)>
-                      </NoSsr>
-                    </button>
-                  </ForwardRef(ButtonBase)>
-                </WithStyles(ForwardRef(ButtonBase))>
-              </ForwardRef(Button)>
-            </WithStyles(ForwardRef(Button))>
-            <WithStyles(ForwardRef(Button))
-              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
-              color="default"
-              disableFocusRipple={false}
-              disableRipple={false}
-              disabled={false}
-              fullWidth={false}
-              key=".1"
-              onClick={[Function]}
-              size="medium"
-              variant="outlined"
+              <path
+                d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"
+              />
+            </svg>
+          </span>
+          <NoSsr>
+            <span
+              className="MuiTouchRipple-root"
             >
-              <ForwardRef(Button)
-                className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
-                classes={
-                  Object {
-                    "colorInherit": "MuiButton-colorInherit",
-                    "contained": "MuiButton-contained",
-                    "containedPrimary": "MuiButton-containedPrimary",
-                    "containedSecondary": "MuiButton-containedSecondary",
-                    "containedSizeLarge": "MuiButton-containedSizeLarge",
-                    "containedSizeSmall": "MuiButton-containedSizeSmall",
-                    "disableElevation": "MuiButton-disableElevation",
-                    "disabled": "Mui-disabled",
-                    "endIcon": "MuiButton-endIcon",
-                    "focusVisible": "Mui-focusVisible",
-                    "fullWidth": "MuiButton-fullWidth",
-                    "iconSizeLarge": "MuiButton-iconSizeLarge",
-                    "iconSizeMedium": "MuiButton-iconSizeMedium",
-                    "iconSizeSmall": "MuiButton-iconSizeSmall",
-                    "label": "MuiButton-label",
-                    "outlined": "MuiButton-outlined",
-                    "outlinedPrimary": "MuiButton-outlinedPrimary",
-                    "outlinedSecondary": "MuiButton-outlinedSecondary",
-                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                    "root": "MuiButton-root",
-                    "sizeLarge": "MuiButton-sizeLarge",
-                    "sizeSmall": "MuiButton-sizeSmall",
-                    "startIcon": "MuiButton-startIcon",
-                    "text": "MuiButton-text",
-                    "textPrimary": "MuiButton-textPrimary",
-                    "textSecondary": "MuiButton-textSecondary",
-                    "textSizeLarge": "MuiButton-textSizeLarge",
-                    "textSizeSmall": "MuiButton-textSizeSmall",
-                  }
-                }
-                color="default"
-                disableFocusRipple={false}
-                disableRipple={false}
-                disabled={false}
-                fullWidth={false}
-                onClick={[Function]}
-                size="medium"
-                variant="outlined"
-              >
-                <WithStyles(ForwardRef(ButtonBase))
-                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
-                  component="button"
-                  disableRipple={false}
-                  disabled={false}
-                  focusRipple={true}
-                  focusVisibleClassName="Mui-focusVisible"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <ForwardRef(ButtonBase)
-                    className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
-                    classes={
-                      Object {
-                        "disabled": "Mui-disabled",
-                        "focusVisible": "Mui-focusVisible",
-                        "root": "MuiButtonBase-root",
-                      }
-                    }
-                    component="button"
-                    disableRipple={false}
-                    disabled={false}
-                    focusRipple={true}
-                    focusVisibleClassName="Mui-focusVisible"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <button
-                      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
-                      disabled={false}
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onDragLeave={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyUp={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="MuiButton-label"
-                      >
-                        一天內
-                      </span>
-                      <NoSsr>
-                        <WithStyles(memo)
-                          center={false}
-                        >
-                          <ForwardRef(TouchRipple)
-                            center={false}
-                            classes={
-                              Object {
-                                "child": "MuiTouchRipple-child",
-                                "childLeaving": "MuiTouchRipple-childLeaving",
-                                "childPulsate": "MuiTouchRipple-childPulsate",
-                                "ripple": "MuiTouchRipple-ripple",
-                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                "root": "MuiTouchRipple-root",
-                              }
-                            }
-                          >
-                            <span
-                              className="MuiTouchRipple-root"
-                            >
-                              <TransitionGroup
-                                childFactory={[Function]}
-                                component={null}
-                                exit={true}
-                              />
-                            </span>
-                          </ForwardRef(TouchRipple)>
-                        </WithStyles(memo)>
-                      </NoSsr>
-                    </button>
-                  </ForwardRef(ButtonBase)>
-                </WithStyles(ForwardRef(ButtonBase))>
-              </ForwardRef(Button)>
-            </WithStyles(ForwardRef(Button))>
-          </div>
-        </ForwardRef(ButtonGroup)>
-      </WithStyles(ForwardRef(ButtonGroup))>
-      <WithStyles(ForwardRef(Menu))
-        anchorEl={null}
-        id="time-range"
-        keepMounted={true}
-        onClose={[Function]}
-        open={false}
-      >
-        <ForwardRef(Menu)
-          anchorEl={null}
-          classes={
-            Object {
-              "list": "MuiMenu-list",
-              "paper": "MuiMenu-paper",
-            }
-          }
+              <TransitionGroup
+                childFactory={[Function]}
+                component={null}
+                exit={true}
+              />
+            </span>
+          </NoSsr>
+        </button>
+        <button
+          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
+        >
+          <span
+            className="MuiButton-label"
+          >
+            一天內
+          </span>
+          <NoSsr>
+            <span
+              className="MuiTouchRipple-root"
+            >
+              <TransitionGroup
+                childFactory={[Function]}
+                component={null}
+                exit={true}
+              />
+            </span>
+          </NoSsr>
+        </button>
+      </div>
+      <Portal>
+        <div
+          className="MuiPopover-root"
           id="time-range"
-          keepMounted={true}
-          onClose={[Function]}
-          open={false}
+          onKeyDown={[Function]}
+          role="presentation"
+          style={
+            Object {
+              "bottom": 0,
+              "left": 0,
+              "position": "fixed",
+              "right": 0,
+              "top": 0,
+              "visibility": "hidden",
+              "zIndex": 1300,
+            }
+          }
         >
-          <WithStyles(ForwardRef(Popover))
-            PaperProps={
-              Object {
-                "classes": Object {
-                  "root": "MuiMenu-paper",
-                },
-              }
-            }
-            anchorEl={null}
-            anchorOrigin={
-              Object {
-                "horizontal": "left",
-                "vertical": "top",
-              }
-            }
-            getContentAnchorEl={[Function]}
-            id="time-range"
-            keepMounted={true}
-            onClose={[Function]}
-            onEntering={[Function]}
-            open={false}
-            transformOrigin={
-              Object {
-                "horizontal": "left",
-                "vertical": "top",
-              }
-            }
-            transitionDuration="auto"
-          >
-            <ForwardRef(Popover)
-              PaperProps={
-                Object {
-                  "classes": Object {
-                    "root": "MuiMenu-paper",
-                  },
-                }
-              }
-              anchorEl={null}
-              anchorOrigin={
-                Object {
-                  "horizontal": "left",
-                  "vertical": "top",
-                }
-              }
-              classes={
-                Object {
-                  "paper": "MuiPopover-paper",
-                  "root": "MuiPopover-root",
-                }
-              }
-              getContentAnchorEl={[Function]}
-              id="time-range"
-              keepMounted={true}
-              onClose={[Function]}
-              onEntering={[Function]}
-              open={false}
-              transformOrigin={
-                Object {
-                  "horizontal": "left",
-                  "vertical": "top",
-                }
-              }
-              transitionDuration="auto"
-            >
-              <ForwardRef(Modal)
-                BackdropProps={
+          <TrapFocus>
+            <div
+              data-test="sentinelStart"
+              tabIndex={0}
+            />
+            <Transition>
+              <div
+                className="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                style={
                   Object {
-                    "invisible": true,
+                    "opacity": 0,
+                    "transform": "scale(0.75, 0.5625)",
+                    "visibility": "hidden",
                   }
                 }
-                className="MuiPopover-root"
-                id="time-range"
-                keepMounted={true}
-                onClose={[Function]}
-                open={false}
+                tabIndex="-1"
               >
-                <ForwardRef(Portal)
-                  disablePortal={false}
+                <ul
+                  className="MuiList-root MuiMenu-list MuiList-padding"
+                  onKeyDown={[Function]}
+                  role="menu"
+                  tabIndex={-1}
                 >
-                  <Portal
-                    containerInfo={
-                      <body>
-                        <div
-                          aria-hidden="true"
-                          class="MuiPopover-root"
-                          id="time-range"
-                          role="presentation"
-                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
-                        >
-                          <div
-                            data-test="sentinelStart"
-                            tabindex="0"
-                          />
-                          <div
-                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
-                            tabindex="-1"
-                          >
-                            <ul
-                              class="MuiList-root MuiMenu-list MuiList-padding"
-                              role="menu"
-                              tabindex="-1"
-                            >
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(all)"
-                                role="menuitem"
-                                tabindex="0"
-                              >
-                                時間不限
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1d/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一天內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1w/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一週內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1m/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一個月內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(custom)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                自訂範圍
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                            </ul>
-                          </div>
-                          <div
-                            data-test="sentinelEnd"
-                            tabindex="0"
-                          />
-                        </div>
-                        <div
-                          aria-hidden="true"
-                          class="MuiPopover-root"
-                          id="time-range"
-                          role="presentation"
-                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
-                        >
-                          <div
-                            data-test="sentinelStart"
-                            tabindex="0"
-                          />
-                          <div
-                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
-                            tabindex="-1"
-                          >
-                            <ul
-                              class="MuiList-root MuiMenu-list MuiList-padding"
-                              role="menu"
-                              tabindex="-1"
-                            >
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(all)"
-                                role="menuitem"
-                                tabindex="0"
-                              >
-                                時間不限
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1d/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一天內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1w/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一週內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1m/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一個月內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(custom)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                自訂範圍
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                            </ul>
-                          </div>
-                          <div
-                            data-test="sentinelEnd"
-                            tabindex="0"
-                          />
-                        </div>
-                        <div
-                          aria-hidden="true"
-                          class="MuiPopover-root"
-                          id="time-range"
-                          role="presentation"
-                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
-                        >
-                          <div
-                            data-test="sentinelStart"
-                            tabindex="0"
-                          />
-                          <div
-                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
-                            tabindex="-1"
-                          >
-                            <ul
-                              class="MuiList-root MuiMenu-list MuiList-padding"
-                              role="menu"
-                              tabindex="-1"
-                            >
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(all)"
-                                role="menuitem"
-                                tabindex="0"
-                              >
-                                時間不限
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1d/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一天內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1w/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一週內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1m/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一個月內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(custom)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                自訂範圍
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                            </ul>
-                          </div>
-                          <div
-                            data-test="sentinelEnd"
-                            tabindex="0"
-                          />
-                        </div>
-                      </body>
-                    }
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(all)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={0}
                   >
-                    <div
-                      className="MuiPopover-root"
-                      id="time-range"
-                      onKeyDown={[Function]}
-                      role="presentation"
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "left": 0,
-                          "position": "fixed",
-                          "right": 0,
-                          "top": 0,
-                          "visibility": "hidden",
-                          "zIndex": 1300,
-                        }
-                      }
-                    >
-                      <ForwardRef(SimpleBackdrop)
-                        invisible={true}
-                        onClick={[Function]}
-                        open={false}
-                      />
-                      <TrapFocus
-                        disableAutoFocus={false}
-                        disableEnforceFocus={false}
-                        disableRestoreFocus={false}
-                        getDoc={[Function]}
-                        isEnabled={[Function]}
-                        open={false}
+                    時間不限
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
                       >
-                        <div
-                          data-test="sentinelStart"
-                          tabIndex={0}
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
                         />
-                        <ForwardRef(Grow)
-                          appear={true}
-                          in={false}
-                          onEnter={[Function]}
-                          onEntering={[Function]}
-                          onExited={[Function]}
-                          tabIndex="-1"
-                          timeout="auto"
-                        >
-                          <Transition
-                            addEndListener={[Function]}
-                            appear={true}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            tabIndex="-1"
-                            timeout={null}
-                            unmountOnExit={false}
-                          >
-                            <WithStyles(ForwardRef(Paper))
-                              className="MuiPopover-paper"
-                              classes={
-                                Object {
-                                  "root": "MuiMenu-paper",
-                                }
-                              }
-                              elevation={8}
-                              style={
-                                Object {
-                                  "opacity": 0,
-                                  "transform": "scale(0.75, 0.5625)",
-                                  "visibility": "hidden",
-                                }
-                              }
-                              tabIndex="-1"
-                            >
-                              <ForwardRef(Paper)
-                                className="MuiPopover-paper"
-                                classes={
-                                  Object {
-                                    "elevation0": "MuiPaper-elevation0",
-                                    "elevation1": "MuiPaper-elevation1",
-                                    "elevation10": "MuiPaper-elevation10",
-                                    "elevation11": "MuiPaper-elevation11",
-                                    "elevation12": "MuiPaper-elevation12",
-                                    "elevation13": "MuiPaper-elevation13",
-                                    "elevation14": "MuiPaper-elevation14",
-                                    "elevation15": "MuiPaper-elevation15",
-                                    "elevation16": "MuiPaper-elevation16",
-                                    "elevation17": "MuiPaper-elevation17",
-                                    "elevation18": "MuiPaper-elevation18",
-                                    "elevation19": "MuiPaper-elevation19",
-                                    "elevation2": "MuiPaper-elevation2",
-                                    "elevation20": "MuiPaper-elevation20",
-                                    "elevation21": "MuiPaper-elevation21",
-                                    "elevation22": "MuiPaper-elevation22",
-                                    "elevation23": "MuiPaper-elevation23",
-                                    "elevation24": "MuiPaper-elevation24",
-                                    "elevation3": "MuiPaper-elevation3",
-                                    "elevation4": "MuiPaper-elevation4",
-                                    "elevation5": "MuiPaper-elevation5",
-                                    "elevation6": "MuiPaper-elevation6",
-                                    "elevation7": "MuiPaper-elevation7",
-                                    "elevation8": "MuiPaper-elevation8",
-                                    "elevation9": "MuiPaper-elevation9",
-                                    "outlined": "MuiPaper-outlined",
-                                    "root": "MuiPaper-root MuiMenu-paper",
-                                    "rounded": "MuiPaper-rounded",
-                                  }
-                                }
-                                elevation={8}
-                                style={
-                                  Object {
-                                    "opacity": 0,
-                                    "transform": "scale(0.75, 0.5625)",
-                                    "visibility": "hidden",
-                                  }
-                                }
-                                tabIndex="-1"
-                              >
-                                <div
-                                  className="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                                  style={
-                                    Object {
-                                      "opacity": 0,
-                                      "transform": "scale(0.75, 0.5625)",
-                                      "visibility": "hidden",
-                                    }
-                                  }
-                                  tabIndex="-1"
-                                >
-                                  <ForwardRef(MenuList)
-                                    actions={
-                                      Object {
-                                        "current": Object {
-                                          "adjustStyleForScrollbar": [Function],
-                                        },
-                                      }
-                                    }
-                                    autoFocus={false}
-                                    autoFocusItem={false}
-                                    className="MuiMenu-list"
-                                    onKeyDown={[Function]}
-                                    variant="selectedMenu"
-                                  >
-                                    <WithStyles(ForwardRef(List))
-                                      className="MuiMenu-list"
-                                      onKeyDown={[Function]}
-                                      role="menu"
-                                      tabIndex={-1}
-                                    >
-                                      <ForwardRef(List)
-                                        className="MuiMenu-list"
-                                        classes={
-                                          Object {
-                                            "dense": "MuiList-dense",
-                                            "padding": "MuiList-padding",
-                                            "root": "MuiList-root",
-                                            "subheader": "MuiList-subheader",
-                                          }
-                                        }
-                                        onKeyDown={[Function]}
-                                        role="menu"
-                                        tabIndex={-1}
-                                      >
-                                        <ul
-                                          className="MuiList-root MuiMenu-list MuiList-padding"
-                                          onKeyDown={[Function]}
-                                          role="menu"
-                                          tabIndex={-1}
-                                        >
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(all)"
-                                            key=".$.$all"
-                                            onClick={[Function]}
-                                            tabIndex={0}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(all)"
-                                              onClick={[Function]}
-                                              tabIndex={0}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(all)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={0}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(all)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={0}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(all)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={0}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(all)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={0}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(all)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={0}
-                                                      >
-                                                        時間不限
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(now-1d/d)"
-                                            key=".$.$now-1d/d"
-                                            onClick={[Function]}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(now-1d/d)"
-                                              onClick={[Function]}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(now-1d/d)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(now-1d/d)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(now-1d/d)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(now-1d/d)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(now-1d/d)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={-1}
-                                                      >
-                                                        一天內
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(now-1w/d)"
-                                            key=".$.$now-1w/d"
-                                            onClick={[Function]}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(now-1w/d)"
-                                              onClick={[Function]}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(now-1w/d)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(now-1w/d)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(now-1w/d)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(now-1w/d)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(now-1w/d)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={-1}
-                                                      >
-                                                        一週內
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(now-1m/d)"
-                                            key=".$.$now-1m/d"
-                                            onClick={[Function]}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(now-1m/d)"
-                                              onClick={[Function]}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(now-1m/d)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(now-1m/d)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(now-1m/d)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(now-1m/d)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(now-1m/d)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={-1}
-                                                      >
-                                                        一個月內
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(custom)"
-                                            key=".$.$custom"
-                                            onClick={[Function]}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(custom)"
-                                              onClick={[Function]}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(custom)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(custom)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(custom)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(custom)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(custom)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={-1}
-                                                      >
-                                                        自訂範圍
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                        </ul>
-                                      </ForwardRef(List)>
-                                    </WithStyles(ForwardRef(List))>
-                                  </ForwardRef(MenuList)>
-                                </div>
-                              </ForwardRef(Paper)>
-                            </WithStyles(ForwardRef(Paper))>
-                          </Transition>
-                        </ForwardRef(Grow)>
-                        <div
-                          data-test="sentinelEnd"
-                          tabIndex={0}
+                      </span>
+                    </NoSsr>
+                  </li>
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(now-1d/d)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                  >
+                    一天內
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
+                      >
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
                         />
-                      </TrapFocus>
-                    </div>
-                  </Portal>
-                </ForwardRef(Portal)>
-              </ForwardRef(Modal)>
-            </ForwardRef(Popover)>
-          </WithStyles(ForwardRef(Popover))>
-        </ForwardRef(Menu)>
-      </WithStyles(ForwardRef(Menu))>
+                      </span>
+                    </NoSsr>
+                  </li>
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(now-1w/d)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                  >
+                    一週內
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
+                      >
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
+                        />
+                      </span>
+                    </NoSsr>
+                  </li>
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(now-1m/d)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                  >
+                    一個月內
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
+                      >
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
+                        />
+                      </span>
+                    </NoSsr>
+                  </li>
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(custom)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                  >
+                    自訂範圍
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
+                      >
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
+                        />
+                      </span>
+                    </NoSsr>
+                  </li>
+                </ul>
+              </div>
+            </Transition>
+            <div
+              data-test="sentinelEnd"
+              tabIndex={0}
+            />
+          </TrapFocus>
+        </div>
+      </Portal>
     </div>
   </TimeRange>
   <p>
@@ -4767,245 +941,76 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
     <div
       className="makeStyles-root-134"
     >
-      <WithStyles(ForwardRef(ButtonGroup))
-        classes={
-          Object {
-            "contained": "makeStyles-buttonGroup-135",
-          }
-        }
+      <div
+        className="MuiButtonGroup-root"
+        role="group"
       >
-        <ForwardRef(ButtonGroup)
-          classes={
-            Object {
-              "contained": "MuiButtonGroup-contained makeStyles-buttonGroup-135",
-              "disabled": "Mui-disabled",
-              "fullWidth": "MuiButtonGroup-fullWidth",
-              "grouped": "MuiButtonGroup-grouped",
-              "groupedContained": "MuiButtonGroup-groupedContained",
-              "groupedContainedHorizontal": "MuiButtonGroup-groupedContainedHorizontal",
-              "groupedContainedPrimary": "MuiButtonGroup-groupedContainedPrimary",
-              "groupedContainedSecondary": "MuiButtonGroup-groupedContainedSecondary",
-              "groupedContainedVertical": "MuiButtonGroup-groupedContainedVertical",
-              "groupedHorizontal": "MuiButtonGroup-groupedHorizontal",
-              "groupedOutlined": "MuiButtonGroup-groupedOutlined",
-              "groupedOutlinedHorizontal": "MuiButtonGroup-groupedOutlinedHorizontal",
-              "groupedOutlinedPrimary": "MuiButtonGroup-groupedOutlinedPrimary",
-              "groupedOutlinedSecondary": "MuiButtonGroup-groupedOutlinedSecondary",
-              "groupedOutlinedVertical": "MuiButtonGroup-groupedOutlinedVertical",
-              "groupedText": "MuiButtonGroup-groupedText",
-              "groupedTextHorizontal": "MuiButtonGroup-groupedTextHorizontal",
-              "groupedTextPrimary": "MuiButtonGroup-groupedTextPrimary",
-              "groupedTextSecondary": "MuiButtonGroup-groupedTextSecondary",
-              "groupedTextVertical": "MuiButtonGroup-groupedTextVertical",
-              "groupedVertical": "MuiButtonGroup-groupedVertical",
-              "root": "MuiButtonGroup-root",
-              "vertical": "MuiButtonGroup-vertical",
-            }
-          }
+        <button
+          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+          disabled={false}
+          onBlur={[Function]}
+          onClick={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          tabIndex={0}
+          type="button"
         >
-          <div
-            className="MuiButtonGroup-root"
-            role="group"
+          <span
+            className="MuiButton-label"
           >
-            <WithStyles(ForwardRef(Button))
-              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-              color="default"
-              disableFocusRipple={false}
-              disableRipple={false}
-              disabled={false}
-              fullWidth={false}
-              key=".0"
-              onClick={[Function]}
-              size="medium"
-              variant="outlined"
+            <svg
+              aria-hidden="true"
+              className="MuiSvgIcon-root makeStyles-calendarIcon-137"
+              focusable="false"
+              viewBox="0 0 24 24"
             >
-              <ForwardRef(Button)
-                className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-                classes={
-                  Object {
-                    "colorInherit": "MuiButton-colorInherit",
-                    "contained": "MuiButton-contained",
-                    "containedPrimary": "MuiButton-containedPrimary",
-                    "containedSecondary": "MuiButton-containedSecondary",
-                    "containedSizeLarge": "MuiButton-containedSizeLarge",
-                    "containedSizeSmall": "MuiButton-containedSizeSmall",
-                    "disableElevation": "MuiButton-disableElevation",
-                    "disabled": "Mui-disabled",
-                    "endIcon": "MuiButton-endIcon",
-                    "focusVisible": "Mui-focusVisible",
-                    "fullWidth": "MuiButton-fullWidth",
-                    "iconSizeLarge": "MuiButton-iconSizeLarge",
-                    "iconSizeMedium": "MuiButton-iconSizeMedium",
-                    "iconSizeSmall": "MuiButton-iconSizeSmall",
-                    "label": "MuiButton-label",
-                    "outlined": "MuiButton-outlined",
-                    "outlinedPrimary": "MuiButton-outlinedPrimary",
-                    "outlinedSecondary": "MuiButton-outlinedSecondary",
-                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
-                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
-                    "root": "MuiButton-root",
-                    "sizeLarge": "MuiButton-sizeLarge",
-                    "sizeSmall": "MuiButton-sizeSmall",
-                    "startIcon": "MuiButton-startIcon",
-                    "text": "MuiButton-text",
-                    "textPrimary": "MuiButton-textPrimary",
-                    "textSecondary": "MuiButton-textSecondary",
-                    "textSizeLarge": "MuiButton-textSizeLarge",
-                    "textSizeSmall": "MuiButton-textSizeSmall",
-                  }
-                }
-                color="default"
-                disableFocusRipple={false}
-                disableRipple={false}
-                disabled={false}
-                fullWidth={false}
-                onClick={[Function]}
-                size="medium"
-                variant="outlined"
-              >
-                <WithStyles(ForwardRef(ButtonBase))
-                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-                  component="button"
-                  disableRipple={false}
-                  disabled={false}
-                  focusRipple={true}
-                  focusVisibleClassName="Mui-focusVisible"
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <ForwardRef(ButtonBase)
-                    className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-                    classes={
-                      Object {
-                        "disabled": "Mui-disabled",
-                        "focusVisible": "Mui-focusVisible",
-                        "root": "MuiButtonBase-root",
-                      }
-                    }
-                    component="button"
-                    disableRipple={false}
-                    disabled={false}
-                    focusRipple={true}
-                    focusVisibleClassName="Mui-focusVisible"
-                    onClick={[Function]}
-                    type="button"
-                  >
-                    <button
-                      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
-                      disabled={false}
-                      onBlur={[Function]}
-                      onClick={[Function]}
-                      onDragLeave={[Function]}
-                      onFocus={[Function]}
-                      onKeyDown={[Function]}
-                      onKeyUp={[Function]}
-                      onMouseDown={[Function]}
-                      onMouseLeave={[Function]}
-                      onMouseUp={[Function]}
-                      onTouchEnd={[Function]}
-                      onTouchMove={[Function]}
-                      onTouchStart={[Function]}
-                      tabIndex={0}
-                      type="button"
-                    >
-                      <span
-                        className="MuiButton-label"
-                      >
-                        <ForwardRef
-                          className="makeStyles-calendarIcon-137"
-                        >
-                          <WithStyles(ForwardRef(SvgIcon))
-                            className="makeStyles-calendarIcon-137"
-                          >
-                            <ForwardRef(SvgIcon)
-                              className="makeStyles-calendarIcon-137"
-                              classes={
-                                Object {
-                                  "colorAction": "MuiSvgIcon-colorAction",
-                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
-                                  "colorError": "MuiSvgIcon-colorError",
-                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
-                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
-                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
-                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
-                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
-                                  "root": "MuiSvgIcon-root",
-                                }
-                              }
-                            >
-                              <svg
-                                aria-hidden="true"
-                                className="MuiSvgIcon-root makeStyles-calendarIcon-137"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"
-                                />
-                              </svg>
-                            </ForwardRef(SvgIcon)>
-                          </WithStyles(ForwardRef(SvgIcon))>
-                        </ForwardRef>
-                      </span>
-                      <NoSsr>
-                        <WithStyles(memo)
-                          center={false}
-                        >
-                          <ForwardRef(TouchRipple)
-                            center={false}
-                            classes={
-                              Object {
-                                "child": "MuiTouchRipple-child",
-                                "childLeaving": "MuiTouchRipple-childLeaving",
-                                "childPulsate": "MuiTouchRipple-childPulsate",
-                                "ripple": "MuiTouchRipple-ripple",
-                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                "root": "MuiTouchRipple-root",
-                              }
-                            }
-                          >
-                            <span
-                              className="MuiTouchRipple-root"
-                            >
-                              <TransitionGroup
-                                childFactory={[Function]}
-                                component={null}
-                                exit={true}
-                              />
-                            </span>
-                          </ForwardRef(TouchRipple)>
-                        </WithStyles(memo)>
-                      </NoSsr>
-                    </button>
-                  </ForwardRef(ButtonBase)>
-                </WithStyles(ForwardRef(ButtonBase))>
-              </ForwardRef(Button)>
-            </WithStyles(ForwardRef(Button))>
-            <input
-              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate-139"
-              color="default"
-              disableFocusRipple={false}
-              disableRipple={false}
-              disabled={false}
-              fullWidth={false}
-              key=".1"
-              onChange={[Function]}
-              size="medium"
-              type="date"
-              value="1989-06-04"
-              variant="outlined"
-            >
-              <input
-                className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate-139"
-                onChange={[Function]}
-                type="date"
-                value="1989-06-04"
+              <path
+                d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"
               />
-            </input>
-          </div>
-        </ForwardRef(ButtonGroup)>
-      </WithStyles(ForwardRef(ButtonGroup))>
+            </svg>
+          </span>
+          <NoSsr>
+            <span
+              className="MuiTouchRipple-root"
+            >
+              <TransitionGroup
+                childFactory={[Function]}
+                component={null}
+                exit={true}
+              />
+            </span>
+          </NoSsr>
+        </button>
+        <input
+          className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate-139"
+          color="default"
+          disableFocusRipple={false}
+          disableRipple={false}
+          disabled={false}
+          fullWidth={false}
+          key=".1"
+          onChange={[Function]}
+          size="medium"
+          type="date"
+          value="1989-06-04"
+          variant="outlined"
+        >
+          <input
+            className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate-139"
+            onChange={[Function]}
+            type="date"
+            value="1989-06-04"
+          />
+        </input>
+      </div>
       <span
         className="makeStyles-to-140"
       >
@@ -5017,1276 +1022,217 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
         type="date"
         value="2019-06-04"
       />
-      <WithStyles(ForwardRef(Menu))
-        anchorEl={null}
-        id="time-range"
-        keepMounted={true}
-        onClose={[Function]}
-        open={false}
-      >
-        <ForwardRef(Menu)
-          anchorEl={null}
-          classes={
+      <Portal>
+        <div
+          className="MuiPopover-root"
+          id="time-range"
+          onKeyDown={[Function]}
+          role="presentation"
+          style={
             Object {
-              "list": "MuiMenu-list",
-              "paper": "MuiMenu-paper",
+              "bottom": 0,
+              "left": 0,
+              "position": "fixed",
+              "right": 0,
+              "top": 0,
+              "visibility": "hidden",
+              "zIndex": 1300,
             }
           }
-          id="time-range"
-          keepMounted={true}
-          onClose={[Function]}
-          open={false}
         >
-          <WithStyles(ForwardRef(Popover))
-            PaperProps={
-              Object {
-                "classes": Object {
-                  "root": "MuiMenu-paper",
-                },
-              }
-            }
-            anchorEl={null}
-            anchorOrigin={
-              Object {
-                "horizontal": "left",
-                "vertical": "top",
-              }
-            }
-            getContentAnchorEl={[Function]}
-            id="time-range"
-            keepMounted={true}
-            onClose={[Function]}
-            onEntering={[Function]}
-            open={false}
-            transformOrigin={
-              Object {
-                "horizontal": "left",
-                "vertical": "top",
-              }
-            }
-            transitionDuration="auto"
-          >
-            <ForwardRef(Popover)
-              PaperProps={
-                Object {
-                  "classes": Object {
-                    "root": "MuiMenu-paper",
-                  },
-                }
-              }
-              anchorEl={null}
-              anchorOrigin={
-                Object {
-                  "horizontal": "left",
-                  "vertical": "top",
-                }
-              }
-              classes={
-                Object {
-                  "paper": "MuiPopover-paper",
-                  "root": "MuiPopover-root",
-                }
-              }
-              getContentAnchorEl={[Function]}
-              id="time-range"
-              keepMounted={true}
-              onClose={[Function]}
-              onEntering={[Function]}
-              open={false}
-              transformOrigin={
-                Object {
-                  "horizontal": "left",
-                  "vertical": "top",
-                }
-              }
-              transitionDuration="auto"
-            >
-              <ForwardRef(Modal)
-                BackdropProps={
+          <TrapFocus>
+            <div
+              data-test="sentinelStart"
+              tabIndex={0}
+            />
+            <Transition>
+              <div
+                className="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                style={
                   Object {
-                    "invisible": true,
+                    "opacity": 0,
+                    "transform": "scale(0.75, 0.5625)",
+                    "visibility": "hidden",
                   }
                 }
-                className="MuiPopover-root"
-                id="time-range"
-                keepMounted={true}
-                onClose={[Function]}
-                open={false}
+                tabIndex="-1"
               >
-                <ForwardRef(Portal)
-                  disablePortal={false}
+                <ul
+                  className="MuiList-root MuiMenu-list MuiList-padding"
+                  onKeyDown={[Function]}
+                  role="menu"
+                  tabIndex={-1}
                 >
-                  <Portal
-                    containerInfo={
-                      <body>
-                        <div
-                          aria-hidden="true"
-                          class="MuiPopover-root"
-                          id="time-range"
-                          role="presentation"
-                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
-                        >
-                          <div
-                            data-test="sentinelStart"
-                            tabindex="0"
-                          />
-                          <div
-                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
-                            tabindex="-1"
-                          >
-                            <ul
-                              class="MuiList-root MuiMenu-list MuiList-padding"
-                              role="menu"
-                              tabindex="-1"
-                            >
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(all)"
-                                role="menuitem"
-                                tabindex="0"
-                              >
-                                時間不限
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1d/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一天內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1w/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一週內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1m/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一個月內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(custom)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                自訂範圍
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                            </ul>
-                          </div>
-                          <div
-                            data-test="sentinelEnd"
-                            tabindex="0"
-                          />
-                        </div>
-                        <div
-                          aria-hidden="true"
-                          class="MuiPopover-root"
-                          id="time-range"
-                          role="presentation"
-                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
-                        >
-                          <div
-                            data-test="sentinelStart"
-                            tabindex="0"
-                          />
-                          <div
-                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
-                            tabindex="-1"
-                          >
-                            <ul
-                              class="MuiList-root MuiMenu-list MuiList-padding"
-                              role="menu"
-                              tabindex="-1"
-                            >
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(all)"
-                                role="menuitem"
-                                tabindex="0"
-                              >
-                                時間不限
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1d/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一天內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1w/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一週內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1m/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一個月內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(custom)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                自訂範圍
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                            </ul>
-                          </div>
-                          <div
-                            data-test="sentinelEnd"
-                            tabindex="0"
-                          />
-                        </div>
-                        <div
-                          aria-hidden="true"
-                          class="MuiPopover-root"
-                          id="time-range"
-                          role="presentation"
-                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
-                        >
-                          <div
-                            data-test="sentinelStart"
-                            tabindex="0"
-                          />
-                          <div
-                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
-                            tabindex="-1"
-                          >
-                            <ul
-                              class="MuiList-root MuiMenu-list MuiList-padding"
-                              role="menu"
-                              tabindex="-1"
-                            >
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(all)"
-                                role="menuitem"
-                                tabindex="0"
-                              >
-                                時間不限
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1d/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一天內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1w/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一週內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(now-1m/d)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                一個月內
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                              <li
-                                aria-disabled="false"
-                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                data-ga="MenuItem(custom)"
-                                role="menuitem"
-                                tabindex="-1"
-                              >
-                                自訂範圍
-                                <span
-                                  class="MuiTouchRipple-root"
-                                />
-                              </li>
-                            </ul>
-                          </div>
-                          <div
-                            data-test="sentinelEnd"
-                            tabindex="0"
-                          />
-                        </div>
-                      </body>
-                    }
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(all)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={0}
                   >
-                    <div
-                      className="MuiPopover-root"
-                      id="time-range"
-                      onKeyDown={[Function]}
-                      role="presentation"
-                      style={
-                        Object {
-                          "bottom": 0,
-                          "left": 0,
-                          "position": "fixed",
-                          "right": 0,
-                          "top": 0,
-                          "visibility": "hidden",
-                          "zIndex": 1300,
-                        }
-                      }
-                    >
-                      <ForwardRef(SimpleBackdrop)
-                        invisible={true}
-                        onClick={[Function]}
-                        open={false}
-                      />
-                      <TrapFocus
-                        disableAutoFocus={false}
-                        disableEnforceFocus={false}
-                        disableRestoreFocus={false}
-                        getDoc={[Function]}
-                        isEnabled={[Function]}
-                        open={false}
+                    時間不限
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
                       >
-                        <div
-                          data-test="sentinelStart"
-                          tabIndex={0}
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
                         />
-                        <ForwardRef(Grow)
-                          appear={true}
-                          in={false}
-                          onEnter={[Function]}
-                          onEntering={[Function]}
-                          onExited={[Function]}
-                          tabIndex="-1"
-                          timeout="auto"
-                        >
-                          <Transition
-                            addEndListener={[Function]}
-                            appear={true}
-                            enter={true}
-                            exit={true}
-                            in={false}
-                            mountOnEnter={false}
-                            onEnter={[Function]}
-                            onEntered={[Function]}
-                            onEntering={[Function]}
-                            onExit={[Function]}
-                            onExited={[Function]}
-                            onExiting={[Function]}
-                            tabIndex="-1"
-                            timeout={null}
-                            unmountOnExit={false}
-                          >
-                            <WithStyles(ForwardRef(Paper))
-                              className="MuiPopover-paper"
-                              classes={
-                                Object {
-                                  "root": "MuiMenu-paper",
-                                }
-                              }
-                              elevation={8}
-                              style={
-                                Object {
-                                  "opacity": 0,
-                                  "transform": "scale(0.75, 0.5625)",
-                                  "visibility": "hidden",
-                                }
-                              }
-                              tabIndex="-1"
-                            >
-                              <ForwardRef(Paper)
-                                className="MuiPopover-paper"
-                                classes={
-                                  Object {
-                                    "elevation0": "MuiPaper-elevation0",
-                                    "elevation1": "MuiPaper-elevation1",
-                                    "elevation10": "MuiPaper-elevation10",
-                                    "elevation11": "MuiPaper-elevation11",
-                                    "elevation12": "MuiPaper-elevation12",
-                                    "elevation13": "MuiPaper-elevation13",
-                                    "elevation14": "MuiPaper-elevation14",
-                                    "elevation15": "MuiPaper-elevation15",
-                                    "elevation16": "MuiPaper-elevation16",
-                                    "elevation17": "MuiPaper-elevation17",
-                                    "elevation18": "MuiPaper-elevation18",
-                                    "elevation19": "MuiPaper-elevation19",
-                                    "elevation2": "MuiPaper-elevation2",
-                                    "elevation20": "MuiPaper-elevation20",
-                                    "elevation21": "MuiPaper-elevation21",
-                                    "elevation22": "MuiPaper-elevation22",
-                                    "elevation23": "MuiPaper-elevation23",
-                                    "elevation24": "MuiPaper-elevation24",
-                                    "elevation3": "MuiPaper-elevation3",
-                                    "elevation4": "MuiPaper-elevation4",
-                                    "elevation5": "MuiPaper-elevation5",
-                                    "elevation6": "MuiPaper-elevation6",
-                                    "elevation7": "MuiPaper-elevation7",
-                                    "elevation8": "MuiPaper-elevation8",
-                                    "elevation9": "MuiPaper-elevation9",
-                                    "outlined": "MuiPaper-outlined",
-                                    "root": "MuiPaper-root MuiMenu-paper",
-                                    "rounded": "MuiPaper-rounded",
-                                  }
-                                }
-                                elevation={8}
-                                style={
-                                  Object {
-                                    "opacity": 0,
-                                    "transform": "scale(0.75, 0.5625)",
-                                    "visibility": "hidden",
-                                  }
-                                }
-                                tabIndex="-1"
-                              >
-                                <div
-                                  className="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
-                                  style={
-                                    Object {
-                                      "opacity": 0,
-                                      "transform": "scale(0.75, 0.5625)",
-                                      "visibility": "hidden",
-                                    }
-                                  }
-                                  tabIndex="-1"
-                                >
-                                  <ForwardRef(MenuList)
-                                    actions={
-                                      Object {
-                                        "current": Object {
-                                          "adjustStyleForScrollbar": [Function],
-                                        },
-                                      }
-                                    }
-                                    autoFocus={false}
-                                    autoFocusItem={false}
-                                    className="MuiMenu-list"
-                                    onKeyDown={[Function]}
-                                    variant="selectedMenu"
-                                  >
-                                    <WithStyles(ForwardRef(List))
-                                      className="MuiMenu-list"
-                                      onKeyDown={[Function]}
-                                      role="menu"
-                                      tabIndex={-1}
-                                    >
-                                      <ForwardRef(List)
-                                        className="MuiMenu-list"
-                                        classes={
-                                          Object {
-                                            "dense": "MuiList-dense",
-                                            "padding": "MuiList-padding",
-                                            "root": "MuiList-root",
-                                            "subheader": "MuiList-subheader",
-                                          }
-                                        }
-                                        onKeyDown={[Function]}
-                                        role="menu"
-                                        tabIndex={-1}
-                                      >
-                                        <ul
-                                          className="MuiList-root MuiMenu-list MuiList-padding"
-                                          onKeyDown={[Function]}
-                                          role="menu"
-                                          tabIndex={-1}
-                                        >
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(all)"
-                                            key=".$.$all"
-                                            onClick={[Function]}
-                                            tabIndex={0}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(all)"
-                                              onClick={[Function]}
-                                              tabIndex={0}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(all)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={0}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(all)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={0}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(all)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={0}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(all)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={0}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(all)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={0}
-                                                      >
-                                                        時間不限
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(now-1d/d)"
-                                            key=".$.$now-1d/d"
-                                            onClick={[Function]}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(now-1d/d)"
-                                              onClick={[Function]}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(now-1d/d)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(now-1d/d)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(now-1d/d)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(now-1d/d)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(now-1d/d)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={-1}
-                                                      >
-                                                        一天內
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(now-1w/d)"
-                                            key=".$.$now-1w/d"
-                                            onClick={[Function]}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(now-1w/d)"
-                                              onClick={[Function]}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(now-1w/d)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(now-1w/d)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(now-1w/d)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(now-1w/d)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(now-1w/d)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={-1}
-                                                      >
-                                                        一週內
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(now-1m/d)"
-                                            key=".$.$now-1m/d"
-                                            onClick={[Function]}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(now-1m/d)"
-                                              onClick={[Function]}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(now-1m/d)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(now-1m/d)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(now-1m/d)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(now-1m/d)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(now-1m/d)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={-1}
-                                                      >
-                                                        一個月內
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                          <WithStyles(ForwardRef(MenuItem))
-                                            data-ga="MenuItem(custom)"
-                                            key=".$.$custom"
-                                            onClick={[Function]}
-                                          >
-                                            <ForwardRef(MenuItem)
-                                              classes={
-                                                Object {
-                                                  "dense": "MuiMenuItem-dense",
-                                                  "gutters": "MuiMenuItem-gutters",
-                                                  "root": "MuiMenuItem-root",
-                                                  "selected": "Mui-selected",
-                                                }
-                                              }
-                                              data-ga="MenuItem(custom)"
-                                              onClick={[Function]}
-                                            >
-                                              <WithStyles(ForwardRef(ListItem))
-                                                button={true}
-                                                className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                classes={
-                                                  Object {
-                                                    "dense": "MuiMenuItem-dense",
-                                                  }
-                                                }
-                                                component="li"
-                                                data-ga="MenuItem(custom)"
-                                                disableGutters={false}
-                                                onClick={[Function]}
-                                                role="menuitem"
-                                                tabIndex={-1}
-                                              >
-                                                <ForwardRef(ListItem)
-                                                  button={true}
-                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
-                                                  classes={
-                                                    Object {
-                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
-                                                      "button": "MuiListItem-button",
-                                                      "container": "MuiListItem-container",
-                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
-                                                      "disabled": "Mui-disabled",
-                                                      "divider": "MuiListItem-divider",
-                                                      "focusVisible": "Mui-focusVisible",
-                                                      "gutters": "MuiListItem-gutters",
-                                                      "root": "MuiListItem-root",
-                                                      "secondaryAction": "MuiListItem-secondaryAction",
-                                                      "selected": "Mui-selected",
-                                                    }
-                                                  }
-                                                  component="li"
-                                                  data-ga="MenuItem(custom)"
-                                                  disableGutters={false}
-                                                  onClick={[Function]}
-                                                  role="menuitem"
-                                                  tabIndex={-1}
-                                                >
-                                                  <WithStyles(ForwardRef(ButtonBase))
-                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                    component="li"
-                                                    data-ga="MenuItem(custom)"
-                                                    disabled={false}
-                                                    focusVisibleClassName="Mui-focusVisible"
-                                                    onClick={[Function]}
-                                                    role="menuitem"
-                                                    tabIndex={-1}
-                                                  >
-                                                    <ForwardRef(ButtonBase)
-                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                      classes={
-                                                        Object {
-                                                          "disabled": "Mui-disabled",
-                                                          "focusVisible": "Mui-focusVisible",
-                                                          "root": "MuiButtonBase-root",
-                                                        }
-                                                      }
-                                                      component="li"
-                                                      data-ga="MenuItem(custom)"
-                                                      disabled={false}
-                                                      focusVisibleClassName="Mui-focusVisible"
-                                                      onClick={[Function]}
-                                                      role="menuitem"
-                                                      tabIndex={-1}
-                                                    >
-                                                      <li
-                                                        aria-disabled={false}
-                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
-                                                        data-ga="MenuItem(custom)"
-                                                        onBlur={[Function]}
-                                                        onClick={[Function]}
-                                                        onDragLeave={[Function]}
-                                                        onFocus={[Function]}
-                                                        onKeyDown={[Function]}
-                                                        onKeyUp={[Function]}
-                                                        onMouseDown={[Function]}
-                                                        onMouseLeave={[Function]}
-                                                        onMouseUp={[Function]}
-                                                        onTouchEnd={[Function]}
-                                                        onTouchMove={[Function]}
-                                                        onTouchStart={[Function]}
-                                                        role="menuitem"
-                                                        tabIndex={-1}
-                                                      >
-                                                        自訂範圍
-                                                        <NoSsr>
-                                                          <WithStyles(memo)
-                                                            center={false}
-                                                          >
-                                                            <ForwardRef(TouchRipple)
-                                                              center={false}
-                                                              classes={
-                                                                Object {
-                                                                  "child": "MuiTouchRipple-child",
-                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
-                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
-                                                                  "ripple": "MuiTouchRipple-ripple",
-                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
-                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
-                                                                  "root": "MuiTouchRipple-root",
-                                                                }
-                                                              }
-                                                            >
-                                                              <span
-                                                                className="MuiTouchRipple-root"
-                                                              >
-                                                                <TransitionGroup
-                                                                  childFactory={[Function]}
-                                                                  component={null}
-                                                                  exit={true}
-                                                                />
-                                                              </span>
-                                                            </ForwardRef(TouchRipple)>
-                                                          </WithStyles(memo)>
-                                                        </NoSsr>
-                                                      </li>
-                                                    </ForwardRef(ButtonBase)>
-                                                  </WithStyles(ForwardRef(ButtonBase))>
-                                                </ForwardRef(ListItem)>
-                                              </WithStyles(ForwardRef(ListItem))>
-                                            </ForwardRef(MenuItem)>
-                                          </WithStyles(ForwardRef(MenuItem))>
-                                        </ul>
-                                      </ForwardRef(List)>
-                                    </WithStyles(ForwardRef(List))>
-                                  </ForwardRef(MenuList)>
-                                </div>
-                              </ForwardRef(Paper)>
-                            </WithStyles(ForwardRef(Paper))>
-                          </Transition>
-                        </ForwardRef(Grow)>
-                        <div
-                          data-test="sentinelEnd"
-                          tabIndex={0}
+                      </span>
+                    </NoSsr>
+                  </li>
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(now-1d/d)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                  >
+                    一天內
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
+                      >
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
                         />
-                      </TrapFocus>
-                    </div>
-                  </Portal>
-                </ForwardRef(Portal)>
-              </ForwardRef(Modal)>
-            </ForwardRef(Popover)>
-          </WithStyles(ForwardRef(Popover))>
-        </ForwardRef(Menu)>
-      </WithStyles(ForwardRef(Menu))>
+                      </span>
+                    </NoSsr>
+                  </li>
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(now-1w/d)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                  >
+                    一週內
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
+                      >
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
+                        />
+                      </span>
+                    </NoSsr>
+                  </li>
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(now-1m/d)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                  >
+                    一個月內
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
+                      >
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
+                        />
+                      </span>
+                    </NoSsr>
+                  </li>
+                  <li
+                    aria-disabled={false}
+                    className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                    data-ga="MenuItem(custom)"
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    role="menuitem"
+                    tabIndex={-1}
+                  >
+                    自訂範圍
+                    <NoSsr>
+                      <span
+                        className="MuiTouchRipple-root"
+                      >
+                        <TransitionGroup
+                          childFactory={[Function]}
+                          component={null}
+                          exit={true}
+                        />
+                      </span>
+                    </NoSsr>
+                  </li>
+                </ul>
+              </div>
+            </Transition>
+            <div
+              data-test="sentinelEnd"
+              tabIndex={0}
+            />
+          </TrapFocus>
+        </div>
+      </Portal>
     </div>
   </TimeRange>
 </div>

--- a/__snapshots__/Storyshots.test.js.snap
+++ b/__snapshots__/Storyshots.test.js.snap
@@ -1,5 +1,6293 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots TimeRange No Range Given 1`] = `ReactWrapper {}`;
+exports[`Storyshots TimeRange No Range Given 1`] = `
+<TimeRange
+  onChange={[Function]}
+>
+  <div
+    className="makeStyles-root-1"
+  >
+    <WithStyles(ForwardRef(ButtonGroup))
+      classes={
+        Object {
+          "contained": "makeStyles-buttonGroup-2",
+        }
+      }
+    >
+      <ForwardRef(ButtonGroup)
+        classes={
+          Object {
+            "contained": "MuiButtonGroup-contained makeStyles-buttonGroup-2",
+            "disabled": "Mui-disabled",
+            "fullWidth": "MuiButtonGroup-fullWidth",
+            "grouped": "MuiButtonGroup-grouped",
+            "groupedContained": "MuiButtonGroup-groupedContained",
+            "groupedContainedHorizontal": "MuiButtonGroup-groupedContainedHorizontal",
+            "groupedContainedPrimary": "MuiButtonGroup-groupedContainedPrimary",
+            "groupedContainedSecondary": "MuiButtonGroup-groupedContainedSecondary",
+            "groupedContainedVertical": "MuiButtonGroup-groupedContainedVertical",
+            "groupedHorizontal": "MuiButtonGroup-groupedHorizontal",
+            "groupedOutlined": "MuiButtonGroup-groupedOutlined",
+            "groupedOutlinedHorizontal": "MuiButtonGroup-groupedOutlinedHorizontal",
+            "groupedOutlinedPrimary": "MuiButtonGroup-groupedOutlinedPrimary",
+            "groupedOutlinedSecondary": "MuiButtonGroup-groupedOutlinedSecondary",
+            "groupedOutlinedVertical": "MuiButtonGroup-groupedOutlinedVertical",
+            "groupedText": "MuiButtonGroup-groupedText",
+            "groupedTextHorizontal": "MuiButtonGroup-groupedTextHorizontal",
+            "groupedTextPrimary": "MuiButtonGroup-groupedTextPrimary",
+            "groupedTextSecondary": "MuiButtonGroup-groupedTextSecondary",
+            "groupedTextVertical": "MuiButtonGroup-groupedTextVertical",
+            "groupedVertical": "MuiButtonGroup-groupedVertical",
+            "root": "MuiButtonGroup-root",
+            "vertical": "MuiButtonGroup-vertical",
+          }
+        }
+      >
+        <div
+          className="MuiButtonGroup-root"
+          role="group"
+        >
+          <WithStyles(ForwardRef(Button))
+            className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-3"
+            color="default"
+            disableFocusRipple={false}
+            disableRipple={false}
+            disabled={false}
+            fullWidth={false}
+            key=".0"
+            onClick={[Function]}
+            size="medium"
+            variant="outlined"
+          >
+            <ForwardRef(Button)
+              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-3"
+              classes={
+                Object {
+                  "colorInherit": "MuiButton-colorInherit",
+                  "contained": "MuiButton-contained",
+                  "containedPrimary": "MuiButton-containedPrimary",
+                  "containedSecondary": "MuiButton-containedSecondary",
+                  "containedSizeLarge": "MuiButton-containedSizeLarge",
+                  "containedSizeSmall": "MuiButton-containedSizeSmall",
+                  "disableElevation": "MuiButton-disableElevation",
+                  "disabled": "Mui-disabled",
+                  "endIcon": "MuiButton-endIcon",
+                  "focusVisible": "Mui-focusVisible",
+                  "fullWidth": "MuiButton-fullWidth",
+                  "iconSizeLarge": "MuiButton-iconSizeLarge",
+                  "iconSizeMedium": "MuiButton-iconSizeMedium",
+                  "iconSizeSmall": "MuiButton-iconSizeSmall",
+                  "label": "MuiButton-label",
+                  "outlined": "MuiButton-outlined",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary",
+                  "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                  "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                  "root": "MuiButton-root",
+                  "sizeLarge": "MuiButton-sizeLarge",
+                  "sizeSmall": "MuiButton-sizeSmall",
+                  "startIcon": "MuiButton-startIcon",
+                  "text": "MuiButton-text",
+                  "textPrimary": "MuiButton-textPrimary",
+                  "textSecondary": "MuiButton-textSecondary",
+                  "textSizeLarge": "MuiButton-textSizeLarge",
+                  "textSizeSmall": "MuiButton-textSizeSmall",
+                }
+              }
+              color="default"
+              disableFocusRipple={false}
+              disableRipple={false}
+              disabled={false}
+              fullWidth={false}
+              onClick={[Function]}
+              size="medium"
+              variant="outlined"
+            >
+              <WithStyles(ForwardRef(ButtonBase))
+                className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-3"
+                component="button"
+                disableRipple={false}
+                disabled={false}
+                focusRipple={true}
+                focusVisibleClassName="Mui-focusVisible"
+                onClick={[Function]}
+                type="button"
+              >
+                <ForwardRef(ButtonBase)
+                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-3"
+                  classes={
+                    Object {
+                      "disabled": "Mui-disabled",
+                      "focusVisible": "Mui-focusVisible",
+                      "root": "MuiButtonBase-root",
+                    }
+                  }
+                  component="button"
+                  disableRipple={false}
+                  disabled={false}
+                  focusRipple={true}
+                  focusVisibleClassName="Mui-focusVisible"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <button
+                    className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-3"
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="MuiButton-label"
+                    >
+                      <ForwardRef
+                        className="makeStyles-calendarIcon-4"
+                      >
+                        <WithStyles(ForwardRef(SvgIcon))
+                          className="makeStyles-calendarIcon-4"
+                        >
+                          <ForwardRef(SvgIcon)
+                            className="makeStyles-calendarIcon-4"
+                            classes={
+                              Object {
+                                "colorAction": "MuiSvgIcon-colorAction",
+                                "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                "colorError": "MuiSvgIcon-colorError",
+                                "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                "root": "MuiSvgIcon-root",
+                              }
+                            }
+                          >
+                            <svg
+                              aria-hidden="true"
+                              className="MuiSvgIcon-root makeStyles-calendarIcon-4"
+                              focusable="false"
+                              viewBox="0 0 24 24"
+                            >
+                              <path
+                                d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"
+                              />
+                            </svg>
+                          </ForwardRef(SvgIcon)>
+                        </WithStyles(ForwardRef(SvgIcon))>
+                      </ForwardRef>
+                    </span>
+                    <NoSsr>
+                      <WithStyles(memo)
+                        center={false}
+                      >
+                        <ForwardRef(TouchRipple)
+                          center={false}
+                          classes={
+                            Object {
+                              "child": "MuiTouchRipple-child",
+                              "childLeaving": "MuiTouchRipple-childLeaving",
+                              "childPulsate": "MuiTouchRipple-childPulsate",
+                              "ripple": "MuiTouchRipple-ripple",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible",
+                              "root": "MuiTouchRipple-root",
+                            }
+                          }
+                        >
+                          <span
+                            className="MuiTouchRipple-root"
+                          >
+                            <TransitionGroup
+                              childFactory={[Function]}
+                              component={null}
+                              exit={true}
+                            />
+                          </span>
+                        </ForwardRef(TouchRipple)>
+                      </WithStyles(memo)>
+                    </NoSsr>
+                  </button>
+                </ForwardRef(ButtonBase)>
+              </WithStyles(ForwardRef(ButtonBase))>
+            </ForwardRef(Button)>
+          </WithStyles(ForwardRef(Button))>
+          <WithStyles(ForwardRef(Button))
+            className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-5"
+            color="default"
+            disableFocusRipple={false}
+            disableRipple={false}
+            disabled={false}
+            fullWidth={false}
+            key=".1"
+            onClick={[Function]}
+            size="medium"
+            variant="outlined"
+          >
+            <ForwardRef(Button)
+              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-5"
+              classes={
+                Object {
+                  "colorInherit": "MuiButton-colorInherit",
+                  "contained": "MuiButton-contained",
+                  "containedPrimary": "MuiButton-containedPrimary",
+                  "containedSecondary": "MuiButton-containedSecondary",
+                  "containedSizeLarge": "MuiButton-containedSizeLarge",
+                  "containedSizeSmall": "MuiButton-containedSizeSmall",
+                  "disableElevation": "MuiButton-disableElevation",
+                  "disabled": "Mui-disabled",
+                  "endIcon": "MuiButton-endIcon",
+                  "focusVisible": "Mui-focusVisible",
+                  "fullWidth": "MuiButton-fullWidth",
+                  "iconSizeLarge": "MuiButton-iconSizeLarge",
+                  "iconSizeMedium": "MuiButton-iconSizeMedium",
+                  "iconSizeSmall": "MuiButton-iconSizeSmall",
+                  "label": "MuiButton-label",
+                  "outlined": "MuiButton-outlined",
+                  "outlinedPrimary": "MuiButton-outlinedPrimary",
+                  "outlinedSecondary": "MuiButton-outlinedSecondary",
+                  "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                  "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                  "root": "MuiButton-root",
+                  "sizeLarge": "MuiButton-sizeLarge",
+                  "sizeSmall": "MuiButton-sizeSmall",
+                  "startIcon": "MuiButton-startIcon",
+                  "text": "MuiButton-text",
+                  "textPrimary": "MuiButton-textPrimary",
+                  "textSecondary": "MuiButton-textSecondary",
+                  "textSizeLarge": "MuiButton-textSizeLarge",
+                  "textSizeSmall": "MuiButton-textSizeSmall",
+                }
+              }
+              color="default"
+              disableFocusRipple={false}
+              disableRipple={false}
+              disabled={false}
+              fullWidth={false}
+              onClick={[Function]}
+              size="medium"
+              variant="outlined"
+            >
+              <WithStyles(ForwardRef(ButtonBase))
+                className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-5"
+                component="button"
+                disableRipple={false}
+                disabled={false}
+                focusRipple={true}
+                focusVisibleClassName="Mui-focusVisible"
+                onClick={[Function]}
+                type="button"
+              >
+                <ForwardRef(ButtonBase)
+                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-5"
+                  classes={
+                    Object {
+                      "disabled": "Mui-disabled",
+                      "focusVisible": "Mui-focusVisible",
+                      "root": "MuiButtonBase-root",
+                    }
+                  }
+                  component="button"
+                  disableRipple={false}
+                  disabled={false}
+                  focusRipple={true}
+                  focusVisibleClassName="Mui-focusVisible"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <button
+                    className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-5"
+                    disabled={false}
+                    onBlur={[Function]}
+                    onClick={[Function]}
+                    onDragLeave={[Function]}
+                    onFocus={[Function]}
+                    onKeyDown={[Function]}
+                    onKeyUp={[Function]}
+                    onMouseDown={[Function]}
+                    onMouseLeave={[Function]}
+                    onMouseUp={[Function]}
+                    onTouchEnd={[Function]}
+                    onTouchMove={[Function]}
+                    onTouchStart={[Function]}
+                    tabIndex={0}
+                    type="button"
+                  >
+                    <span
+                      className="MuiButton-label"
+                    >
+                      時間不限
+                    </span>
+                    <NoSsr>
+                      <WithStyles(memo)
+                        center={false}
+                      >
+                        <ForwardRef(TouchRipple)
+                          center={false}
+                          classes={
+                            Object {
+                              "child": "MuiTouchRipple-child",
+                              "childLeaving": "MuiTouchRipple-childLeaving",
+                              "childPulsate": "MuiTouchRipple-childPulsate",
+                              "ripple": "MuiTouchRipple-ripple",
+                              "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                              "rippleVisible": "MuiTouchRipple-rippleVisible",
+                              "root": "MuiTouchRipple-root",
+                            }
+                          }
+                        >
+                          <span
+                            className="MuiTouchRipple-root"
+                          >
+                            <TransitionGroup
+                              childFactory={[Function]}
+                              component={null}
+                              exit={true}
+                            />
+                          </span>
+                        </ForwardRef(TouchRipple)>
+                      </WithStyles(memo)>
+                    </NoSsr>
+                  </button>
+                </ForwardRef(ButtonBase)>
+              </WithStyles(ForwardRef(ButtonBase))>
+            </ForwardRef(Button)>
+          </WithStyles(ForwardRef(Button))>
+        </div>
+      </ForwardRef(ButtonGroup)>
+    </WithStyles(ForwardRef(ButtonGroup))>
+    <WithStyles(ForwardRef(Menu))
+      anchorEl={null}
+      id="time-range"
+      keepMounted={true}
+      onClose={[Function]}
+      open={false}
+    >
+      <ForwardRef(Menu)
+        anchorEl={null}
+        classes={
+          Object {
+            "list": "MuiMenu-list",
+            "paper": "MuiMenu-paper",
+          }
+        }
+        id="time-range"
+        keepMounted={true}
+        onClose={[Function]}
+        open={false}
+      >
+        <WithStyles(ForwardRef(Popover))
+          PaperProps={
+            Object {
+              "classes": Object {
+                "root": "MuiMenu-paper",
+              },
+            }
+          }
+          anchorEl={null}
+          anchorOrigin={
+            Object {
+              "horizontal": "left",
+              "vertical": "top",
+            }
+          }
+          getContentAnchorEl={[Function]}
+          id="time-range"
+          keepMounted={true}
+          onClose={[Function]}
+          onEntering={[Function]}
+          open={false}
+          transformOrigin={
+            Object {
+              "horizontal": "left",
+              "vertical": "top",
+            }
+          }
+          transitionDuration="auto"
+        >
+          <ForwardRef(Popover)
+            PaperProps={
+              Object {
+                "classes": Object {
+                  "root": "MuiMenu-paper",
+                },
+              }
+            }
+            anchorEl={null}
+            anchorOrigin={
+              Object {
+                "horizontal": "left",
+                "vertical": "top",
+              }
+            }
+            classes={
+              Object {
+                "paper": "MuiPopover-paper",
+                "root": "MuiPopover-root",
+              }
+            }
+            getContentAnchorEl={[Function]}
+            id="time-range"
+            keepMounted={true}
+            onClose={[Function]}
+            onEntering={[Function]}
+            open={false}
+            transformOrigin={
+              Object {
+                "horizontal": "left",
+                "vertical": "top",
+              }
+            }
+            transitionDuration="auto"
+          >
+            <ForwardRef(Modal)
+              BackdropProps={
+                Object {
+                  "invisible": true,
+                }
+              }
+              className="MuiPopover-root"
+              id="time-range"
+              keepMounted={true}
+              onClose={[Function]}
+              open={false}
+            >
+              <ForwardRef(Portal)
+                disablePortal={false}
+              >
+                <Portal
+                  containerInfo={
+                    <body>
+                      <div
+                        aria-hidden="true"
+                        class="MuiPopover-root"
+                        id="time-range"
+                        role="presentation"
+                        style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
+                      >
+                        <div
+                          data-test="sentinelStart"
+                          tabindex="0"
+                        />
+                        <div
+                          class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                          style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
+                          tabindex="-1"
+                        >
+                          <ul
+                            class="MuiList-root MuiMenu-list MuiList-padding"
+                            role="menu"
+                            tabindex="-1"
+                          >
+                            <li
+                              aria-disabled="false"
+                              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                              data-ga="MenuItem(all)"
+                              role="menuitem"
+                              tabindex="0"
+                            >
+                              時間不限
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </li>
+                            <li
+                              aria-disabled="false"
+                              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                              data-ga="MenuItem(now-1d/d)"
+                              role="menuitem"
+                              tabindex="-1"
+                            >
+                              一天內
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </li>
+                            <li
+                              aria-disabled="false"
+                              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                              data-ga="MenuItem(now-1w/d)"
+                              role="menuitem"
+                              tabindex="-1"
+                            >
+                              一週內
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </li>
+                            <li
+                              aria-disabled="false"
+                              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                              data-ga="MenuItem(now-1m/d)"
+                              role="menuitem"
+                              tabindex="-1"
+                            >
+                              一個月內
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </li>
+                            <li
+                              aria-disabled="false"
+                              class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                              data-ga="MenuItem(custom)"
+                              role="menuitem"
+                              tabindex="-1"
+                            >
+                              自訂範圍
+                              <span
+                                class="MuiTouchRipple-root"
+                              />
+                            </li>
+                          </ul>
+                        </div>
+                        <div
+                          data-test="sentinelEnd"
+                          tabindex="0"
+                        />
+                      </div>
+                    </body>
+                  }
+                >
+                  <div
+                    className="MuiPopover-root"
+                    id="time-range"
+                    onKeyDown={[Function]}
+                    role="presentation"
+                    style={
+                      Object {
+                        "bottom": 0,
+                        "left": 0,
+                        "position": "fixed",
+                        "right": 0,
+                        "top": 0,
+                        "visibility": "hidden",
+                        "zIndex": 1300,
+                      }
+                    }
+                  >
+                    <ForwardRef(SimpleBackdrop)
+                      invisible={true}
+                      onClick={[Function]}
+                      open={false}
+                    />
+                    <TrapFocus
+                      disableAutoFocus={false}
+                      disableEnforceFocus={false}
+                      disableRestoreFocus={false}
+                      getDoc={[Function]}
+                      isEnabled={[Function]}
+                      open={false}
+                    >
+                      <div
+                        data-test="sentinelStart"
+                        tabIndex={0}
+                      />
+                      <ForwardRef(Grow)
+                        appear={true}
+                        in={false}
+                        onEnter={[Function]}
+                        onEntering={[Function]}
+                        onExited={[Function]}
+                        tabIndex="-1"
+                        timeout="auto"
+                      >
+                        <Transition
+                          addEndListener={[Function]}
+                          appear={true}
+                          enter={true}
+                          exit={true}
+                          in={false}
+                          mountOnEnter={false}
+                          onEnter={[Function]}
+                          onEntered={[Function]}
+                          onEntering={[Function]}
+                          onExit={[Function]}
+                          onExited={[Function]}
+                          onExiting={[Function]}
+                          tabIndex="-1"
+                          timeout={null}
+                          unmountOnExit={false}
+                        >
+                          <WithStyles(ForwardRef(Paper))
+                            className="MuiPopover-paper"
+                            classes={
+                              Object {
+                                "root": "MuiMenu-paper",
+                              }
+                            }
+                            elevation={8}
+                            style={
+                              Object {
+                                "opacity": 0,
+                                "transform": "scale(0.75, 0.5625)",
+                                "visibility": "hidden",
+                              }
+                            }
+                            tabIndex="-1"
+                          >
+                            <ForwardRef(Paper)
+                              className="MuiPopover-paper"
+                              classes={
+                                Object {
+                                  "elevation0": "MuiPaper-elevation0",
+                                  "elevation1": "MuiPaper-elevation1",
+                                  "elevation10": "MuiPaper-elevation10",
+                                  "elevation11": "MuiPaper-elevation11",
+                                  "elevation12": "MuiPaper-elevation12",
+                                  "elevation13": "MuiPaper-elevation13",
+                                  "elevation14": "MuiPaper-elevation14",
+                                  "elevation15": "MuiPaper-elevation15",
+                                  "elevation16": "MuiPaper-elevation16",
+                                  "elevation17": "MuiPaper-elevation17",
+                                  "elevation18": "MuiPaper-elevation18",
+                                  "elevation19": "MuiPaper-elevation19",
+                                  "elevation2": "MuiPaper-elevation2",
+                                  "elevation20": "MuiPaper-elevation20",
+                                  "elevation21": "MuiPaper-elevation21",
+                                  "elevation22": "MuiPaper-elevation22",
+                                  "elevation23": "MuiPaper-elevation23",
+                                  "elevation24": "MuiPaper-elevation24",
+                                  "elevation3": "MuiPaper-elevation3",
+                                  "elevation4": "MuiPaper-elevation4",
+                                  "elevation5": "MuiPaper-elevation5",
+                                  "elevation6": "MuiPaper-elevation6",
+                                  "elevation7": "MuiPaper-elevation7",
+                                  "elevation8": "MuiPaper-elevation8",
+                                  "elevation9": "MuiPaper-elevation9",
+                                  "outlined": "MuiPaper-outlined",
+                                  "root": "MuiPaper-root MuiMenu-paper",
+                                  "rounded": "MuiPaper-rounded",
+                                }
+                              }
+                              elevation={8}
+                              style={
+                                Object {
+                                  "opacity": 0,
+                                  "transform": "scale(0.75, 0.5625)",
+                                  "visibility": "hidden",
+                                }
+                              }
+                              tabIndex="-1"
+                            >
+                              <div
+                                className="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                                style={
+                                  Object {
+                                    "opacity": 0,
+                                    "transform": "scale(0.75, 0.5625)",
+                                    "visibility": "hidden",
+                                  }
+                                }
+                                tabIndex="-1"
+                              >
+                                <ForwardRef(MenuList)
+                                  actions={
+                                    Object {
+                                      "current": Object {
+                                        "adjustStyleForScrollbar": [Function],
+                                      },
+                                    }
+                                  }
+                                  autoFocus={false}
+                                  autoFocusItem={false}
+                                  className="MuiMenu-list"
+                                  onKeyDown={[Function]}
+                                  variant="selectedMenu"
+                                >
+                                  <WithStyles(ForwardRef(List))
+                                    className="MuiMenu-list"
+                                    onKeyDown={[Function]}
+                                    role="menu"
+                                    tabIndex={-1}
+                                  >
+                                    <ForwardRef(List)
+                                      className="MuiMenu-list"
+                                      classes={
+                                        Object {
+                                          "dense": "MuiList-dense",
+                                          "padding": "MuiList-padding",
+                                          "root": "MuiList-root",
+                                          "subheader": "MuiList-subheader",
+                                        }
+                                      }
+                                      onKeyDown={[Function]}
+                                      role="menu"
+                                      tabIndex={-1}
+                                    >
+                                      <ul
+                                        className="MuiList-root MuiMenu-list MuiList-padding"
+                                        onKeyDown={[Function]}
+                                        role="menu"
+                                        tabIndex={-1}
+                                      >
+                                        <WithStyles(ForwardRef(MenuItem))
+                                          data-ga="MenuItem(all)"
+                                          key=".$.$all"
+                                          onClick={[Function]}
+                                          tabIndex={0}
+                                        >
+                                          <ForwardRef(MenuItem)
+                                            classes={
+                                              Object {
+                                                "dense": "MuiMenuItem-dense",
+                                                "gutters": "MuiMenuItem-gutters",
+                                                "root": "MuiMenuItem-root",
+                                                "selected": "Mui-selected",
+                                              }
+                                            }
+                                            data-ga="MenuItem(all)"
+                                            onClick={[Function]}
+                                            tabIndex={0}
+                                          >
+                                            <WithStyles(ForwardRef(ListItem))
+                                              button={true}
+                                              className="MuiMenuItem-root MuiMenuItem-gutters"
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                }
+                                              }
+                                              component="li"
+                                              data-ga="MenuItem(all)"
+                                              disableGutters={false}
+                                              onClick={[Function]}
+                                              role="menuitem"
+                                              tabIndex={0}
+                                            >
+                                              <ForwardRef(ListItem)
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                    "button": "MuiListItem-button",
+                                                    "container": "MuiListItem-container",
+                                                    "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                    "disabled": "Mui-disabled",
+                                                    "divider": "MuiListItem-divider",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "gutters": "MuiListItem-gutters",
+                                                    "root": "MuiListItem-root",
+                                                    "secondaryAction": "MuiListItem-secondaryAction",
+                                                    "selected": "Mui-selected",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(all)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={0}
+                                              >
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                  component="li"
+                                                  data-ga="MenuItem(all)"
+                                                  disabled={false}
+                                                  focusVisibleClassName="Mui-focusVisible"
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={0}
+                                                >
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    classes={
+                                                      Object {
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
+                                                      }
+                                                    }
+                                                    component="li"
+                                                    data-ga="MenuItem(all)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={0}
+                                                  >
+                                                    <li
+                                                      aria-disabled={false}
+                                                      className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      data-ga="MenuItem(all)"
+                                                      onBlur={[Function]}
+                                                      onClick={[Function]}
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={0}
+                                                    >
+                                                      時間不限
+                                                      <NoSsr>
+                                                        <WithStyles(memo)
+                                                          center={false}
+                                                        >
+                                                          <ForwardRef(TouchRipple)
+                                                            center={false}
+                                                            classes={
+                                                              Object {
+                                                                "child": "MuiTouchRipple-child",
+                                                                "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                "ripple": "MuiTouchRipple-ripple",
+                                                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                "root": "MuiTouchRipple-root",
+                                                              }
+                                                            }
+                                                          >
+                                                            <span
+                                                              className="MuiTouchRipple-root"
+                                                            >
+                                                              <TransitionGroup
+                                                                childFactory={[Function]}
+                                                                component={null}
+                                                                exit={true}
+                                                              />
+                                                            </span>
+                                                          </ForwardRef(TouchRipple)>
+                                                        </WithStyles(memo)>
+                                                      </NoSsr>
+                                                    </li>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(ListItem)>
+                                            </WithStyles(ForwardRef(ListItem))>
+                                          </ForwardRef(MenuItem)>
+                                        </WithStyles(ForwardRef(MenuItem))>
+                                        <WithStyles(ForwardRef(MenuItem))
+                                          data-ga="MenuItem(now-1d/d)"
+                                          key=".$.$now-1d/d"
+                                          onClick={[Function]}
+                                        >
+                                          <ForwardRef(MenuItem)
+                                            classes={
+                                              Object {
+                                                "dense": "MuiMenuItem-dense",
+                                                "gutters": "MuiMenuItem-gutters",
+                                                "root": "MuiMenuItem-root",
+                                                "selected": "Mui-selected",
+                                              }
+                                            }
+                                            data-ga="MenuItem(now-1d/d)"
+                                            onClick={[Function]}
+                                          >
+                                            <WithStyles(ForwardRef(ListItem))
+                                              button={true}
+                                              className="MuiMenuItem-root MuiMenuItem-gutters"
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                }
+                                              }
+                                              component="li"
+                                              data-ga="MenuItem(now-1d/d)"
+                                              disableGutters={false}
+                                              onClick={[Function]}
+                                              role="menuitem"
+                                              tabIndex={-1}
+                                            >
+                                              <ForwardRef(ListItem)
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                    "button": "MuiListItem-button",
+                                                    "container": "MuiListItem-container",
+                                                    "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                    "disabled": "Mui-disabled",
+                                                    "divider": "MuiListItem-divider",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "gutters": "MuiListItem-gutters",
+                                                    "root": "MuiListItem-root",
+                                                    "secondaryAction": "MuiListItem-secondaryAction",
+                                                    "selected": "Mui-selected",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(now-1d/d)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                  component="li"
+                                                  data-ga="MenuItem(now-1d/d)"
+                                                  disabled={false}
+                                                  focusVisibleClassName="Mui-focusVisible"
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    classes={
+                                                      Object {
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
+                                                      }
+                                                    }
+                                                    component="li"
+                                                    data-ga="MenuItem(now-1d/d)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <li
+                                                      aria-disabled={false}
+                                                      className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      data-ga="MenuItem(now-1d/d)"
+                                                      onBlur={[Function]}
+                                                      onClick={[Function]}
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      一天內
+                                                      <NoSsr>
+                                                        <WithStyles(memo)
+                                                          center={false}
+                                                        >
+                                                          <ForwardRef(TouchRipple)
+                                                            center={false}
+                                                            classes={
+                                                              Object {
+                                                                "child": "MuiTouchRipple-child",
+                                                                "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                "ripple": "MuiTouchRipple-ripple",
+                                                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                "root": "MuiTouchRipple-root",
+                                                              }
+                                                            }
+                                                          >
+                                                            <span
+                                                              className="MuiTouchRipple-root"
+                                                            >
+                                                              <TransitionGroup
+                                                                childFactory={[Function]}
+                                                                component={null}
+                                                                exit={true}
+                                                              />
+                                                            </span>
+                                                          </ForwardRef(TouchRipple)>
+                                                        </WithStyles(memo)>
+                                                      </NoSsr>
+                                                    </li>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(ListItem)>
+                                            </WithStyles(ForwardRef(ListItem))>
+                                          </ForwardRef(MenuItem)>
+                                        </WithStyles(ForwardRef(MenuItem))>
+                                        <WithStyles(ForwardRef(MenuItem))
+                                          data-ga="MenuItem(now-1w/d)"
+                                          key=".$.$now-1w/d"
+                                          onClick={[Function]}
+                                        >
+                                          <ForwardRef(MenuItem)
+                                            classes={
+                                              Object {
+                                                "dense": "MuiMenuItem-dense",
+                                                "gutters": "MuiMenuItem-gutters",
+                                                "root": "MuiMenuItem-root",
+                                                "selected": "Mui-selected",
+                                              }
+                                            }
+                                            data-ga="MenuItem(now-1w/d)"
+                                            onClick={[Function]}
+                                          >
+                                            <WithStyles(ForwardRef(ListItem))
+                                              button={true}
+                                              className="MuiMenuItem-root MuiMenuItem-gutters"
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                }
+                                              }
+                                              component="li"
+                                              data-ga="MenuItem(now-1w/d)"
+                                              disableGutters={false}
+                                              onClick={[Function]}
+                                              role="menuitem"
+                                              tabIndex={-1}
+                                            >
+                                              <ForwardRef(ListItem)
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                    "button": "MuiListItem-button",
+                                                    "container": "MuiListItem-container",
+                                                    "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                    "disabled": "Mui-disabled",
+                                                    "divider": "MuiListItem-divider",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "gutters": "MuiListItem-gutters",
+                                                    "root": "MuiListItem-root",
+                                                    "secondaryAction": "MuiListItem-secondaryAction",
+                                                    "selected": "Mui-selected",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(now-1w/d)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                  component="li"
+                                                  data-ga="MenuItem(now-1w/d)"
+                                                  disabled={false}
+                                                  focusVisibleClassName="Mui-focusVisible"
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    classes={
+                                                      Object {
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
+                                                      }
+                                                    }
+                                                    component="li"
+                                                    data-ga="MenuItem(now-1w/d)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <li
+                                                      aria-disabled={false}
+                                                      className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      data-ga="MenuItem(now-1w/d)"
+                                                      onBlur={[Function]}
+                                                      onClick={[Function]}
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      一週內
+                                                      <NoSsr>
+                                                        <WithStyles(memo)
+                                                          center={false}
+                                                        >
+                                                          <ForwardRef(TouchRipple)
+                                                            center={false}
+                                                            classes={
+                                                              Object {
+                                                                "child": "MuiTouchRipple-child",
+                                                                "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                "ripple": "MuiTouchRipple-ripple",
+                                                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                "root": "MuiTouchRipple-root",
+                                                              }
+                                                            }
+                                                          >
+                                                            <span
+                                                              className="MuiTouchRipple-root"
+                                                            >
+                                                              <TransitionGroup
+                                                                childFactory={[Function]}
+                                                                component={null}
+                                                                exit={true}
+                                                              />
+                                                            </span>
+                                                          </ForwardRef(TouchRipple)>
+                                                        </WithStyles(memo)>
+                                                      </NoSsr>
+                                                    </li>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(ListItem)>
+                                            </WithStyles(ForwardRef(ListItem))>
+                                          </ForwardRef(MenuItem)>
+                                        </WithStyles(ForwardRef(MenuItem))>
+                                        <WithStyles(ForwardRef(MenuItem))
+                                          data-ga="MenuItem(now-1m/d)"
+                                          key=".$.$now-1m/d"
+                                          onClick={[Function]}
+                                        >
+                                          <ForwardRef(MenuItem)
+                                            classes={
+                                              Object {
+                                                "dense": "MuiMenuItem-dense",
+                                                "gutters": "MuiMenuItem-gutters",
+                                                "root": "MuiMenuItem-root",
+                                                "selected": "Mui-selected",
+                                              }
+                                            }
+                                            data-ga="MenuItem(now-1m/d)"
+                                            onClick={[Function]}
+                                          >
+                                            <WithStyles(ForwardRef(ListItem))
+                                              button={true}
+                                              className="MuiMenuItem-root MuiMenuItem-gutters"
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                }
+                                              }
+                                              component="li"
+                                              data-ga="MenuItem(now-1m/d)"
+                                              disableGutters={false}
+                                              onClick={[Function]}
+                                              role="menuitem"
+                                              tabIndex={-1}
+                                            >
+                                              <ForwardRef(ListItem)
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                    "button": "MuiListItem-button",
+                                                    "container": "MuiListItem-container",
+                                                    "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                    "disabled": "Mui-disabled",
+                                                    "divider": "MuiListItem-divider",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "gutters": "MuiListItem-gutters",
+                                                    "root": "MuiListItem-root",
+                                                    "secondaryAction": "MuiListItem-secondaryAction",
+                                                    "selected": "Mui-selected",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(now-1m/d)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                  component="li"
+                                                  data-ga="MenuItem(now-1m/d)"
+                                                  disabled={false}
+                                                  focusVisibleClassName="Mui-focusVisible"
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    classes={
+                                                      Object {
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
+                                                      }
+                                                    }
+                                                    component="li"
+                                                    data-ga="MenuItem(now-1m/d)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <li
+                                                      aria-disabled={false}
+                                                      className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      data-ga="MenuItem(now-1m/d)"
+                                                      onBlur={[Function]}
+                                                      onClick={[Function]}
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      一個月內
+                                                      <NoSsr>
+                                                        <WithStyles(memo)
+                                                          center={false}
+                                                        >
+                                                          <ForwardRef(TouchRipple)
+                                                            center={false}
+                                                            classes={
+                                                              Object {
+                                                                "child": "MuiTouchRipple-child",
+                                                                "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                "ripple": "MuiTouchRipple-ripple",
+                                                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                "root": "MuiTouchRipple-root",
+                                                              }
+                                                            }
+                                                          >
+                                                            <span
+                                                              className="MuiTouchRipple-root"
+                                                            >
+                                                              <TransitionGroup
+                                                                childFactory={[Function]}
+                                                                component={null}
+                                                                exit={true}
+                                                              />
+                                                            </span>
+                                                          </ForwardRef(TouchRipple)>
+                                                        </WithStyles(memo)>
+                                                      </NoSsr>
+                                                    </li>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(ListItem)>
+                                            </WithStyles(ForwardRef(ListItem))>
+                                          </ForwardRef(MenuItem)>
+                                        </WithStyles(ForwardRef(MenuItem))>
+                                        <WithStyles(ForwardRef(MenuItem))
+                                          data-ga="MenuItem(custom)"
+                                          key=".$.$custom"
+                                          onClick={[Function]}
+                                        >
+                                          <ForwardRef(MenuItem)
+                                            classes={
+                                              Object {
+                                                "dense": "MuiMenuItem-dense",
+                                                "gutters": "MuiMenuItem-gutters",
+                                                "root": "MuiMenuItem-root",
+                                                "selected": "Mui-selected",
+                                              }
+                                            }
+                                            data-ga="MenuItem(custom)"
+                                            onClick={[Function]}
+                                          >
+                                            <WithStyles(ForwardRef(ListItem))
+                                              button={true}
+                                              className="MuiMenuItem-root MuiMenuItem-gutters"
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                }
+                                              }
+                                              component="li"
+                                              data-ga="MenuItem(custom)"
+                                              disableGutters={false}
+                                              onClick={[Function]}
+                                              role="menuitem"
+                                              tabIndex={-1}
+                                            >
+                                              <ForwardRef(ListItem)
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                    "button": "MuiListItem-button",
+                                                    "container": "MuiListItem-container",
+                                                    "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                    "disabled": "Mui-disabled",
+                                                    "divider": "MuiListItem-divider",
+                                                    "focusVisible": "Mui-focusVisible",
+                                                    "gutters": "MuiListItem-gutters",
+                                                    "root": "MuiListItem-root",
+                                                    "secondaryAction": "MuiListItem-secondaryAction",
+                                                    "selected": "Mui-selected",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(custom)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <WithStyles(ForwardRef(ButtonBase))
+                                                  className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                  component="li"
+                                                  data-ga="MenuItem(custom)"
+                                                  disabled={false}
+                                                  focusVisibleClassName="Mui-focusVisible"
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <ForwardRef(ButtonBase)
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    classes={
+                                                      Object {
+                                                        "disabled": "Mui-disabled",
+                                                        "focusVisible": "Mui-focusVisible",
+                                                        "root": "MuiButtonBase-root",
+                                                      }
+                                                    }
+                                                    component="li"
+                                                    data-ga="MenuItem(custom)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <li
+                                                      aria-disabled={false}
+                                                      className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      data-ga="MenuItem(custom)"
+                                                      onBlur={[Function]}
+                                                      onClick={[Function]}
+                                                      onDragLeave={[Function]}
+                                                      onFocus={[Function]}
+                                                      onKeyDown={[Function]}
+                                                      onKeyUp={[Function]}
+                                                      onMouseDown={[Function]}
+                                                      onMouseLeave={[Function]}
+                                                      onMouseUp={[Function]}
+                                                      onTouchEnd={[Function]}
+                                                      onTouchMove={[Function]}
+                                                      onTouchStart={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      自訂範圍
+                                                      <NoSsr>
+                                                        <WithStyles(memo)
+                                                          center={false}
+                                                        >
+                                                          <ForwardRef(TouchRipple)
+                                                            center={false}
+                                                            classes={
+                                                              Object {
+                                                                "child": "MuiTouchRipple-child",
+                                                                "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                "ripple": "MuiTouchRipple-ripple",
+                                                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                "root": "MuiTouchRipple-root",
+                                                              }
+                                                            }
+                                                          >
+                                                            <span
+                                                              className="MuiTouchRipple-root"
+                                                            >
+                                                              <TransitionGroup
+                                                                childFactory={[Function]}
+                                                                component={null}
+                                                                exit={true}
+                                                              />
+                                                            </span>
+                                                          </ForwardRef(TouchRipple)>
+                                                        </WithStyles(memo)>
+                                                      </NoSsr>
+                                                    </li>
+                                                  </ForwardRef(ButtonBase)>
+                                                </WithStyles(ForwardRef(ButtonBase))>
+                                              </ForwardRef(ListItem)>
+                                            </WithStyles(ForwardRef(ListItem))>
+                                          </ForwardRef(MenuItem)>
+                                        </WithStyles(ForwardRef(MenuItem))>
+                                      </ul>
+                                    </ForwardRef(List)>
+                                  </WithStyles(ForwardRef(List))>
+                                </ForwardRef(MenuList)>
+                              </div>
+                            </ForwardRef(Paper)>
+                          </WithStyles(ForwardRef(Paper))>
+                        </Transition>
+                      </ForwardRef(Grow)>
+                      <div
+                        data-test="sentinelEnd"
+                        tabIndex={0}
+                      />
+                    </TrapFocus>
+                  </div>
+                </Portal>
+              </ForwardRef(Portal)>
+            </ForwardRef(Modal)>
+          </ForwardRef(Popover)>
+        </WithStyles(ForwardRef(Popover))>
+      </ForwardRef(Menu)>
+    </WithStyles(ForwardRef(Menu))>
+  </div>
+</TimeRange>
+`;
 
-exports[`Storyshots TimeRange Set Range From Props 1`] = `ReactWrapper {}`;
+exports[`Storyshots TimeRange Set Range From Props 1`] = `
+<div>
+  <p>
+    range = null:
+  </p>
+  <TimeRange
+    onChange={[Function]}
+    range={null}
+  >
+    <div
+      className="makeStyles-root-134"
+    >
+      <WithStyles(ForwardRef(ButtonGroup))
+        classes={
+          Object {
+            "contained": "makeStyles-buttonGroup-135",
+          }
+        }
+      >
+        <ForwardRef(ButtonGroup)
+          classes={
+            Object {
+              "contained": "MuiButtonGroup-contained makeStyles-buttonGroup-135",
+              "disabled": "Mui-disabled",
+              "fullWidth": "MuiButtonGroup-fullWidth",
+              "grouped": "MuiButtonGroup-grouped",
+              "groupedContained": "MuiButtonGroup-groupedContained",
+              "groupedContainedHorizontal": "MuiButtonGroup-groupedContainedHorizontal",
+              "groupedContainedPrimary": "MuiButtonGroup-groupedContainedPrimary",
+              "groupedContainedSecondary": "MuiButtonGroup-groupedContainedSecondary",
+              "groupedContainedVertical": "MuiButtonGroup-groupedContainedVertical",
+              "groupedHorizontal": "MuiButtonGroup-groupedHorizontal",
+              "groupedOutlined": "MuiButtonGroup-groupedOutlined",
+              "groupedOutlinedHorizontal": "MuiButtonGroup-groupedOutlinedHorizontal",
+              "groupedOutlinedPrimary": "MuiButtonGroup-groupedOutlinedPrimary",
+              "groupedOutlinedSecondary": "MuiButtonGroup-groupedOutlinedSecondary",
+              "groupedOutlinedVertical": "MuiButtonGroup-groupedOutlinedVertical",
+              "groupedText": "MuiButtonGroup-groupedText",
+              "groupedTextHorizontal": "MuiButtonGroup-groupedTextHorizontal",
+              "groupedTextPrimary": "MuiButtonGroup-groupedTextPrimary",
+              "groupedTextSecondary": "MuiButtonGroup-groupedTextSecondary",
+              "groupedTextVertical": "MuiButtonGroup-groupedTextVertical",
+              "groupedVertical": "MuiButtonGroup-groupedVertical",
+              "root": "MuiButtonGroup-root",
+              "vertical": "MuiButtonGroup-vertical",
+            }
+          }
+        >
+          <div
+            className="MuiButtonGroup-root"
+            role="group"
+          >
+            <WithStyles(ForwardRef(Button))
+              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+              color="default"
+              disableFocusRipple={false}
+              disableRipple={false}
+              disabled={false}
+              fullWidth={false}
+              key=".0"
+              onClick={[Function]}
+              size="medium"
+              variant="outlined"
+            >
+              <ForwardRef(Button)
+                className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+                classes={
+                  Object {
+                    "colorInherit": "MuiButton-colorInherit",
+                    "contained": "MuiButton-contained",
+                    "containedPrimary": "MuiButton-containedPrimary",
+                    "containedSecondary": "MuiButton-containedSecondary",
+                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                    "disableElevation": "MuiButton-disableElevation",
+                    "disabled": "Mui-disabled",
+                    "endIcon": "MuiButton-endIcon",
+                    "focusVisible": "Mui-focusVisible",
+                    "fullWidth": "MuiButton-fullWidth",
+                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                    "label": "MuiButton-label",
+                    "outlined": "MuiButton-outlined",
+                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                    "root": "MuiButton-root",
+                    "sizeLarge": "MuiButton-sizeLarge",
+                    "sizeSmall": "MuiButton-sizeSmall",
+                    "startIcon": "MuiButton-startIcon",
+                    "text": "MuiButton-text",
+                    "textPrimary": "MuiButton-textPrimary",
+                    "textSecondary": "MuiButton-textSecondary",
+                    "textSizeLarge": "MuiButton-textSizeLarge",
+                    "textSizeSmall": "MuiButton-textSizeSmall",
+                  }
+                }
+                color="default"
+                disableFocusRipple={false}
+                disableRipple={false}
+                disabled={false}
+                fullWidth={false}
+                onClick={[Function]}
+                size="medium"
+                variant="outlined"
+              >
+                <WithStyles(ForwardRef(ButtonBase))
+                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+                  component="button"
+                  disableRipple={false}
+                  disabled={false}
+                  focusRipple={true}
+                  focusVisibleClassName="Mui-focusVisible"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <ForwardRef(ButtonBase)
+                    className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+                    classes={
+                      Object {
+                        "disabled": "Mui-disabled",
+                        "focusVisible": "Mui-focusVisible",
+                        "root": "MuiButtonBase-root",
+                      }
+                    }
+                    component="button"
+                    disableRipple={false}
+                    disabled={false}
+                    focusRipple={true}
+                    focusVisibleClassName="Mui-focusVisible"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onDragLeave={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyUp={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="MuiButton-label"
+                      >
+                        <ForwardRef
+                          className="makeStyles-calendarIcon-137"
+                        >
+                          <WithStyles(ForwardRef(SvgIcon))
+                            className="makeStyles-calendarIcon-137"
+                          >
+                            <ForwardRef(SvgIcon)
+                              className="makeStyles-calendarIcon-137"
+                              classes={
+                                Object {
+                                  "colorAction": "MuiSvgIcon-colorAction",
+                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                  "colorError": "MuiSvgIcon-colorError",
+                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                  "root": "MuiSvgIcon-root",
+                                }
+                              }
+                            >
+                              <svg
+                                aria-hidden="true"
+                                className="MuiSvgIcon-root makeStyles-calendarIcon-137"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"
+                                />
+                              </svg>
+                            </ForwardRef(SvgIcon)>
+                          </WithStyles(ForwardRef(SvgIcon))>
+                        </ForwardRef>
+                      </span>
+                      <NoSsr>
+                        <WithStyles(memo)
+                          center={false}
+                        >
+                          <ForwardRef(TouchRipple)
+                            center={false}
+                            classes={
+                              Object {
+                                "child": "MuiTouchRipple-child",
+                                "childLeaving": "MuiTouchRipple-childLeaving",
+                                "childPulsate": "MuiTouchRipple-childPulsate",
+                                "ripple": "MuiTouchRipple-ripple",
+                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                "root": "MuiTouchRipple-root",
+                              }
+                            }
+                          >
+                            <span
+                              className="MuiTouchRipple-root"
+                            >
+                              <TransitionGroup
+                                childFactory={[Function]}
+                                component={null}
+                                exit={true}
+                              />
+                            </span>
+                          </ForwardRef(TouchRipple)>
+                        </WithStyles(memo)>
+                      </NoSsr>
+                    </button>
+                  </ForwardRef(ButtonBase)>
+                </WithStyles(ForwardRef(ButtonBase))>
+              </ForwardRef(Button)>
+            </WithStyles(ForwardRef(Button))>
+            <WithStyles(ForwardRef(Button))
+              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
+              color="default"
+              disableFocusRipple={false}
+              disableRipple={false}
+              disabled={false}
+              fullWidth={false}
+              key=".1"
+              onClick={[Function]}
+              size="medium"
+              variant="outlined"
+            >
+              <ForwardRef(Button)
+                className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
+                classes={
+                  Object {
+                    "colorInherit": "MuiButton-colorInherit",
+                    "contained": "MuiButton-contained",
+                    "containedPrimary": "MuiButton-containedPrimary",
+                    "containedSecondary": "MuiButton-containedSecondary",
+                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                    "disableElevation": "MuiButton-disableElevation",
+                    "disabled": "Mui-disabled",
+                    "endIcon": "MuiButton-endIcon",
+                    "focusVisible": "Mui-focusVisible",
+                    "fullWidth": "MuiButton-fullWidth",
+                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                    "label": "MuiButton-label",
+                    "outlined": "MuiButton-outlined",
+                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                    "root": "MuiButton-root",
+                    "sizeLarge": "MuiButton-sizeLarge",
+                    "sizeSmall": "MuiButton-sizeSmall",
+                    "startIcon": "MuiButton-startIcon",
+                    "text": "MuiButton-text",
+                    "textPrimary": "MuiButton-textPrimary",
+                    "textSecondary": "MuiButton-textSecondary",
+                    "textSizeLarge": "MuiButton-textSizeLarge",
+                    "textSizeSmall": "MuiButton-textSizeSmall",
+                  }
+                }
+                color="default"
+                disableFocusRipple={false}
+                disableRipple={false}
+                disabled={false}
+                fullWidth={false}
+                onClick={[Function]}
+                size="medium"
+                variant="outlined"
+              >
+                <WithStyles(ForwardRef(ButtonBase))
+                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
+                  component="button"
+                  disableRipple={false}
+                  disabled={false}
+                  focusRipple={true}
+                  focusVisibleClassName="Mui-focusVisible"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <ForwardRef(ButtonBase)
+                    className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
+                    classes={
+                      Object {
+                        "disabled": "Mui-disabled",
+                        "focusVisible": "Mui-focusVisible",
+                        "root": "MuiButtonBase-root",
+                      }
+                    }
+                    component="button"
+                    disableRipple={false}
+                    disabled={false}
+                    focusRipple={true}
+                    focusVisibleClassName="Mui-focusVisible"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onDragLeave={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyUp={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="MuiButton-label"
+                      >
+                        時間不限
+                      </span>
+                      <NoSsr>
+                        <WithStyles(memo)
+                          center={false}
+                        >
+                          <ForwardRef(TouchRipple)
+                            center={false}
+                            classes={
+                              Object {
+                                "child": "MuiTouchRipple-child",
+                                "childLeaving": "MuiTouchRipple-childLeaving",
+                                "childPulsate": "MuiTouchRipple-childPulsate",
+                                "ripple": "MuiTouchRipple-ripple",
+                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                "root": "MuiTouchRipple-root",
+                              }
+                            }
+                          >
+                            <span
+                              className="MuiTouchRipple-root"
+                            >
+                              <TransitionGroup
+                                childFactory={[Function]}
+                                component={null}
+                                exit={true}
+                              />
+                            </span>
+                          </ForwardRef(TouchRipple)>
+                        </WithStyles(memo)>
+                      </NoSsr>
+                    </button>
+                  </ForwardRef(ButtonBase)>
+                </WithStyles(ForwardRef(ButtonBase))>
+              </ForwardRef(Button)>
+            </WithStyles(ForwardRef(Button))>
+          </div>
+        </ForwardRef(ButtonGroup)>
+      </WithStyles(ForwardRef(ButtonGroup))>
+      <WithStyles(ForwardRef(Menu))
+        anchorEl={null}
+        id="time-range"
+        keepMounted={true}
+        onClose={[Function]}
+        open={false}
+      >
+        <ForwardRef(Menu)
+          anchorEl={null}
+          classes={
+            Object {
+              "list": "MuiMenu-list",
+              "paper": "MuiMenu-paper",
+            }
+          }
+          id="time-range"
+          keepMounted={true}
+          onClose={[Function]}
+          open={false}
+        >
+          <WithStyles(ForwardRef(Popover))
+            PaperProps={
+              Object {
+                "classes": Object {
+                  "root": "MuiMenu-paper",
+                },
+              }
+            }
+            anchorEl={null}
+            anchorOrigin={
+              Object {
+                "horizontal": "left",
+                "vertical": "top",
+              }
+            }
+            getContentAnchorEl={[Function]}
+            id="time-range"
+            keepMounted={true}
+            onClose={[Function]}
+            onEntering={[Function]}
+            open={false}
+            transformOrigin={
+              Object {
+                "horizontal": "left",
+                "vertical": "top",
+              }
+            }
+            transitionDuration="auto"
+          >
+            <ForwardRef(Popover)
+              PaperProps={
+                Object {
+                  "classes": Object {
+                    "root": "MuiMenu-paper",
+                  },
+                }
+              }
+              anchorEl={null}
+              anchorOrigin={
+                Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                }
+              }
+              classes={
+                Object {
+                  "paper": "MuiPopover-paper",
+                  "root": "MuiPopover-root",
+                }
+              }
+              getContentAnchorEl={[Function]}
+              id="time-range"
+              keepMounted={true}
+              onClose={[Function]}
+              onEntering={[Function]}
+              open={false}
+              transformOrigin={
+                Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                }
+              }
+              transitionDuration="auto"
+            >
+              <ForwardRef(Modal)
+                BackdropProps={
+                  Object {
+                    "invisible": true,
+                  }
+                }
+                className="MuiPopover-root"
+                id="time-range"
+                keepMounted={true}
+                onClose={[Function]}
+                open={false}
+              >
+                <ForwardRef(Portal)
+                  disablePortal={false}
+                >
+                  <Portal
+                    containerInfo={
+                      <body>
+                        <div
+                          aria-hidden="true"
+                          class="MuiPopover-root"
+                          id="time-range"
+                          role="presentation"
+                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
+                        >
+                          <div
+                            data-test="sentinelStart"
+                            tabindex="0"
+                          />
+                          <div
+                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
+                            tabindex="-1"
+                          >
+                            <ul
+                              class="MuiList-root MuiMenu-list MuiList-padding"
+                              role="menu"
+                              tabindex="-1"
+                            >
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(all)"
+                                role="menuitem"
+                                tabindex="0"
+                              >
+                                時間不限
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1d/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一天內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1w/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一週內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1m/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一個月內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(custom)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                自訂範圍
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                            </ul>
+                          </div>
+                          <div
+                            data-test="sentinelEnd"
+                            tabindex="0"
+                          />
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="MuiPopover-root"
+                          id="time-range"
+                          role="presentation"
+                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
+                        >
+                          <div
+                            data-test="sentinelStart"
+                            tabindex="0"
+                          />
+                          <div
+                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
+                            tabindex="-1"
+                          >
+                            <ul
+                              class="MuiList-root MuiMenu-list MuiList-padding"
+                              role="menu"
+                              tabindex="-1"
+                            >
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(all)"
+                                role="menuitem"
+                                tabindex="0"
+                              >
+                                時間不限
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1d/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一天內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1w/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一週內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1m/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一個月內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(custom)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                自訂範圍
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                            </ul>
+                          </div>
+                          <div
+                            data-test="sentinelEnd"
+                            tabindex="0"
+                          />
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="MuiPopover-root"
+                          id="time-range"
+                          role="presentation"
+                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
+                        >
+                          <div
+                            data-test="sentinelStart"
+                            tabindex="0"
+                          />
+                          <div
+                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
+                            tabindex="-1"
+                          >
+                            <ul
+                              class="MuiList-root MuiMenu-list MuiList-padding"
+                              role="menu"
+                              tabindex="-1"
+                            >
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(all)"
+                                role="menuitem"
+                                tabindex="0"
+                              >
+                                時間不限
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1d/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一天內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1w/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一週內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1m/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一個月內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(custom)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                自訂範圍
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                            </ul>
+                          </div>
+                          <div
+                            data-test="sentinelEnd"
+                            tabindex="0"
+                          />
+                        </div>
+                      </body>
+                    }
+                  >
+                    <div
+                      className="MuiPopover-root"
+                      id="time-range"
+                      onKeyDown={[Function]}
+                      role="presentation"
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "left": 0,
+                          "position": "fixed",
+                          "right": 0,
+                          "top": 0,
+                          "visibility": "hidden",
+                          "zIndex": 1300,
+                        }
+                      }
+                    >
+                      <ForwardRef(SimpleBackdrop)
+                        invisible={true}
+                        onClick={[Function]}
+                        open={false}
+                      />
+                      <TrapFocus
+                        disableAutoFocus={false}
+                        disableEnforceFocus={false}
+                        disableRestoreFocus={false}
+                        getDoc={[Function]}
+                        isEnabled={[Function]}
+                        open={false}
+                      >
+                        <div
+                          data-test="sentinelStart"
+                          tabIndex={0}
+                        />
+                        <ForwardRef(Grow)
+                          appear={true}
+                          in={false}
+                          onEnter={[Function]}
+                          onEntering={[Function]}
+                          onExited={[Function]}
+                          tabIndex="-1"
+                          timeout="auto"
+                        >
+                          <Transition
+                            addEndListener={[Function]}
+                            appear={true}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            tabIndex="-1"
+                            timeout={null}
+                            unmountOnExit={false}
+                          >
+                            <WithStyles(ForwardRef(Paper))
+                              className="MuiPopover-paper"
+                              classes={
+                                Object {
+                                  "root": "MuiMenu-paper",
+                                }
+                              }
+                              elevation={8}
+                              style={
+                                Object {
+                                  "opacity": 0,
+                                  "transform": "scale(0.75, 0.5625)",
+                                  "visibility": "hidden",
+                                }
+                              }
+                              tabIndex="-1"
+                            >
+                              <ForwardRef(Paper)
+                                className="MuiPopover-paper"
+                                classes={
+                                  Object {
+                                    "elevation0": "MuiPaper-elevation0",
+                                    "elevation1": "MuiPaper-elevation1",
+                                    "elevation10": "MuiPaper-elevation10",
+                                    "elevation11": "MuiPaper-elevation11",
+                                    "elevation12": "MuiPaper-elevation12",
+                                    "elevation13": "MuiPaper-elevation13",
+                                    "elevation14": "MuiPaper-elevation14",
+                                    "elevation15": "MuiPaper-elevation15",
+                                    "elevation16": "MuiPaper-elevation16",
+                                    "elevation17": "MuiPaper-elevation17",
+                                    "elevation18": "MuiPaper-elevation18",
+                                    "elevation19": "MuiPaper-elevation19",
+                                    "elevation2": "MuiPaper-elevation2",
+                                    "elevation20": "MuiPaper-elevation20",
+                                    "elevation21": "MuiPaper-elevation21",
+                                    "elevation22": "MuiPaper-elevation22",
+                                    "elevation23": "MuiPaper-elevation23",
+                                    "elevation24": "MuiPaper-elevation24",
+                                    "elevation3": "MuiPaper-elevation3",
+                                    "elevation4": "MuiPaper-elevation4",
+                                    "elevation5": "MuiPaper-elevation5",
+                                    "elevation6": "MuiPaper-elevation6",
+                                    "elevation7": "MuiPaper-elevation7",
+                                    "elevation8": "MuiPaper-elevation8",
+                                    "elevation9": "MuiPaper-elevation9",
+                                    "outlined": "MuiPaper-outlined",
+                                    "root": "MuiPaper-root MuiMenu-paper",
+                                    "rounded": "MuiPaper-rounded",
+                                  }
+                                }
+                                elevation={8}
+                                style={
+                                  Object {
+                                    "opacity": 0,
+                                    "transform": "scale(0.75, 0.5625)",
+                                    "visibility": "hidden",
+                                  }
+                                }
+                                tabIndex="-1"
+                              >
+                                <div
+                                  className="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                                  style={
+                                    Object {
+                                      "opacity": 0,
+                                      "transform": "scale(0.75, 0.5625)",
+                                      "visibility": "hidden",
+                                    }
+                                  }
+                                  tabIndex="-1"
+                                >
+                                  <ForwardRef(MenuList)
+                                    actions={
+                                      Object {
+                                        "current": Object {
+                                          "adjustStyleForScrollbar": [Function],
+                                        },
+                                      }
+                                    }
+                                    autoFocus={false}
+                                    autoFocusItem={false}
+                                    className="MuiMenu-list"
+                                    onKeyDown={[Function]}
+                                    variant="selectedMenu"
+                                  >
+                                    <WithStyles(ForwardRef(List))
+                                      className="MuiMenu-list"
+                                      onKeyDown={[Function]}
+                                      role="menu"
+                                      tabIndex={-1}
+                                    >
+                                      <ForwardRef(List)
+                                        className="MuiMenu-list"
+                                        classes={
+                                          Object {
+                                            "dense": "MuiList-dense",
+                                            "padding": "MuiList-padding",
+                                            "root": "MuiList-root",
+                                            "subheader": "MuiList-subheader",
+                                          }
+                                        }
+                                        onKeyDown={[Function]}
+                                        role="menu"
+                                        tabIndex={-1}
+                                      >
+                                        <ul
+                                          className="MuiList-root MuiMenu-list MuiList-padding"
+                                          onKeyDown={[Function]}
+                                          role="menu"
+                                          tabIndex={-1}
+                                        >
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(all)"
+                                            key=".$.$all"
+                                            onClick={[Function]}
+                                            tabIndex={0}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(all)"
+                                              onClick={[Function]}
+                                              tabIndex={0}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(all)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={0}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(all)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={0}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(all)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={0}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(all)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={0}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(all)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={0}
+                                                      >
+                                                        時間不限
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(now-1d/d)"
+                                            key=".$.$now-1d/d"
+                                            onClick={[Function]}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(now-1d/d)"
+                                              onClick={[Function]}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(now-1d/d)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(now-1d/d)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(now-1d/d)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(now-1d/d)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(now-1d/d)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={-1}
+                                                      >
+                                                        一天內
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(now-1w/d)"
+                                            key=".$.$now-1w/d"
+                                            onClick={[Function]}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(now-1w/d)"
+                                              onClick={[Function]}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(now-1w/d)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(now-1w/d)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(now-1w/d)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(now-1w/d)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(now-1w/d)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={-1}
+                                                      >
+                                                        一週內
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(now-1m/d)"
+                                            key=".$.$now-1m/d"
+                                            onClick={[Function]}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(now-1m/d)"
+                                              onClick={[Function]}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(now-1m/d)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(now-1m/d)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(now-1m/d)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(now-1m/d)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(now-1m/d)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={-1}
+                                                      >
+                                                        一個月內
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(custom)"
+                                            key=".$.$custom"
+                                            onClick={[Function]}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(custom)"
+                                              onClick={[Function]}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(custom)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(custom)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(custom)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(custom)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(custom)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={-1}
+                                                      >
+                                                        自訂範圍
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                        </ul>
+                                      </ForwardRef(List)>
+                                    </WithStyles(ForwardRef(List))>
+                                  </ForwardRef(MenuList)>
+                                </div>
+                              </ForwardRef(Paper)>
+                            </WithStyles(ForwardRef(Paper))>
+                          </Transition>
+                        </ForwardRef(Grow)>
+                        <div
+                          data-test="sentinelEnd"
+                          tabIndex={0}
+                        />
+                      </TrapFocus>
+                    </div>
+                  </Portal>
+                </ForwardRef(Portal)>
+              </ForwardRef(Modal)>
+            </ForwardRef(Popover)>
+          </WithStyles(ForwardRef(Popover))>
+        </ForwardRef(Menu)>
+      </WithStyles(ForwardRef(Menu))>
+    </div>
+  </TimeRange>
+  <p>
+    range = Object with GTE equal to option values:
+  </p>
+  <TimeRange
+    onChange={[Function]}
+    range={
+      Object {
+        "GTE": "now-1d/d",
+      }
+    }
+  >
+    <div
+      className="makeStyles-root-134"
+    >
+      <WithStyles(ForwardRef(ButtonGroup))
+        classes={
+          Object {
+            "contained": "makeStyles-buttonGroup-135",
+          }
+        }
+      >
+        <ForwardRef(ButtonGroup)
+          classes={
+            Object {
+              "contained": "MuiButtonGroup-contained makeStyles-buttonGroup-135",
+              "disabled": "Mui-disabled",
+              "fullWidth": "MuiButtonGroup-fullWidth",
+              "grouped": "MuiButtonGroup-grouped",
+              "groupedContained": "MuiButtonGroup-groupedContained",
+              "groupedContainedHorizontal": "MuiButtonGroup-groupedContainedHorizontal",
+              "groupedContainedPrimary": "MuiButtonGroup-groupedContainedPrimary",
+              "groupedContainedSecondary": "MuiButtonGroup-groupedContainedSecondary",
+              "groupedContainedVertical": "MuiButtonGroup-groupedContainedVertical",
+              "groupedHorizontal": "MuiButtonGroup-groupedHorizontal",
+              "groupedOutlined": "MuiButtonGroup-groupedOutlined",
+              "groupedOutlinedHorizontal": "MuiButtonGroup-groupedOutlinedHorizontal",
+              "groupedOutlinedPrimary": "MuiButtonGroup-groupedOutlinedPrimary",
+              "groupedOutlinedSecondary": "MuiButtonGroup-groupedOutlinedSecondary",
+              "groupedOutlinedVertical": "MuiButtonGroup-groupedOutlinedVertical",
+              "groupedText": "MuiButtonGroup-groupedText",
+              "groupedTextHorizontal": "MuiButtonGroup-groupedTextHorizontal",
+              "groupedTextPrimary": "MuiButtonGroup-groupedTextPrimary",
+              "groupedTextSecondary": "MuiButtonGroup-groupedTextSecondary",
+              "groupedTextVertical": "MuiButtonGroup-groupedTextVertical",
+              "groupedVertical": "MuiButtonGroup-groupedVertical",
+              "root": "MuiButtonGroup-root",
+              "vertical": "MuiButtonGroup-vertical",
+            }
+          }
+        >
+          <div
+            className="MuiButtonGroup-root"
+            role="group"
+          >
+            <WithStyles(ForwardRef(Button))
+              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+              color="default"
+              disableFocusRipple={false}
+              disableRipple={false}
+              disabled={false}
+              fullWidth={false}
+              key=".0"
+              onClick={[Function]}
+              size="medium"
+              variant="outlined"
+            >
+              <ForwardRef(Button)
+                className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+                classes={
+                  Object {
+                    "colorInherit": "MuiButton-colorInherit",
+                    "contained": "MuiButton-contained",
+                    "containedPrimary": "MuiButton-containedPrimary",
+                    "containedSecondary": "MuiButton-containedSecondary",
+                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                    "disableElevation": "MuiButton-disableElevation",
+                    "disabled": "Mui-disabled",
+                    "endIcon": "MuiButton-endIcon",
+                    "focusVisible": "Mui-focusVisible",
+                    "fullWidth": "MuiButton-fullWidth",
+                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                    "label": "MuiButton-label",
+                    "outlined": "MuiButton-outlined",
+                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                    "root": "MuiButton-root",
+                    "sizeLarge": "MuiButton-sizeLarge",
+                    "sizeSmall": "MuiButton-sizeSmall",
+                    "startIcon": "MuiButton-startIcon",
+                    "text": "MuiButton-text",
+                    "textPrimary": "MuiButton-textPrimary",
+                    "textSecondary": "MuiButton-textSecondary",
+                    "textSizeLarge": "MuiButton-textSizeLarge",
+                    "textSizeSmall": "MuiButton-textSizeSmall",
+                  }
+                }
+                color="default"
+                disableFocusRipple={false}
+                disableRipple={false}
+                disabled={false}
+                fullWidth={false}
+                onClick={[Function]}
+                size="medium"
+                variant="outlined"
+              >
+                <WithStyles(ForwardRef(ButtonBase))
+                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+                  component="button"
+                  disableRipple={false}
+                  disabled={false}
+                  focusRipple={true}
+                  focusVisibleClassName="Mui-focusVisible"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <ForwardRef(ButtonBase)
+                    className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+                    classes={
+                      Object {
+                        "disabled": "Mui-disabled",
+                        "focusVisible": "Mui-focusVisible",
+                        "root": "MuiButtonBase-root",
+                      }
+                    }
+                    component="button"
+                    disableRipple={false}
+                    disabled={false}
+                    focusRipple={true}
+                    focusVisibleClassName="Mui-focusVisible"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onDragLeave={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyUp={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="MuiButton-label"
+                      >
+                        <ForwardRef
+                          className="makeStyles-calendarIcon-137"
+                        >
+                          <WithStyles(ForwardRef(SvgIcon))
+                            className="makeStyles-calendarIcon-137"
+                          >
+                            <ForwardRef(SvgIcon)
+                              className="makeStyles-calendarIcon-137"
+                              classes={
+                                Object {
+                                  "colorAction": "MuiSvgIcon-colorAction",
+                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                  "colorError": "MuiSvgIcon-colorError",
+                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                  "root": "MuiSvgIcon-root",
+                                }
+                              }
+                            >
+                              <svg
+                                aria-hidden="true"
+                                className="MuiSvgIcon-root makeStyles-calendarIcon-137"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"
+                                />
+                              </svg>
+                            </ForwardRef(SvgIcon)>
+                          </WithStyles(ForwardRef(SvgIcon))>
+                        </ForwardRef>
+                      </span>
+                      <NoSsr>
+                        <WithStyles(memo)
+                          center={false}
+                        >
+                          <ForwardRef(TouchRipple)
+                            center={false}
+                            classes={
+                              Object {
+                                "child": "MuiTouchRipple-child",
+                                "childLeaving": "MuiTouchRipple-childLeaving",
+                                "childPulsate": "MuiTouchRipple-childPulsate",
+                                "ripple": "MuiTouchRipple-ripple",
+                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                "root": "MuiTouchRipple-root",
+                              }
+                            }
+                          >
+                            <span
+                              className="MuiTouchRipple-root"
+                            >
+                              <TransitionGroup
+                                childFactory={[Function]}
+                                component={null}
+                                exit={true}
+                              />
+                            </span>
+                          </ForwardRef(TouchRipple)>
+                        </WithStyles(memo)>
+                      </NoSsr>
+                    </button>
+                  </ForwardRef(ButtonBase)>
+                </WithStyles(ForwardRef(ButtonBase))>
+              </ForwardRef(Button)>
+            </WithStyles(ForwardRef(Button))>
+            <WithStyles(ForwardRef(Button))
+              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
+              color="default"
+              disableFocusRipple={false}
+              disableRipple={false}
+              disabled={false}
+              fullWidth={false}
+              key=".1"
+              onClick={[Function]}
+              size="medium"
+              variant="outlined"
+            >
+              <ForwardRef(Button)
+                className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
+                classes={
+                  Object {
+                    "colorInherit": "MuiButton-colorInherit",
+                    "contained": "MuiButton-contained",
+                    "containedPrimary": "MuiButton-containedPrimary",
+                    "containedSecondary": "MuiButton-containedSecondary",
+                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                    "disableElevation": "MuiButton-disableElevation",
+                    "disabled": "Mui-disabled",
+                    "endIcon": "MuiButton-endIcon",
+                    "focusVisible": "Mui-focusVisible",
+                    "fullWidth": "MuiButton-fullWidth",
+                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                    "label": "MuiButton-label",
+                    "outlined": "MuiButton-outlined",
+                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                    "root": "MuiButton-root",
+                    "sizeLarge": "MuiButton-sizeLarge",
+                    "sizeSmall": "MuiButton-sizeSmall",
+                    "startIcon": "MuiButton-startIcon",
+                    "text": "MuiButton-text",
+                    "textPrimary": "MuiButton-textPrimary",
+                    "textSecondary": "MuiButton-textSecondary",
+                    "textSizeLarge": "MuiButton-textSizeLarge",
+                    "textSizeSmall": "MuiButton-textSizeSmall",
+                  }
+                }
+                color="default"
+                disableFocusRipple={false}
+                disableRipple={false}
+                disabled={false}
+                fullWidth={false}
+                onClick={[Function]}
+                size="medium"
+                variant="outlined"
+              >
+                <WithStyles(ForwardRef(ButtonBase))
+                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
+                  component="button"
+                  disableRipple={false}
+                  disabled={false}
+                  focusRipple={true}
+                  focusVisibleClassName="Mui-focusVisible"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <ForwardRef(ButtonBase)
+                    className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
+                    classes={
+                      Object {
+                        "disabled": "Mui-disabled",
+                        "focusVisible": "Mui-focusVisible",
+                        "root": "MuiButtonBase-root",
+                      }
+                    }
+                    component="button"
+                    disableRipple={false}
+                    disabled={false}
+                    focusRipple={true}
+                    focusVisibleClassName="Mui-focusVisible"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-138"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onDragLeave={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyUp={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="MuiButton-label"
+                      >
+                        一天內
+                      </span>
+                      <NoSsr>
+                        <WithStyles(memo)
+                          center={false}
+                        >
+                          <ForwardRef(TouchRipple)
+                            center={false}
+                            classes={
+                              Object {
+                                "child": "MuiTouchRipple-child",
+                                "childLeaving": "MuiTouchRipple-childLeaving",
+                                "childPulsate": "MuiTouchRipple-childPulsate",
+                                "ripple": "MuiTouchRipple-ripple",
+                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                "root": "MuiTouchRipple-root",
+                              }
+                            }
+                          >
+                            <span
+                              className="MuiTouchRipple-root"
+                            >
+                              <TransitionGroup
+                                childFactory={[Function]}
+                                component={null}
+                                exit={true}
+                              />
+                            </span>
+                          </ForwardRef(TouchRipple)>
+                        </WithStyles(memo)>
+                      </NoSsr>
+                    </button>
+                  </ForwardRef(ButtonBase)>
+                </WithStyles(ForwardRef(ButtonBase))>
+              </ForwardRef(Button)>
+            </WithStyles(ForwardRef(Button))>
+          </div>
+        </ForwardRef(ButtonGroup)>
+      </WithStyles(ForwardRef(ButtonGroup))>
+      <WithStyles(ForwardRef(Menu))
+        anchorEl={null}
+        id="time-range"
+        keepMounted={true}
+        onClose={[Function]}
+        open={false}
+      >
+        <ForwardRef(Menu)
+          anchorEl={null}
+          classes={
+            Object {
+              "list": "MuiMenu-list",
+              "paper": "MuiMenu-paper",
+            }
+          }
+          id="time-range"
+          keepMounted={true}
+          onClose={[Function]}
+          open={false}
+        >
+          <WithStyles(ForwardRef(Popover))
+            PaperProps={
+              Object {
+                "classes": Object {
+                  "root": "MuiMenu-paper",
+                },
+              }
+            }
+            anchorEl={null}
+            anchorOrigin={
+              Object {
+                "horizontal": "left",
+                "vertical": "top",
+              }
+            }
+            getContentAnchorEl={[Function]}
+            id="time-range"
+            keepMounted={true}
+            onClose={[Function]}
+            onEntering={[Function]}
+            open={false}
+            transformOrigin={
+              Object {
+                "horizontal": "left",
+                "vertical": "top",
+              }
+            }
+            transitionDuration="auto"
+          >
+            <ForwardRef(Popover)
+              PaperProps={
+                Object {
+                  "classes": Object {
+                    "root": "MuiMenu-paper",
+                  },
+                }
+              }
+              anchorEl={null}
+              anchorOrigin={
+                Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                }
+              }
+              classes={
+                Object {
+                  "paper": "MuiPopover-paper",
+                  "root": "MuiPopover-root",
+                }
+              }
+              getContentAnchorEl={[Function]}
+              id="time-range"
+              keepMounted={true}
+              onClose={[Function]}
+              onEntering={[Function]}
+              open={false}
+              transformOrigin={
+                Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                }
+              }
+              transitionDuration="auto"
+            >
+              <ForwardRef(Modal)
+                BackdropProps={
+                  Object {
+                    "invisible": true,
+                  }
+                }
+                className="MuiPopover-root"
+                id="time-range"
+                keepMounted={true}
+                onClose={[Function]}
+                open={false}
+              >
+                <ForwardRef(Portal)
+                  disablePortal={false}
+                >
+                  <Portal
+                    containerInfo={
+                      <body>
+                        <div
+                          aria-hidden="true"
+                          class="MuiPopover-root"
+                          id="time-range"
+                          role="presentation"
+                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
+                        >
+                          <div
+                            data-test="sentinelStart"
+                            tabindex="0"
+                          />
+                          <div
+                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
+                            tabindex="-1"
+                          >
+                            <ul
+                              class="MuiList-root MuiMenu-list MuiList-padding"
+                              role="menu"
+                              tabindex="-1"
+                            >
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(all)"
+                                role="menuitem"
+                                tabindex="0"
+                              >
+                                時間不限
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1d/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一天內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1w/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一週內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1m/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一個月內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(custom)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                自訂範圍
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                            </ul>
+                          </div>
+                          <div
+                            data-test="sentinelEnd"
+                            tabindex="0"
+                          />
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="MuiPopover-root"
+                          id="time-range"
+                          role="presentation"
+                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
+                        >
+                          <div
+                            data-test="sentinelStart"
+                            tabindex="0"
+                          />
+                          <div
+                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
+                            tabindex="-1"
+                          >
+                            <ul
+                              class="MuiList-root MuiMenu-list MuiList-padding"
+                              role="menu"
+                              tabindex="-1"
+                            >
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(all)"
+                                role="menuitem"
+                                tabindex="0"
+                              >
+                                時間不限
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1d/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一天內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1w/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一週內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1m/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一個月內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(custom)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                自訂範圍
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                            </ul>
+                          </div>
+                          <div
+                            data-test="sentinelEnd"
+                            tabindex="0"
+                          />
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="MuiPopover-root"
+                          id="time-range"
+                          role="presentation"
+                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
+                        >
+                          <div
+                            data-test="sentinelStart"
+                            tabindex="0"
+                          />
+                          <div
+                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
+                            tabindex="-1"
+                          >
+                            <ul
+                              class="MuiList-root MuiMenu-list MuiList-padding"
+                              role="menu"
+                              tabindex="-1"
+                            >
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(all)"
+                                role="menuitem"
+                                tabindex="0"
+                              >
+                                時間不限
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1d/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一天內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1w/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一週內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1m/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一個月內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(custom)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                自訂範圍
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                            </ul>
+                          </div>
+                          <div
+                            data-test="sentinelEnd"
+                            tabindex="0"
+                          />
+                        </div>
+                      </body>
+                    }
+                  >
+                    <div
+                      className="MuiPopover-root"
+                      id="time-range"
+                      onKeyDown={[Function]}
+                      role="presentation"
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "left": 0,
+                          "position": "fixed",
+                          "right": 0,
+                          "top": 0,
+                          "visibility": "hidden",
+                          "zIndex": 1300,
+                        }
+                      }
+                    >
+                      <ForwardRef(SimpleBackdrop)
+                        invisible={true}
+                        onClick={[Function]}
+                        open={false}
+                      />
+                      <TrapFocus
+                        disableAutoFocus={false}
+                        disableEnforceFocus={false}
+                        disableRestoreFocus={false}
+                        getDoc={[Function]}
+                        isEnabled={[Function]}
+                        open={false}
+                      >
+                        <div
+                          data-test="sentinelStart"
+                          tabIndex={0}
+                        />
+                        <ForwardRef(Grow)
+                          appear={true}
+                          in={false}
+                          onEnter={[Function]}
+                          onEntering={[Function]}
+                          onExited={[Function]}
+                          tabIndex="-1"
+                          timeout="auto"
+                        >
+                          <Transition
+                            addEndListener={[Function]}
+                            appear={true}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            tabIndex="-1"
+                            timeout={null}
+                            unmountOnExit={false}
+                          >
+                            <WithStyles(ForwardRef(Paper))
+                              className="MuiPopover-paper"
+                              classes={
+                                Object {
+                                  "root": "MuiMenu-paper",
+                                }
+                              }
+                              elevation={8}
+                              style={
+                                Object {
+                                  "opacity": 0,
+                                  "transform": "scale(0.75, 0.5625)",
+                                  "visibility": "hidden",
+                                }
+                              }
+                              tabIndex="-1"
+                            >
+                              <ForwardRef(Paper)
+                                className="MuiPopover-paper"
+                                classes={
+                                  Object {
+                                    "elevation0": "MuiPaper-elevation0",
+                                    "elevation1": "MuiPaper-elevation1",
+                                    "elevation10": "MuiPaper-elevation10",
+                                    "elevation11": "MuiPaper-elevation11",
+                                    "elevation12": "MuiPaper-elevation12",
+                                    "elevation13": "MuiPaper-elevation13",
+                                    "elevation14": "MuiPaper-elevation14",
+                                    "elevation15": "MuiPaper-elevation15",
+                                    "elevation16": "MuiPaper-elevation16",
+                                    "elevation17": "MuiPaper-elevation17",
+                                    "elevation18": "MuiPaper-elevation18",
+                                    "elevation19": "MuiPaper-elevation19",
+                                    "elevation2": "MuiPaper-elevation2",
+                                    "elevation20": "MuiPaper-elevation20",
+                                    "elevation21": "MuiPaper-elevation21",
+                                    "elevation22": "MuiPaper-elevation22",
+                                    "elevation23": "MuiPaper-elevation23",
+                                    "elevation24": "MuiPaper-elevation24",
+                                    "elevation3": "MuiPaper-elevation3",
+                                    "elevation4": "MuiPaper-elevation4",
+                                    "elevation5": "MuiPaper-elevation5",
+                                    "elevation6": "MuiPaper-elevation6",
+                                    "elevation7": "MuiPaper-elevation7",
+                                    "elevation8": "MuiPaper-elevation8",
+                                    "elevation9": "MuiPaper-elevation9",
+                                    "outlined": "MuiPaper-outlined",
+                                    "root": "MuiPaper-root MuiMenu-paper",
+                                    "rounded": "MuiPaper-rounded",
+                                  }
+                                }
+                                elevation={8}
+                                style={
+                                  Object {
+                                    "opacity": 0,
+                                    "transform": "scale(0.75, 0.5625)",
+                                    "visibility": "hidden",
+                                  }
+                                }
+                                tabIndex="-1"
+                              >
+                                <div
+                                  className="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                                  style={
+                                    Object {
+                                      "opacity": 0,
+                                      "transform": "scale(0.75, 0.5625)",
+                                      "visibility": "hidden",
+                                    }
+                                  }
+                                  tabIndex="-1"
+                                >
+                                  <ForwardRef(MenuList)
+                                    actions={
+                                      Object {
+                                        "current": Object {
+                                          "adjustStyleForScrollbar": [Function],
+                                        },
+                                      }
+                                    }
+                                    autoFocus={false}
+                                    autoFocusItem={false}
+                                    className="MuiMenu-list"
+                                    onKeyDown={[Function]}
+                                    variant="selectedMenu"
+                                  >
+                                    <WithStyles(ForwardRef(List))
+                                      className="MuiMenu-list"
+                                      onKeyDown={[Function]}
+                                      role="menu"
+                                      tabIndex={-1}
+                                    >
+                                      <ForwardRef(List)
+                                        className="MuiMenu-list"
+                                        classes={
+                                          Object {
+                                            "dense": "MuiList-dense",
+                                            "padding": "MuiList-padding",
+                                            "root": "MuiList-root",
+                                            "subheader": "MuiList-subheader",
+                                          }
+                                        }
+                                        onKeyDown={[Function]}
+                                        role="menu"
+                                        tabIndex={-1}
+                                      >
+                                        <ul
+                                          className="MuiList-root MuiMenu-list MuiList-padding"
+                                          onKeyDown={[Function]}
+                                          role="menu"
+                                          tabIndex={-1}
+                                        >
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(all)"
+                                            key=".$.$all"
+                                            onClick={[Function]}
+                                            tabIndex={0}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(all)"
+                                              onClick={[Function]}
+                                              tabIndex={0}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(all)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={0}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(all)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={0}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(all)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={0}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(all)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={0}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(all)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={0}
+                                                      >
+                                                        時間不限
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(now-1d/d)"
+                                            key=".$.$now-1d/d"
+                                            onClick={[Function]}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(now-1d/d)"
+                                              onClick={[Function]}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(now-1d/d)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(now-1d/d)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(now-1d/d)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(now-1d/d)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(now-1d/d)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={-1}
+                                                      >
+                                                        一天內
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(now-1w/d)"
+                                            key=".$.$now-1w/d"
+                                            onClick={[Function]}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(now-1w/d)"
+                                              onClick={[Function]}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(now-1w/d)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(now-1w/d)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(now-1w/d)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(now-1w/d)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(now-1w/d)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={-1}
+                                                      >
+                                                        一週內
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(now-1m/d)"
+                                            key=".$.$now-1m/d"
+                                            onClick={[Function]}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(now-1m/d)"
+                                              onClick={[Function]}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(now-1m/d)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(now-1m/d)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(now-1m/d)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(now-1m/d)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(now-1m/d)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={-1}
+                                                      >
+                                                        一個月內
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(custom)"
+                                            key=".$.$custom"
+                                            onClick={[Function]}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(custom)"
+                                              onClick={[Function]}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(custom)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(custom)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(custom)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(custom)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(custom)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={-1}
+                                                      >
+                                                        自訂範圍
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                        </ul>
+                                      </ForwardRef(List)>
+                                    </WithStyles(ForwardRef(List))>
+                                  </ForwardRef(MenuList)>
+                                </div>
+                              </ForwardRef(Paper)>
+                            </WithStyles(ForwardRef(Paper))>
+                          </Transition>
+                        </ForwardRef(Grow)>
+                        <div
+                          data-test="sentinelEnd"
+                          tabIndex={0}
+                        />
+                      </TrapFocus>
+                    </div>
+                  </Portal>
+                </ForwardRef(Portal)>
+              </ForwardRef(Modal)>
+            </ForwardRef(Popover)>
+          </WithStyles(ForwardRef(Popover))>
+        </ForwardRef(Menu)>
+      </WithStyles(ForwardRef(Menu))>
+    </div>
+  </TimeRange>
+  <p>
+    range = Object with \`GTE\` and \`LTE\`:
+  </p>
+  <TimeRange
+    onChange={[Function]}
+    range={
+      Object {
+        "GTE": "1989-06-04",
+        "LTE": "2019-06-04",
+      }
+    }
+  >
+    <div
+      className="makeStyles-root-134"
+    >
+      <WithStyles(ForwardRef(ButtonGroup))
+        classes={
+          Object {
+            "contained": "makeStyles-buttonGroup-135",
+          }
+        }
+      >
+        <ForwardRef(ButtonGroup)
+          classes={
+            Object {
+              "contained": "MuiButtonGroup-contained makeStyles-buttonGroup-135",
+              "disabled": "Mui-disabled",
+              "fullWidth": "MuiButtonGroup-fullWidth",
+              "grouped": "MuiButtonGroup-grouped",
+              "groupedContained": "MuiButtonGroup-groupedContained",
+              "groupedContainedHorizontal": "MuiButtonGroup-groupedContainedHorizontal",
+              "groupedContainedPrimary": "MuiButtonGroup-groupedContainedPrimary",
+              "groupedContainedSecondary": "MuiButtonGroup-groupedContainedSecondary",
+              "groupedContainedVertical": "MuiButtonGroup-groupedContainedVertical",
+              "groupedHorizontal": "MuiButtonGroup-groupedHorizontal",
+              "groupedOutlined": "MuiButtonGroup-groupedOutlined",
+              "groupedOutlinedHorizontal": "MuiButtonGroup-groupedOutlinedHorizontal",
+              "groupedOutlinedPrimary": "MuiButtonGroup-groupedOutlinedPrimary",
+              "groupedOutlinedSecondary": "MuiButtonGroup-groupedOutlinedSecondary",
+              "groupedOutlinedVertical": "MuiButtonGroup-groupedOutlinedVertical",
+              "groupedText": "MuiButtonGroup-groupedText",
+              "groupedTextHorizontal": "MuiButtonGroup-groupedTextHorizontal",
+              "groupedTextPrimary": "MuiButtonGroup-groupedTextPrimary",
+              "groupedTextSecondary": "MuiButtonGroup-groupedTextSecondary",
+              "groupedTextVertical": "MuiButtonGroup-groupedTextVertical",
+              "groupedVertical": "MuiButtonGroup-groupedVertical",
+              "root": "MuiButtonGroup-root",
+              "vertical": "MuiButtonGroup-vertical",
+            }
+          }
+        >
+          <div
+            className="MuiButtonGroup-root"
+            role="group"
+          >
+            <WithStyles(ForwardRef(Button))
+              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+              color="default"
+              disableFocusRipple={false}
+              disableRipple={false}
+              disabled={false}
+              fullWidth={false}
+              key=".0"
+              onClick={[Function]}
+              size="medium"
+              variant="outlined"
+            >
+              <ForwardRef(Button)
+                className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+                classes={
+                  Object {
+                    "colorInherit": "MuiButton-colorInherit",
+                    "contained": "MuiButton-contained",
+                    "containedPrimary": "MuiButton-containedPrimary",
+                    "containedSecondary": "MuiButton-containedSecondary",
+                    "containedSizeLarge": "MuiButton-containedSizeLarge",
+                    "containedSizeSmall": "MuiButton-containedSizeSmall",
+                    "disableElevation": "MuiButton-disableElevation",
+                    "disabled": "Mui-disabled",
+                    "endIcon": "MuiButton-endIcon",
+                    "focusVisible": "Mui-focusVisible",
+                    "fullWidth": "MuiButton-fullWidth",
+                    "iconSizeLarge": "MuiButton-iconSizeLarge",
+                    "iconSizeMedium": "MuiButton-iconSizeMedium",
+                    "iconSizeSmall": "MuiButton-iconSizeSmall",
+                    "label": "MuiButton-label",
+                    "outlined": "MuiButton-outlined",
+                    "outlinedPrimary": "MuiButton-outlinedPrimary",
+                    "outlinedSecondary": "MuiButton-outlinedSecondary",
+                    "outlinedSizeLarge": "MuiButton-outlinedSizeLarge",
+                    "outlinedSizeSmall": "MuiButton-outlinedSizeSmall",
+                    "root": "MuiButton-root",
+                    "sizeLarge": "MuiButton-sizeLarge",
+                    "sizeSmall": "MuiButton-sizeSmall",
+                    "startIcon": "MuiButton-startIcon",
+                    "text": "MuiButton-text",
+                    "textPrimary": "MuiButton-textPrimary",
+                    "textSecondary": "MuiButton-textSecondary",
+                    "textSizeLarge": "MuiButton-textSizeLarge",
+                    "textSizeSmall": "MuiButton-textSizeSmall",
+                  }
+                }
+                color="default"
+                disableFocusRipple={false}
+                disableRipple={false}
+                disabled={false}
+                fullWidth={false}
+                onClick={[Function]}
+                size="medium"
+                variant="outlined"
+              >
+                <WithStyles(ForwardRef(ButtonBase))
+                  className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+                  component="button"
+                  disableRipple={false}
+                  disabled={false}
+                  focusRipple={true}
+                  focusVisibleClassName="Mui-focusVisible"
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <ForwardRef(ButtonBase)
+                    className="MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+                    classes={
+                      Object {
+                        "disabled": "Mui-disabled",
+                        "focusVisible": "Mui-focusVisible",
+                        "root": "MuiButtonBase-root",
+                      }
+                    }
+                    component="button"
+                    disableRipple={false}
+                    disabled={false}
+                    focusRipple={true}
+                    focusVisibleClassName="Mui-focusVisible"
+                    onClick={[Function]}
+                    type="button"
+                  >
+                    <button
+                      className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-136"
+                      disabled={false}
+                      onBlur={[Function]}
+                      onClick={[Function]}
+                      onDragLeave={[Function]}
+                      onFocus={[Function]}
+                      onKeyDown={[Function]}
+                      onKeyUp={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseUp={[Function]}
+                      onTouchEnd={[Function]}
+                      onTouchMove={[Function]}
+                      onTouchStart={[Function]}
+                      tabIndex={0}
+                      type="button"
+                    >
+                      <span
+                        className="MuiButton-label"
+                      >
+                        <ForwardRef
+                          className="makeStyles-calendarIcon-137"
+                        >
+                          <WithStyles(ForwardRef(SvgIcon))
+                            className="makeStyles-calendarIcon-137"
+                          >
+                            <ForwardRef(SvgIcon)
+                              className="makeStyles-calendarIcon-137"
+                              classes={
+                                Object {
+                                  "colorAction": "MuiSvgIcon-colorAction",
+                                  "colorDisabled": "MuiSvgIcon-colorDisabled",
+                                  "colorError": "MuiSvgIcon-colorError",
+                                  "colorPrimary": "MuiSvgIcon-colorPrimary",
+                                  "colorSecondary": "MuiSvgIcon-colorSecondary",
+                                  "fontSizeInherit": "MuiSvgIcon-fontSizeInherit",
+                                  "fontSizeLarge": "MuiSvgIcon-fontSizeLarge",
+                                  "fontSizeSmall": "MuiSvgIcon-fontSizeSmall",
+                                  "root": "MuiSvgIcon-root",
+                                }
+                              }
+                            >
+                              <svg
+                                aria-hidden="true"
+                                className="MuiSvgIcon-root makeStyles-calendarIcon-137"
+                                focusable="false"
+                                viewBox="0 0 24 24"
+                              >
+                                <path
+                                  d="M9 11H7v2h2v-2zm4 0h-2v2h2v-2zm4 0h-2v2h2v-2zm2-7h-1V2h-2v2H8V2H6v2H5c-1.11 0-1.99.9-1.99 2L3 20c0 1.1.89 2 2 2h14c1.1 0 2-.9 2-2V6c0-1.1-.9-2-2-2zm0 16H5V9h14v11z"
+                                />
+                              </svg>
+                            </ForwardRef(SvgIcon)>
+                          </WithStyles(ForwardRef(SvgIcon))>
+                        </ForwardRef>
+                      </span>
+                      <NoSsr>
+                        <WithStyles(memo)
+                          center={false}
+                        >
+                          <ForwardRef(TouchRipple)
+                            center={false}
+                            classes={
+                              Object {
+                                "child": "MuiTouchRipple-child",
+                                "childLeaving": "MuiTouchRipple-childLeaving",
+                                "childPulsate": "MuiTouchRipple-childPulsate",
+                                "ripple": "MuiTouchRipple-ripple",
+                                "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                "root": "MuiTouchRipple-root",
+                              }
+                            }
+                          >
+                            <span
+                              className="MuiTouchRipple-root"
+                            >
+                              <TransitionGroup
+                                childFactory={[Function]}
+                                component={null}
+                                exit={true}
+                              />
+                            </span>
+                          </ForwardRef(TouchRipple)>
+                        </WithStyles(memo)>
+                      </NoSsr>
+                    </button>
+                  </ForwardRef(ButtonBase)>
+                </WithStyles(ForwardRef(ButtonBase))>
+              </ForwardRef(Button)>
+            </WithStyles(ForwardRef(Button))>
+            <input
+              className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate-139"
+              color="default"
+              disableFocusRipple={false}
+              disableRipple={false}
+              disabled={false}
+              fullWidth={false}
+              key=".1"
+              onChange={[Function]}
+              size="medium"
+              type="date"
+              value="1989-06-04"
+              variant="outlined"
+            >
+              <input
+                className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate-139"
+                onChange={[Function]}
+                type="date"
+                value="1989-06-04"
+              />
+            </input>
+          </div>
+        </ForwardRef(ButtonGroup)>
+      </WithStyles(ForwardRef(ButtonGroup))>
+      <span
+        className="makeStyles-to-140"
+      >
+        到
+      </span>
+      <input
+        className="makeStyles-endDate-141"
+        onChange={[Function]}
+        type="date"
+        value="2019-06-04"
+      />
+      <WithStyles(ForwardRef(Menu))
+        anchorEl={null}
+        id="time-range"
+        keepMounted={true}
+        onClose={[Function]}
+        open={false}
+      >
+        <ForwardRef(Menu)
+          anchorEl={null}
+          classes={
+            Object {
+              "list": "MuiMenu-list",
+              "paper": "MuiMenu-paper",
+            }
+          }
+          id="time-range"
+          keepMounted={true}
+          onClose={[Function]}
+          open={false}
+        >
+          <WithStyles(ForwardRef(Popover))
+            PaperProps={
+              Object {
+                "classes": Object {
+                  "root": "MuiMenu-paper",
+                },
+              }
+            }
+            anchorEl={null}
+            anchorOrigin={
+              Object {
+                "horizontal": "left",
+                "vertical": "top",
+              }
+            }
+            getContentAnchorEl={[Function]}
+            id="time-range"
+            keepMounted={true}
+            onClose={[Function]}
+            onEntering={[Function]}
+            open={false}
+            transformOrigin={
+              Object {
+                "horizontal": "left",
+                "vertical": "top",
+              }
+            }
+            transitionDuration="auto"
+          >
+            <ForwardRef(Popover)
+              PaperProps={
+                Object {
+                  "classes": Object {
+                    "root": "MuiMenu-paper",
+                  },
+                }
+              }
+              anchorEl={null}
+              anchorOrigin={
+                Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                }
+              }
+              classes={
+                Object {
+                  "paper": "MuiPopover-paper",
+                  "root": "MuiPopover-root",
+                }
+              }
+              getContentAnchorEl={[Function]}
+              id="time-range"
+              keepMounted={true}
+              onClose={[Function]}
+              onEntering={[Function]}
+              open={false}
+              transformOrigin={
+                Object {
+                  "horizontal": "left",
+                  "vertical": "top",
+                }
+              }
+              transitionDuration="auto"
+            >
+              <ForwardRef(Modal)
+                BackdropProps={
+                  Object {
+                    "invisible": true,
+                  }
+                }
+                className="MuiPopover-root"
+                id="time-range"
+                keepMounted={true}
+                onClose={[Function]}
+                open={false}
+              >
+                <ForwardRef(Portal)
+                  disablePortal={false}
+                >
+                  <Portal
+                    containerInfo={
+                      <body>
+                        <div
+                          aria-hidden="true"
+                          class="MuiPopover-root"
+                          id="time-range"
+                          role="presentation"
+                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
+                        >
+                          <div
+                            data-test="sentinelStart"
+                            tabindex="0"
+                          />
+                          <div
+                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
+                            tabindex="-1"
+                          >
+                            <ul
+                              class="MuiList-root MuiMenu-list MuiList-padding"
+                              role="menu"
+                              tabindex="-1"
+                            >
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(all)"
+                                role="menuitem"
+                                tabindex="0"
+                              >
+                                時間不限
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1d/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一天內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1w/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一週內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1m/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一個月內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(custom)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                自訂範圍
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                            </ul>
+                          </div>
+                          <div
+                            data-test="sentinelEnd"
+                            tabindex="0"
+                          />
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="MuiPopover-root"
+                          id="time-range"
+                          role="presentation"
+                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
+                        >
+                          <div
+                            data-test="sentinelStart"
+                            tabindex="0"
+                          />
+                          <div
+                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
+                            tabindex="-1"
+                          >
+                            <ul
+                              class="MuiList-root MuiMenu-list MuiList-padding"
+                              role="menu"
+                              tabindex="-1"
+                            >
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(all)"
+                                role="menuitem"
+                                tabindex="0"
+                              >
+                                時間不限
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1d/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一天內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1w/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一週內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1m/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一個月內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(custom)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                自訂範圍
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                            </ul>
+                          </div>
+                          <div
+                            data-test="sentinelEnd"
+                            tabindex="0"
+                          />
+                        </div>
+                        <div
+                          aria-hidden="true"
+                          class="MuiPopover-root"
+                          id="time-range"
+                          role="presentation"
+                          style="position: fixed; z-index: 1300; right: 0px; bottom: 0px; top: 0px; left: 0px; visibility: hidden;"
+                        >
+                          <div
+                            data-test="sentinelStart"
+                            tabindex="0"
+                          />
+                          <div
+                            class="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                            style="opacity: 0; transform: scale(0.75, 0.5625); visibility: hidden;"
+                            tabindex="-1"
+                          >
+                            <ul
+                              class="MuiList-root MuiMenu-list MuiList-padding"
+                              role="menu"
+                              tabindex="-1"
+                            >
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(all)"
+                                role="menuitem"
+                                tabindex="0"
+                              >
+                                時間不限
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1d/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一天內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1w/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一週內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(now-1m/d)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                一個月內
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                              <li
+                                aria-disabled="false"
+                                class="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                data-ga="MenuItem(custom)"
+                                role="menuitem"
+                                tabindex="-1"
+                              >
+                                自訂範圍
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </li>
+                            </ul>
+                          </div>
+                          <div
+                            data-test="sentinelEnd"
+                            tabindex="0"
+                          />
+                        </div>
+                      </body>
+                    }
+                  >
+                    <div
+                      className="MuiPopover-root"
+                      id="time-range"
+                      onKeyDown={[Function]}
+                      role="presentation"
+                      style={
+                        Object {
+                          "bottom": 0,
+                          "left": 0,
+                          "position": "fixed",
+                          "right": 0,
+                          "top": 0,
+                          "visibility": "hidden",
+                          "zIndex": 1300,
+                        }
+                      }
+                    >
+                      <ForwardRef(SimpleBackdrop)
+                        invisible={true}
+                        onClick={[Function]}
+                        open={false}
+                      />
+                      <TrapFocus
+                        disableAutoFocus={false}
+                        disableEnforceFocus={false}
+                        disableRestoreFocus={false}
+                        getDoc={[Function]}
+                        isEnabled={[Function]}
+                        open={false}
+                      >
+                        <div
+                          data-test="sentinelStart"
+                          tabIndex={0}
+                        />
+                        <ForwardRef(Grow)
+                          appear={true}
+                          in={false}
+                          onEnter={[Function]}
+                          onEntering={[Function]}
+                          onExited={[Function]}
+                          tabIndex="-1"
+                          timeout="auto"
+                        >
+                          <Transition
+                            addEndListener={[Function]}
+                            appear={true}
+                            enter={true}
+                            exit={true}
+                            in={false}
+                            mountOnEnter={false}
+                            onEnter={[Function]}
+                            onEntered={[Function]}
+                            onEntering={[Function]}
+                            onExit={[Function]}
+                            onExited={[Function]}
+                            onExiting={[Function]}
+                            tabIndex="-1"
+                            timeout={null}
+                            unmountOnExit={false}
+                          >
+                            <WithStyles(ForwardRef(Paper))
+                              className="MuiPopover-paper"
+                              classes={
+                                Object {
+                                  "root": "MuiMenu-paper",
+                                }
+                              }
+                              elevation={8}
+                              style={
+                                Object {
+                                  "opacity": 0,
+                                  "transform": "scale(0.75, 0.5625)",
+                                  "visibility": "hidden",
+                                }
+                              }
+                              tabIndex="-1"
+                            >
+                              <ForwardRef(Paper)
+                                className="MuiPopover-paper"
+                                classes={
+                                  Object {
+                                    "elevation0": "MuiPaper-elevation0",
+                                    "elevation1": "MuiPaper-elevation1",
+                                    "elevation10": "MuiPaper-elevation10",
+                                    "elevation11": "MuiPaper-elevation11",
+                                    "elevation12": "MuiPaper-elevation12",
+                                    "elevation13": "MuiPaper-elevation13",
+                                    "elevation14": "MuiPaper-elevation14",
+                                    "elevation15": "MuiPaper-elevation15",
+                                    "elevation16": "MuiPaper-elevation16",
+                                    "elevation17": "MuiPaper-elevation17",
+                                    "elevation18": "MuiPaper-elevation18",
+                                    "elevation19": "MuiPaper-elevation19",
+                                    "elevation2": "MuiPaper-elevation2",
+                                    "elevation20": "MuiPaper-elevation20",
+                                    "elevation21": "MuiPaper-elevation21",
+                                    "elevation22": "MuiPaper-elevation22",
+                                    "elevation23": "MuiPaper-elevation23",
+                                    "elevation24": "MuiPaper-elevation24",
+                                    "elevation3": "MuiPaper-elevation3",
+                                    "elevation4": "MuiPaper-elevation4",
+                                    "elevation5": "MuiPaper-elevation5",
+                                    "elevation6": "MuiPaper-elevation6",
+                                    "elevation7": "MuiPaper-elevation7",
+                                    "elevation8": "MuiPaper-elevation8",
+                                    "elevation9": "MuiPaper-elevation9",
+                                    "outlined": "MuiPaper-outlined",
+                                    "root": "MuiPaper-root MuiMenu-paper",
+                                    "rounded": "MuiPaper-rounded",
+                                  }
+                                }
+                                elevation={8}
+                                style={
+                                  Object {
+                                    "opacity": 0,
+                                    "transform": "scale(0.75, 0.5625)",
+                                    "visibility": "hidden",
+                                  }
+                                }
+                                tabIndex="-1"
+                              >
+                                <div
+                                  className="MuiPaper-root MuiMenu-paper MuiPopover-paper MuiPaper-elevation8 MuiPaper-rounded"
+                                  style={
+                                    Object {
+                                      "opacity": 0,
+                                      "transform": "scale(0.75, 0.5625)",
+                                      "visibility": "hidden",
+                                    }
+                                  }
+                                  tabIndex="-1"
+                                >
+                                  <ForwardRef(MenuList)
+                                    actions={
+                                      Object {
+                                        "current": Object {
+                                          "adjustStyleForScrollbar": [Function],
+                                        },
+                                      }
+                                    }
+                                    autoFocus={false}
+                                    autoFocusItem={false}
+                                    className="MuiMenu-list"
+                                    onKeyDown={[Function]}
+                                    variant="selectedMenu"
+                                  >
+                                    <WithStyles(ForwardRef(List))
+                                      className="MuiMenu-list"
+                                      onKeyDown={[Function]}
+                                      role="menu"
+                                      tabIndex={-1}
+                                    >
+                                      <ForwardRef(List)
+                                        className="MuiMenu-list"
+                                        classes={
+                                          Object {
+                                            "dense": "MuiList-dense",
+                                            "padding": "MuiList-padding",
+                                            "root": "MuiList-root",
+                                            "subheader": "MuiList-subheader",
+                                          }
+                                        }
+                                        onKeyDown={[Function]}
+                                        role="menu"
+                                        tabIndex={-1}
+                                      >
+                                        <ul
+                                          className="MuiList-root MuiMenu-list MuiList-padding"
+                                          onKeyDown={[Function]}
+                                          role="menu"
+                                          tabIndex={-1}
+                                        >
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(all)"
+                                            key=".$.$all"
+                                            onClick={[Function]}
+                                            tabIndex={0}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(all)"
+                                              onClick={[Function]}
+                                              tabIndex={0}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(all)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={0}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(all)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={0}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(all)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={0}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(all)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={0}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(all)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={0}
+                                                      >
+                                                        時間不限
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(now-1d/d)"
+                                            key=".$.$now-1d/d"
+                                            onClick={[Function]}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(now-1d/d)"
+                                              onClick={[Function]}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(now-1d/d)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(now-1d/d)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(now-1d/d)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(now-1d/d)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(now-1d/d)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={-1}
+                                                      >
+                                                        一天內
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(now-1w/d)"
+                                            key=".$.$now-1w/d"
+                                            onClick={[Function]}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(now-1w/d)"
+                                              onClick={[Function]}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(now-1w/d)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(now-1w/d)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(now-1w/d)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(now-1w/d)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(now-1w/d)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={-1}
+                                                      >
+                                                        一週內
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(now-1m/d)"
+                                            key=".$.$now-1m/d"
+                                            onClick={[Function]}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(now-1m/d)"
+                                              onClick={[Function]}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(now-1m/d)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(now-1m/d)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(now-1m/d)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(now-1m/d)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(now-1m/d)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={-1}
+                                                      >
+                                                        一個月內
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                          <WithStyles(ForwardRef(MenuItem))
+                                            data-ga="MenuItem(custom)"
+                                            key=".$.$custom"
+                                            onClick={[Function]}
+                                          >
+                                            <ForwardRef(MenuItem)
+                                              classes={
+                                                Object {
+                                                  "dense": "MuiMenuItem-dense",
+                                                  "gutters": "MuiMenuItem-gutters",
+                                                  "root": "MuiMenuItem-root",
+                                                  "selected": "Mui-selected",
+                                                }
+                                              }
+                                              data-ga="MenuItem(custom)"
+                                              onClick={[Function]}
+                                            >
+                                              <WithStyles(ForwardRef(ListItem))
+                                                button={true}
+                                                className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                classes={
+                                                  Object {
+                                                    "dense": "MuiMenuItem-dense",
+                                                  }
+                                                }
+                                                component="li"
+                                                data-ga="MenuItem(custom)"
+                                                disableGutters={false}
+                                                onClick={[Function]}
+                                                role="menuitem"
+                                                tabIndex={-1}
+                                              >
+                                                <ForwardRef(ListItem)
+                                                  button={true}
+                                                  className="MuiMenuItem-root MuiMenuItem-gutters"
+                                                  classes={
+                                                    Object {
+                                                      "alignItemsFlexStart": "MuiListItem-alignItemsFlexStart",
+                                                      "button": "MuiListItem-button",
+                                                      "container": "MuiListItem-container",
+                                                      "dense": "MuiListItem-dense MuiMenuItem-dense",
+                                                      "disabled": "Mui-disabled",
+                                                      "divider": "MuiListItem-divider",
+                                                      "focusVisible": "Mui-focusVisible",
+                                                      "gutters": "MuiListItem-gutters",
+                                                      "root": "MuiListItem-root",
+                                                      "secondaryAction": "MuiListItem-secondaryAction",
+                                                      "selected": "Mui-selected",
+                                                    }
+                                                  }
+                                                  component="li"
+                                                  data-ga="MenuItem(custom)"
+                                                  disableGutters={false}
+                                                  onClick={[Function]}
+                                                  role="menuitem"
+                                                  tabIndex={-1}
+                                                >
+                                                  <WithStyles(ForwardRef(ButtonBase))
+                                                    className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                    component="li"
+                                                    data-ga="MenuItem(custom)"
+                                                    disabled={false}
+                                                    focusVisibleClassName="Mui-focusVisible"
+                                                    onClick={[Function]}
+                                                    role="menuitem"
+                                                    tabIndex={-1}
+                                                  >
+                                                    <ForwardRef(ButtonBase)
+                                                      className="MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                      classes={
+                                                        Object {
+                                                          "disabled": "Mui-disabled",
+                                                          "focusVisible": "Mui-focusVisible",
+                                                          "root": "MuiButtonBase-root",
+                                                        }
+                                                      }
+                                                      component="li"
+                                                      data-ga="MenuItem(custom)"
+                                                      disabled={false}
+                                                      focusVisibleClassName="Mui-focusVisible"
+                                                      onClick={[Function]}
+                                                      role="menuitem"
+                                                      tabIndex={-1}
+                                                    >
+                                                      <li
+                                                        aria-disabled={false}
+                                                        className="MuiButtonBase-root MuiListItem-root MuiMenuItem-root MuiMenuItem-gutters MuiListItem-gutters MuiListItem-button"
+                                                        data-ga="MenuItem(custom)"
+                                                        onBlur={[Function]}
+                                                        onClick={[Function]}
+                                                        onDragLeave={[Function]}
+                                                        onFocus={[Function]}
+                                                        onKeyDown={[Function]}
+                                                        onKeyUp={[Function]}
+                                                        onMouseDown={[Function]}
+                                                        onMouseLeave={[Function]}
+                                                        onMouseUp={[Function]}
+                                                        onTouchEnd={[Function]}
+                                                        onTouchMove={[Function]}
+                                                        onTouchStart={[Function]}
+                                                        role="menuitem"
+                                                        tabIndex={-1}
+                                                      >
+                                                        自訂範圍
+                                                        <NoSsr>
+                                                          <WithStyles(memo)
+                                                            center={false}
+                                                          >
+                                                            <ForwardRef(TouchRipple)
+                                                              center={false}
+                                                              classes={
+                                                                Object {
+                                                                  "child": "MuiTouchRipple-child",
+                                                                  "childLeaving": "MuiTouchRipple-childLeaving",
+                                                                  "childPulsate": "MuiTouchRipple-childPulsate",
+                                                                  "ripple": "MuiTouchRipple-ripple",
+                                                                  "ripplePulsate": "MuiTouchRipple-ripplePulsate",
+                                                                  "rippleVisible": "MuiTouchRipple-rippleVisible",
+                                                                  "root": "MuiTouchRipple-root",
+                                                                }
+                                                              }
+                                                            >
+                                                              <span
+                                                                className="MuiTouchRipple-root"
+                                                              >
+                                                                <TransitionGroup
+                                                                  childFactory={[Function]}
+                                                                  component={null}
+                                                                  exit={true}
+                                                                />
+                                                              </span>
+                                                            </ForwardRef(TouchRipple)>
+                                                          </WithStyles(memo)>
+                                                        </NoSsr>
+                                                      </li>
+                                                    </ForwardRef(ButtonBase)>
+                                                  </WithStyles(ForwardRef(ButtonBase))>
+                                                </ForwardRef(ListItem)>
+                                              </WithStyles(ForwardRef(ListItem))>
+                                            </ForwardRef(MenuItem)>
+                                          </WithStyles(ForwardRef(MenuItem))>
+                                        </ul>
+                                      </ForwardRef(List)>
+                                    </WithStyles(ForwardRef(List))>
+                                  </ForwardRef(MenuList)>
+                                </div>
+                              </ForwardRef(Paper)>
+                            </WithStyles(ForwardRef(Paper))>
+                          </Transition>
+                        </ForwardRef(Grow)>
+                        <div
+                          data-test="sentinelEnd"
+                          tabIndex={0}
+                        />
+                      </TrapFocus>
+                    </div>
+                  </Portal>
+                </ForwardRef(Portal)>
+              </ForwardRef(Modal)>
+            </ForwardRef(Popover)>
+          </WithStyles(ForwardRef(Popover))>
+        </ForwardRef(Menu)>
+      </WithStyles(ForwardRef(Menu))>
+    </div>
+  </TimeRange>
+</div>
+`;

--- a/__snapshots__/Storyshots.test.js.snap
+++ b/__snapshots__/Storyshots.test.js.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Storyshots Example story Hello World 1`] = `
-<div>
-  Hello world!
-</div>
-`;
+exports[`Storyshots TimeRange No Range Given 1`] = `ReactWrapper {}`;
+
+exports[`Storyshots TimeRange Set Range From Props 1`] = `ReactWrapper {}`;

--- a/components/Example.stories.js
+++ b/components/Example.stories.js
@@ -1,5 +1,0 @@
-import React from 'react';
-
-export default { title: 'Example story' };
-
-export const HelloWorld = () => <div>Hello world!</div>;

--- a/components/TimeRange.js
+++ b/components/TimeRange.js
@@ -58,7 +58,7 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const options = [
+export const options = [
   { value: 'all', label: c('Time range dropdown').t`All` },
   { value: 'now-1d/d', label: t`In 1 Day` },
   { value: 'now-1w/d', label: t`In 1 Week` },

--- a/components/TimeRange.stories.js
+++ b/components/TimeRange.stories.js
@@ -14,7 +14,7 @@ export const noRangeGiven = () => <TimeRange onChange={action('onChange')} />;
 
 const optionValues = options.map(({ value }) => value);
 export const setRangeFromProps = () => (
-  <>
+  <div>
     <p>range = null:</p>
     <TimeRange range={null} onChange={action('onChange')} />
 
@@ -29,5 +29,5 @@ export const setRangeFromProps = () => (
       range={{ GTE: text('GTE', '1989-06-04'), LTE: text('LTE', '2019-06-04') }}
       onChange={action('onChange')}
     />
-  </>
+  </div>
 );

--- a/components/TimeRange.stories.js
+++ b/components/TimeRange.stories.js
@@ -1,0 +1,33 @@
+import React from 'react';
+import { withKnobs, text, select } from '@storybook/addon-knobs';
+import { action } from '@storybook/addon-actions';
+
+import TimeRange, { options } from './TimeRange';
+
+export default {
+  title: 'TimeRange',
+  component: 'TimeRange',
+  decorators: [withKnobs],
+};
+
+export const noRangeGiven = () => <TimeRange onChange={action('onChange')} />;
+
+const optionValues = options.map(({ value }) => value);
+export const setRangeFromProps = () => (
+  <>
+    <p>range = null:</p>
+    <TimeRange range={null} onChange={action('onChange')} />
+
+    <p>range = Object with GTE equal to option values:</p>
+    <TimeRange
+      range={{ GTE: select('GTE options', optionValues, optionValues[1]) }}
+      onChange={action('onChange')}
+    />
+
+    <p>range = Object with `GTE` and `LTE`:</p>
+    <TimeRange
+      range={{ GTE: text('GTE', '1989-06-04'), LTE: text('LTE', '2019-06-04') }}
+      onChange={action('onChange')}
+    />
+  </>
+);

--- a/components/TimeRange.stories.js
+++ b/components/TimeRange.stories.js
@@ -10,10 +10,10 @@ export default {
   decorators: [withKnobs],
 };
 
-export const noRangeGiven = () => <TimeRange onChange={action('onChange')} />;
+export const NoRangeGiven = () => <TimeRange onChange={action('onChange')} />;
 
 const optionValues = options.map(({ value }) => value);
-export const setRangeFromProps = () => (
+export const SetRangeFromProps = () => (
   <div>
     <p>range = null:</p>
     <TimeRange range={null} onChange={action('onChange')} />

--- a/components/__snapshots__/TimeRange.stories.storyshot
+++ b/components/__snapshots__/TimeRange.stories.storyshot
@@ -76,7 +76,7 @@ exports[`Storyshots TimeRange No Range Given 1`] = `
         <span
           className="MuiButton-label"
         >
-          時間不限
+          All
         </span>
         <NoSsr>
           <span
@@ -151,7 +151,7 @@ exports[`Storyshots TimeRange No Range Given 1`] = `
                   role="menuitem"
                   tabIndex={0}
                 >
-                  時間不限
+                  All
                   <NoSsr>
                     <span
                       className="MuiTouchRipple-root"
@@ -183,7 +183,7 @@ exports[`Storyshots TimeRange No Range Given 1`] = `
                   role="menuitem"
                   tabIndex={-1}
                 >
-                  一天內
+                  In 1 Day
                   <NoSsr>
                     <span
                       className="MuiTouchRipple-root"
@@ -215,7 +215,7 @@ exports[`Storyshots TimeRange No Range Given 1`] = `
                   role="menuitem"
                   tabIndex={-1}
                 >
-                  一週內
+                  In 1 Week
                   <NoSsr>
                     <span
                       className="MuiTouchRipple-root"
@@ -247,7 +247,7 @@ exports[`Storyshots TimeRange No Range Given 1`] = `
                   role="menuitem"
                   tabIndex={-1}
                 >
-                  一個月內
+                  In 1 Month
                   <NoSsr>
                     <span
                       className="MuiTouchRipple-root"
@@ -279,7 +279,7 @@ exports[`Storyshots TimeRange No Range Given 1`] = `
                   role="menuitem"
                   tabIndex={-1}
                 >
-                  自訂範圍
+                  Custom
                   <NoSsr>
                     <span
                       className="MuiTouchRipple-root"
@@ -387,7 +387,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
           <span
             className="MuiButton-label"
           >
-            時間不限
+            All
           </span>
           <NoSsr>
             <span
@@ -462,7 +462,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={0}
                   >
-                    時間不限
+                    All
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -494,7 +494,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={-1}
                   >
-                    一天內
+                    In 1 Day
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -526,7 +526,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={-1}
                   >
-                    一週內
+                    In 1 Week
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -558,7 +558,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={-1}
                   >
-                    一個月內
+                    In 1 Month
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -590,7 +590,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={-1}
                   >
-                    自訂範圍
+                    Custom
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -698,7 +698,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
           <span
             className="MuiButton-label"
           >
-            一天內
+            In 1 Day
           </span>
           <NoSsr>
             <span
@@ -773,7 +773,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={0}
                   >
-                    時間不限
+                    All
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -805,7 +805,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={-1}
                   >
-                    一天內
+                    In 1 Day
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -837,7 +837,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={-1}
                   >
-                    一週內
+                    In 1 Week
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -869,7 +869,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={-1}
                   >
-                    一個月內
+                    In 1 Month
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -901,7 +901,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={-1}
                   >
-                    自訂範圍
+                    Custom
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -1014,7 +1014,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
       <span
         className="makeStyles-to-140"
       >
-        到
+        to
       </span>
       <input
         className="makeStyles-endDate-141"
@@ -1082,7 +1082,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={0}
                   >
-                    時間不限
+                    All
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -1114,7 +1114,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={-1}
                   >
-                    一天內
+                    In 1 Day
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -1146,7 +1146,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={-1}
                   >
-                    一週內
+                    In 1 Week
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -1178,7 +1178,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={-1}
                   >
-                    一個月內
+                    In 1 Month
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"
@@ -1210,7 +1210,7 @@ exports[`Storyshots TimeRange Set Range From Props 1`] = `
                     role="menuitem"
                     tabIndex={-1}
                   >
-                    自訂範圍
+                    Custom
                     <NoSsr>
                       <span
                         className="MuiTouchRipple-root"

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  transform: {
+    '^.+\\.stories\\.jsx?$': '@storybook/addon-storyshots/injectFileName',
+    '^.+\\.jsx?$': 'babel-jest',
+  },
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,8 @@
 module.exports = {
   transform: {
+    // Required by Storyshot multiSnapshotWithOptions()
+    // Ref: https://github.com/storybookjs/storybook/tree/master/addons/storyshots/storyshots-core#multisnapshotwithoptionsoptions
+    //
     '^.+\\.stories\\.jsx?$': '@storybook/addon-storyshots/injectFileName',
     '^.+\\.jsx?$': 'babel-jest',
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3438,6 +3438,12 @@
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA==",
       "dev": true
     },
+    "@icons/material": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
+      "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
+      "dev": true
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -4474,28 +4480,241 @@
         }
       }
     },
-    "@storybook/addon-links": {
-      "version": "5.3.17",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-links/-/addon-links-5.3.17.tgz",
-      "integrity": "sha512-g8PsDoHYEmgK1q1h+eLqXsWLhCj5CFyiZLrtomjCp1R0XpZA7PS8LyO5yHbxzEzEv68DHlU5rwQnNnkbGnr7XA==",
+    "@storybook/addon-knobs": {
+      "version": "5.3.19",
+      "resolved": "https://registry.npmjs.org/@storybook/addon-knobs/-/addon-knobs-5.3.19.tgz",
+      "integrity": "sha512-e7z6KhvVOUGjygK4VL5Un1U3t0XG0jkb/BOHVWQMtH5dWNn3zofD3LrZZy24eAsyre/ej/LGo/BzwDSXkKLTog==",
       "dev": true,
       "requires": {
-        "@storybook/addons": "5.3.17",
-        "@storybook/client-logger": "5.3.17",
-        "@storybook/core-events": "5.3.17",
-        "@storybook/csf": "0.0.1",
-        "@storybook/router": "5.3.17",
+        "@storybook/addons": "5.3.19",
+        "@storybook/api": "5.3.19",
+        "@storybook/client-api": "5.3.19",
+        "@storybook/components": "5.3.19",
+        "@storybook/core-events": "5.3.19",
+        "@storybook/theming": "5.3.19",
+        "@types/react-color": "^3.0.1",
+        "copy-to-clipboard": "^3.0.8",
         "core-js": "^3.0.1",
+        "escape-html": "^1.0.3",
+        "fast-deep-equal": "^2.0.1",
         "global": "^4.3.2",
+        "lodash": "^4.17.15",
         "prop-types": "^15.7.2",
         "qs": "^6.6.0",
-        "ts-dedent": "^1.1.0"
+        "react-color": "^2.17.0",
+        "react-lifecycles-compat": "^3.0.4",
+        "react-select": "^3.0.8"
       },
       "dependencies": {
-        "core-js": {
-          "version": "3.6.4",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.4.tgz",
-          "integrity": "sha512-4paDGScNgZP2IXXilaffL9X7968RuvwlkK3xWtZRVqgd8SYNiVKRJvkFd1aqqEuPfN7E68ZHEp9hDj6lHj4Hyw==",
+        "@storybook/addons": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/addons/-/addons-5.3.19.tgz",
+          "integrity": "sha512-Ky/k22p6i6FVNvs1VhuFyGvYJdcp+FgXqFgnPyY/OXJW/vPDapdElpTpHJZLFI9I2FQBDcygBPU5RXkumQ+KUQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/api": "5.3.19",
+            "@storybook/channels": "5.3.19",
+            "@storybook/client-logger": "5.3.19",
+            "@storybook/core-events": "5.3.19",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/api": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/api/-/api-5.3.19.tgz",
+          "integrity": "sha512-U/VzDvhNCPmw2igvJYNNM+uwJCL+3teiL6JmuoL4/cmcqhI6IqqG9dZmMP1egoCd19wXEP7rnAfB/VcYVg41dQ==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@storybook/channels": "5.3.19",
+            "@storybook/client-logger": "5.3.19",
+            "@storybook/core-events": "5.3.19",
+            "@storybook/csf": "0.0.1",
+            "@storybook/router": "5.3.19",
+            "@storybook/theming": "5.3.19",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "fast-deep-equal": "^2.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "prop-types": "^15.6.2",
+            "react": "^16.8.3",
+            "semver": "^6.0.0",
+            "shallow-equal": "^1.1.0",
+            "store2": "^2.7.1",
+            "telejson": "^3.2.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/channel-postmessage": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/channel-postmessage/-/channel-postmessage-5.3.19.tgz",
+          "integrity": "sha512-Iq0f4NPHR0UVVFCWt0cI7Myadk4/SATXYJPT6sv95KhnLjKEeYw571WBlThfp8a9FM80887xG+eIRe93c8dleA==",
+          "dev": true,
+          "requires": {
+            "@storybook/channels": "5.3.19",
+            "@storybook/client-logger": "5.3.19",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "telejson": "^3.2.0"
+          }
+        },
+        "@storybook/channels": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/channels/-/channels-5.3.19.tgz",
+          "integrity": "sha512-38seaeyshRGotTEZJppyYMg/Vx2zRKgFv1L6uGqkJT0LYoNSYtJhsiNFCJ2/KUJu2chAJ/j8h80bpVBVLQ/+WA==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/client-api": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/client-api/-/client-api-5.3.19.tgz",
+          "integrity": "sha512-Dh8ZLrLH91j9Fa28Gmp0KFUvvgK348aNMrDNAUdj4m4witz/BWQ2pxz6qq9/xFVErk/GanVC05kazGElqgYCRQ==",
+          "dev": true,
+          "requires": {
+            "@storybook/addons": "5.3.19",
+            "@storybook/channel-postmessage": "5.3.19",
+            "@storybook/channels": "5.3.19",
+            "@storybook/client-logger": "5.3.19",
+            "@storybook/core-events": "5.3.19",
+            "@storybook/csf": "0.0.1",
+            "@types/webpack-env": "^1.15.0",
+            "core-js": "^3.0.1",
+            "eventemitter3": "^4.0.0",
+            "global": "^4.3.2",
+            "is-plain-object": "^3.0.0",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0",
+            "stable": "^0.1.8",
+            "ts-dedent": "^1.1.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/client-logger": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/client-logger/-/client-logger-5.3.19.tgz",
+          "integrity": "sha512-nHftT9Ow71YgAd2/tsu79kwKk30mPuE0sGRRUHZVyCRciGFQweKNOS/6xi2Aq+WwBNNjPKNlbgxwRt1yKe1Vkg==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/components": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/components/-/components-5.3.19.tgz",
+          "integrity": "sha512-3g23/+ktlocaHLJKISu9Neu3XKa6aYP2ctDYkRtGchSB0Q55hQsUVGO+BEVuT7Pk2D59mVCxboBjxcRoPUY4pw==",
+          "dev": true,
+          "requires": {
+            "@storybook/client-logger": "5.3.19",
+            "@storybook/theming": "5.3.19",
+            "@types/react-syntax-highlighter": "11.0.4",
+            "@types/react-textarea-autosize": "^4.3.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "markdown-to-jsx": "^6.11.4",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "popper.js": "^1.14.7",
+            "prop-types": "^15.7.2",
+            "react": "^16.8.3",
+            "react-dom": "^16.8.3",
+            "react-focus-lock": "^2.1.0",
+            "react-helmet-async": "^1.0.2",
+            "react-popper-tooltip": "^2.8.3",
+            "react-syntax-highlighter": "^11.0.2",
+            "react-textarea-autosize": "^7.1.0",
+            "simplebar-react": "^1.0.0-alpha.6",
+            "ts-dedent": "^1.1.0"
+          }
+        },
+        "@storybook/core-events": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/core-events/-/core-events-5.3.19.tgz",
+          "integrity": "sha512-lh78ySqMS7pDdMJAQAe35d1I/I4yPTqp09Cq0YIYOxx9BQZhah4DZTV1QIZt22H5p2lPb5MWLkWSxBaexZnz8A==",
+          "dev": true,
+          "requires": {
+            "core-js": "^3.0.1"
+          }
+        },
+        "@storybook/router": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/router/-/router-5.3.19.tgz",
+          "integrity": "sha512-yNClpuP7BXQlBTRf6Ggle3/R349/k6kvI5Aim4jf6X/2cFVg2pzBXDAF41imNm9PcvdxwabQLm6I48p7OvKr/w==",
+          "dev": true,
+          "requires": {
+            "@reach/router": "^1.2.1",
+            "@storybook/csf": "0.0.1",
+            "@types/reach__router": "^1.2.3",
+            "core-js": "^3.0.1",
+            "global": "^4.3.2",
+            "lodash": "^4.17.15",
+            "memoizerific": "^1.11.3",
+            "qs": "^6.6.0",
+            "util-deprecate": "^1.0.2"
+          }
+        },
+        "@storybook/theming": {
+          "version": "5.3.19",
+          "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-5.3.19.tgz",
+          "integrity": "sha512-ecG+Rq3hc1GOzKHamYnD4wZ0PEP9nNg0mXbC3RhbxfHj+pMMCWWmx9B2Uu75SL1PTT8WcfkFO0hU/0IO84Pzlg==",
+          "dev": true,
+          "requires": {
+            "@emotion/core": "^10.0.20",
+            "@emotion/styled": "^10.0.17",
+            "@storybook/client-logger": "5.3.19",
+            "core-js": "^3.0.1",
+            "deep-object-diff": "^1.1.0",
+            "emotion-theming": "^10.0.19",
+            "global": "^4.3.2",
+            "memoizerific": "^1.11.3",
+            "polished": "^3.3.1",
+            "prop-types": "^15.7.2",
+            "resolve-from": "^5.0.0",
+            "ts-dedent": "^1.1.0"
+          }
+        },
+        "is-plain-object": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
+          "integrity": "sha512-tZIpofR+P05k8Aocp7UI/2UTa9lTJSebCXpFFoR9aibpokDj/uXBsJ8luUu0tTVYKkMU6URDUuOfJZ7koewXvg==",
+          "dev": true,
+          "requires": {
+            "isobject": "^4.0.0"
+          }
+        },
+        "isobject": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/isobject/-/isobject-4.0.0.tgz",
+          "integrity": "sha512-S/2fF5wH8SJA/kmwr6HYhK/RI/OkhD84k8ntalo0iJjZikgq1XFvR5M8NPT1x5F7fBwCG3qHfnzeP/Vh/ZxCUA==",
+          "dev": true
+        },
+        "markdown-to-jsx": {
+          "version": "6.11.4",
+          "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-6.11.4.tgz",
+          "integrity": "sha512-3lRCD5Sh+tfA52iGgfs/XZiw33f7fFX9Bn55aNnVNUd2GzLDkOWyKYYD8Yju2B1Vn+feiEdgJs8T6Tg0xNokPw==",
+          "dev": true,
+          "requires": {
+            "prop-types": "^15.6.2",
+            "unquote": "^1.1.0"
+          }
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
       }
@@ -6768,6 +6987,15 @@
       "requires": {
         "@types/prop-types": "*",
         "csstype": "^2.2.0"
+      }
+    },
+    "@types/react-color": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-3.0.2.tgz",
+      "integrity": "sha512-FhrRy0xEYEpysl1iKL11ynJc79H6ztyYc4xD1pliZyygEChleTlHGohb/bClTYPN8XeSw6yaz45l3YW5SGYftQ==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
       }
     },
     "@types/react-syntax-highlighter": {
@@ -9975,6 +10203,12 @@
       "requires": {
         "toggle-selection": "^1.0.6"
       }
+    },
+    "core-js": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+      "dev": true
     },
     "core-js-compat": {
       "version": "3.1.4",
@@ -17506,6 +17740,12 @@
         "unquote": "^1.1.0"
       }
     },
+    "material-colors": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/material-colors/-/material-colors-1.2.6.tgz",
+      "integrity": "sha512-6qE4B9deFBIa9YSpOc9O0Sgc43zTeVYbgDT5veRKSlB2+ZuHNoVVxA1L/ckMUayV9Ay9y7Z/SZCLcGteW9i7bg==",
+      "dev": true
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -17536,6 +17776,12 @@
       "requires": {
         "mimic-fn": "^1.0.0"
       }
+    },
+    "memoize-one": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-5.1.1.tgz",
+      "integrity": "sha512-HKeeBpWvqiVJD57ZUAsJNm71eHTykffzcLZVYWiVfQeI1rJtuEaS7hQiEpWfVVk18donPwJEcFKIkCmPJNOhHA==",
+      "dev": true
     },
     "memoizerific": {
       "version": "1.11.3",
@@ -21619,6 +21865,20 @@
         "@babel/runtime": "^7.0.0"
       }
     },
+    "react-color": {
+      "version": "2.18.1",
+      "resolved": "https://registry.npmjs.org/react-color/-/react-color-2.18.1.tgz",
+      "integrity": "sha512-X5XpyJS6ncplZs74ak0JJoqPi+33Nzpv5RYWWxn17bslih+X7OlgmfpmGC1fNvdkK7/SGWYf1JJdn7D2n5gSuQ==",
+      "dev": true,
+      "requires": {
+        "@icons/material": "^0.2.4",
+        "lodash": "^4.17.11",
+        "material-colors": "^1.2.1",
+        "prop-types": "^15.5.10",
+        "reactcss": "^1.2.0",
+        "tinycolor2": "^1.4.1"
+      }
+    },
     "react-dev-utils": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/react-dev-utils/-/react-dev-utils-9.1.0.tgz",
@@ -21972,6 +22232,15 @@
         "prop-types": "^15.6.1"
       }
     },
+    "react-input-autosize": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/react-input-autosize/-/react-input-autosize-2.2.2.tgz",
+      "integrity": "sha512-jQJgYCA3S0j+cuOwzuCd1OjmBmnZLdqQdiLKRYrsMMzbjUrVDS5RvJUDwJqA7sKuksDuzFtm6hZGKFu7Mjk5aw==",
+      "dev": true,
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
+    },
     "react-inspector": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/react-inspector/-/react-inspector-4.0.1.tgz",
@@ -22069,6 +22338,22 @@
         }
       }
     },
+    "react-select": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-select/-/react-select-3.1.0.tgz",
+      "integrity": "sha512-wBFVblBH1iuCBprtpyGtd1dGMadsG36W5/t2Aj8OE6WbByDg5jIFyT7X5gT+l0qmT5TqWhxX+VsKJvCEl2uL9g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@emotion/cache": "^10.0.9",
+        "@emotion/core": "^10.0.9",
+        "@emotion/css": "^10.0.9",
+        "memoize-one": "^5.0.0",
+        "prop-types": "^15.6.0",
+        "react-input-autosize": "^2.2.2",
+        "react-transition-group": "^4.3.0"
+      }
+    },
     "react-sizeme": {
       "version": "2.6.12",
       "resolved": "https://registry.npmjs.org/react-sizeme/-/react-sizeme-2.6.12.tgz",
@@ -22140,6 +22425,15 @@
           "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
           "integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
         }
+      }
+    },
+    "reactcss": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/reactcss/-/reactcss-1.2.3.tgz",
+      "integrity": "sha512-KiwVUcFu1RErkI97ywr8nvx8dNOpT03rbnma0SSalTYjkrPYaEajR4a/MRt6DZ46K6arDRbWMNHF+xH7G7n/8A==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.0.1"
       }
     },
     "read": {
@@ -24598,6 +24892,12 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
       "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+    },
+    "tinycolor2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.4.1.tgz",
+      "integrity": "sha1-9PrTM0R7wLB9TcjpIJ2POaisd+g=",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11634,6 +11634,24 @@
         "object-is": "^1.0.2"
       }
     },
+    "enzyme-to-json": {
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/enzyme-to-json/-/enzyme-to-json-3.5.0.tgz",
+      "integrity": "sha512-clusXRsiaQhG7+wtyc4t7MU8N3zCOgf4eY9+CeSenYzKlFST4lxerfOvnWd4SNaToKhkuba+w6m242YpQOS7eA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15",
+        "react-is": "^16.12.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        }
+      }
+    },
     "errno": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7377,6 +7377,32 @@
         "symbol.prototype.description": "^1.0.0"
       }
     },
+    "airbnb-prop-types": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/airbnb-prop-types/-/airbnb-prop-types-2.15.0.tgz",
+      "integrity": "sha512-jUh2/hfKsRjNFC4XONQrxo/n/3GG4Tn6Hl0WlFQN5PY9OMC9loSCoAYKnZsWaP8wEfd5xcrPloK0Zg6iS1xwVA==",
+      "dev": true,
+      "requires": {
+        "array.prototype.find": "^2.1.0",
+        "function.prototype.name": "^1.1.1",
+        "has": "^1.0.3",
+        "is-regex": "^1.0.4",
+        "object-is": "^1.0.1",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.0",
+        "prop-types": "^15.7.2",
+        "prop-types-exact": "^1.2.0",
+        "react-is": "^16.9.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        }
+      }
+    },
     "ajv": {
       "version": "6.10.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -7788,6 +7814,12 @@
       "integrity": "sha1-jCpe8kcv2ep0KwTHenUJO6J1fJM=",
       "dev": true
     },
+    "array-filter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-1.0.0.tgz",
+      "integrity": "sha1-uveeYubvTCpMC4MSMtr/7CUfnYM=",
+      "dev": true
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -7821,6 +7853,69 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
+    },
+    "array.prototype.find": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array.prototype.find/-/array.prototype.find-2.1.1.tgz",
+      "integrity": "sha512-mi+MYNJYLTx2eNYy+Yh6raoQacCsNeeMUaspFPh9Y141lFSsWxxB8V9mM2ye+eqiRs917J6/pJ4M9ZPzenWckA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.4"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        }
+      }
     },
     "array.prototype.flat": {
       "version": "1.2.3",
@@ -9616,6 +9711,41 @@
       "resolved": "https://registry.npmjs.org/charm/-/charm-0.1.2.tgz",
       "integrity": "sha1-BsIe7RobBq62dVPNxT4jJ0usIpY="
     },
+    "cheerio": {
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.0.0-rc.3.tgz",
+      "integrity": "sha512-0td5ijfUPuubwLUu0OBoe98gZj8C/AA+RW3v67GPlGOrvxWjZmBXiBCRU+I8VEiNyJzjth40POfHiz2RB3gImA==",
+      "dev": true,
+      "requires": {
+        "css-select": "~1.2.0",
+        "dom-serializer": "~0.1.1",
+        "entities": "~1.1.1",
+        "htmlparser2": "^3.9.1",
+        "lodash": "^4.15.0",
+        "parse5": "^3.0.1"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "0.1.1",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.1.1.tgz",
+          "integrity": "sha512-l0IU0pPzLWSHBcieZbpOKgkIn3ts3vAh7ZuFyXNwJxJXk/c4Gwj9xaTJwIDVQCXawWD0qb3IzMGH5rglQaO0XA==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^1.3.0",
+            "entities": "^1.1.1"
+          }
+        },
+        "parse5": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/parse5/-/parse5-3.0.3.tgz",
+          "integrity": "sha512-rgO9Zg5LLLkfJF9E6CCmXlSE4UVceloys8JrFqCcHloC3usd/kJCyPDwH2SOlzix2j3xaP9sUX3e8+kvkuleAA==",
+          "dev": true,
+          "requires": {
+            "@types/node": "*"
+          }
+        }
+      }
+    },
     "chokidar": {
       "version": "2.1.8",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -10860,6 +10990,12 @@
         }
       }
     },
+    "discontinuous-range": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
+      "integrity": "sha1-44Mx8IRLukm5qctxx3FYWqsbxlo=",
+      "dev": true
+    },
     "doctrine": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
@@ -11208,6 +11344,295 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.0.tgz",
       "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
+    },
+    "enzyme": {
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/enzyme/-/enzyme-3.11.0.tgz",
+      "integrity": "sha512-Dw8/Gs4vRjxY6/6i9wU0V+utmQO9kvh9XLnz3LIudviOnVYDEe2ec+0k+NQoMamn1VrjKgCUOWj5jG/5M5M0Qw==",
+      "dev": true,
+      "requires": {
+        "array.prototype.flat": "^1.2.3",
+        "cheerio": "^1.0.0-rc.3",
+        "enzyme-shallow-equal": "^1.0.1",
+        "function.prototype.name": "^1.1.2",
+        "has": "^1.0.3",
+        "html-element-map": "^1.2.0",
+        "is-boolean-object": "^1.0.1",
+        "is-callable": "^1.1.5",
+        "is-number-object": "^1.0.4",
+        "is-regex": "^1.0.5",
+        "is-string": "^1.0.5",
+        "is-subset": "^0.1.1",
+        "lodash.escape": "^4.0.1",
+        "lodash.isequal": "^4.5.0",
+        "object-inspect": "^1.7.0",
+        "object-is": "^1.0.2",
+        "object.assign": "^4.1.0",
+        "object.entries": "^1.1.1",
+        "object.values": "^1.1.1",
+        "raf": "^3.4.1",
+        "rst-selector-parser": "^2.2.3",
+        "string.prototype.trim": "^1.2.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object.entries": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
+          "integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.5",
+            "has": "^1.0.3"
+          }
+        },
+        "object.values": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+          "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.0-next.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3"
+          }
+        }
+      }
+    },
+    "enzyme-adapter-react-16": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-react-16/-/enzyme-adapter-react-16-1.15.2.tgz",
+      "integrity": "sha512-SkvDrb8xU3lSxID8Qic9rB8pvevDbLybxPK6D/vW7PrT0s2Cl/zJYuXvsd1EBTz0q4o3iqG3FJhpYz3nUNpM2Q==",
+      "dev": true,
+      "requires": {
+        "enzyme-adapter-utils": "^1.13.0",
+        "enzyme-shallow-equal": "^1.0.1",
+        "has": "^1.0.3",
+        "object.assign": "^4.1.0",
+        "object.values": "^1.1.1",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.12.0",
+        "react-test-renderer": "^16.0.0-0",
+        "semver": "^5.7.0"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object.values": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+          "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.0-next.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        }
+      }
+    },
+    "enzyme-adapter-utils": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.13.0.tgz",
+      "integrity": "sha512-YuEtfQp76Lj5TG1NvtP2eGJnFKogk/zT70fyYHXK2j3v6CtuHqc8YmgH/vaiBfL8K1SgVVbQXtTcgQZFwzTVyQ==",
+      "dev": true,
+      "requires": {
+        "airbnb-prop-types": "^2.15.0",
+        "function.prototype.name": "^1.1.2",
+        "object.assign": "^4.1.0",
+        "object.fromentries": "^2.0.2",
+        "prop-types": "^15.7.2",
+        "semver": "^5.7.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
+          }
+        },
+        "object.fromentries": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/object.fromentries/-/object.fromentries-2.0.2.tgz",
+          "integrity": "sha512-r3ZiBH7MQppDJVLx6fhD618GKNG40CZYH9wgwdhKxBDDbQgjeWGGd4AtkZad84d291YxvWe7bJGuE65Anh0dxQ==",
+          "dev": true,
+          "requires": {
+            "define-properties": "^1.1.3",
+            "es-abstract": "^1.17.0-next.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        }
+      }
+    },
+    "enzyme-shallow-equal": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/enzyme-shallow-equal/-/enzyme-shallow-equal-1.0.1.tgz",
+      "integrity": "sha512-hGA3i1so8OrYOZSM9whlkNmVHOicJpsjgTzC+wn2JMJXhq1oO4kA4bJ5MsfzSIcC71aLDKzJ6gZpIxrqt3QTAQ==",
+      "dev": true,
+      "requires": {
+        "has": "^1.0.3",
+        "object-is": "^1.0.2"
+      }
     },
     "errno": {
       "version": "0.1.7",
@@ -13770,6 +14195,15 @@
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.4.tgz",
       "integrity": "sha512-pzXIvANXEFrc5oFFXRMkbLPQ2rXRoDERwDLyrcUxGhaZhgP54BBSl9Oheh7Vv0T090cszWBxPjkQQ5Sq1PbBRQ=="
     },
+    "html-element-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/html-element-map/-/html-element-map-1.2.0.tgz",
+      "integrity": "sha512-0uXq8HsuG1v2TmQ8QkIhzbrqeskE4kn52Q18QJ9iAA/SnHoEKXWiUxHQtclRsCFWEUD2So34X+0+pZZu862nnw==",
+      "dev": true,
+      "requires": {
+        "array-filter": "^1.0.0"
+      }
+    },
     "html-encoding-sniffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-1.0.2.tgz",
@@ -14313,6 +14747,12 @@
         "binary-extensions": "^1.0.0"
       }
     },
+    "is-boolean-object": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-boolean-object/-/is-boolean-object-1.0.1.tgz",
+      "integrity": "sha512-TqZuVwa/sppcrhUCAYkGBk7w0yxfQQnxq28fjkO53tnK9FQXmdwz2JS5+GjsWQ6RByES1K40nI+yDic5c9/aAQ==",
+      "dev": true
+    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -14476,6 +14916,12 @@
         }
       }
     },
+    "is-number-object": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.4.tgz",
+      "integrity": "sha512-zohwelOAur+5uXtk8O3GPQ1eAcu4ZX3UwxQhUlfFFMNpUd83gXgjbhJh6HmB6LUNV/ieOLQuDwJO3dWJosUeMw==",
+      "dev": true
+    },
     "is-obj": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
@@ -14558,6 +15004,12 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
       "integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+      "dev": true
+    },
+    "is-subset": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-subset/-/is-subset-0.1.1.tgz",
+      "integrity": "sha1-ilkRfZMt4d4A8kX83TnOQ/HpOaY=",
       "dev": true
     },
     "is-symbol": {
@@ -17505,10 +17957,22 @@
       "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
       "dev": true
     },
+    "lodash.escape": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-4.0.1.tgz",
+      "integrity": "sha1-yQRGkMIeBClL6qUXcS/e0fqI3pg=",
+      "dev": true
+    },
     "lodash.findindex": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/lodash.findindex/-/lodash.findindex-4.6.0.tgz",
       "integrity": "sha1-oyRd7mH7m24GJLU1ElYku2nBEQY="
+    },
+    "lodash.flattendeep": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
+      "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
+      "dev": true
     },
     "lodash.foreach": {
       "version": "4.5.0",
@@ -17529,6 +17993,12 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
+    },
+    "lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA=",
+      "dev": true
     },
     "lodash.isinteger": {
       "version": "4.0.4",
@@ -18154,6 +18624,12 @@
         "moment": ">= 2.9.0"
       }
     },
+    "moo": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.1.tgz",
+      "integrity": "sha512-I1mnb5xn4fO80BH9BLcF0yLypy2UKl+Cb01Fu0hJRkJjlCRtxZMWkTdAtDd5ZqCOxtCkhmRwyI57vWT+1iZ67w==",
+      "dev": true
+    },
     "move-concurrently": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/move-concurrently/-/move-concurrently-1.0.1.tgz",
@@ -18213,6 +18689,19 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "nearley": {
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.19.3.tgz",
+      "integrity": "sha512-FpAy1PmTsUpOtgxr23g4jRNvJHYzZEW2PixXeSzksLR/ykPfwKhAodc2+9wQhY+JneWLcvkDw6q7FJIsIdF/aQ==",
+      "dev": true,
+      "requires": {
+        "commander": "^2.19.0",
+        "moo": "^0.5.0",
+        "railroad-diagrams": "^1.0.0",
+        "randexp": "0.4.6",
+        "semver": "^5.4.1"
+      }
     },
     "needle": {
       "version": "2.4.0",
@@ -21796,11 +22285,36 @@
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
       "dev": true
     },
+    "raf": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
+      "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
+      "dev": true,
+      "requires": {
+        "performance-now": "^2.1.0"
+      }
+    },
+    "railroad-diagrams": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
+      "integrity": "sha1-635iZ1SN3t+4mcG5Dlc3RVnN234=",
+      "dev": true
+    },
     "ramda": {
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.21.0.tgz",
       "integrity": "sha1-oAGr7bP/YQd9T/HVd9RN536NCjU=",
       "dev": true
+    },
+    "randexp": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
+      "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
+      "dev": true,
+      "requires": {
+        "discontinuous-range": "1.0.0",
+        "ret": "~0.1.10"
+      }
     },
     "randombytes": {
       "version": "2.1.0",
@@ -23087,6 +23601,16 @@
         }
       }
     },
+    "rst-selector-parser": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/rst-selector-parser/-/rst-selector-parser-2.2.3.tgz",
+      "integrity": "sha1-gbIw6i/MYGbInjRy3nlChdmwPZE=",
+      "dev": true,
+      "requires": {
+        "lodash.flattendeep": "^4.4.0",
+        "nearley": "^2.7.10"
+      }
+    },
     "rsvp": {
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
@@ -24254,6 +24778,70 @@
           "dev": true,
           "requires": {
             "has": "^1.0.3"
+          }
+        }
+      }
+    },
+    "string.prototype.trim": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.1.tgz",
+      "integrity": "sha512-MjGFEeqixw47dAMFMtgUro/I0+wNqZB5GKXGt1fFr24u3TzDXCPu7J9Buppzoe3r/LqkSDLDDJzE15RGWDGAVw==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1",
+        "function-bind": "^1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.17.5",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
+          "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.5",
+            "is-regex": "^1.0.5",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.0",
+            "string.prototype.trimleft": "^2.1.1",
+            "string.prototype.trimright": "^2.1.1"
+          }
+        },
+        "es-to-primitive": {
+          "version": "1.2.1",
+          "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.2.1.tgz",
+          "integrity": "sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==",
+          "dev": true,
+          "requires": {
+            "is-callable": "^1.1.4",
+            "is-date-object": "^1.0.1",
+            "is-symbol": "^1.0.2"
+          }
+        },
+        "has-symbols": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
+          "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+          "dev": true
+        },
+        "is-callable": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+          "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+          "dev": true
+        },
+        "is-regex": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+          "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+          "dev": true,
+          "requires": {
+            "has-symbols": "^1.0.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@babel/preset-env": "^7.9.0",
     "@babel/preset-react": "^7.8.3",
     "@storybook/addon-actions": "^5.3.17",
-    "@storybook/addon-links": "^5.3.17",
+    "@storybook/addon-knobs": "^5.3.17",
     "@storybook/addon-storyshots": "^5.3.17",
     "@storybook/addons": "^5.3.17",
     "@storybook/react": "^5.3.17",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "babel-loader": "^8.0.6",
     "babel-plugin-module-resolver": "^4.0.0",
     "babel-plugin-ttag": "^1.7.23",
+    "enzyme": "^3.11.0",
+    "enzyme-adapter-react-16": "^1.15.2",
     "eslint": "^6.2.2",
     "eslint-config-prettier": "^6.1.0",
     "eslint-import-resolver-babel-module": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "babel-plugin-ttag": "^1.7.23",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
+    "enzyme-to-json": "^3.5.0",
     "eslint": "^6.2.2",
     "eslint-config-prettier": "^6.1.0",
     "eslint-import-resolver-babel-module": "^5.1.0",


### PR DESCRIPTION
Adds storybook & storyshot for `<TimeRange>` component.

![image](https://user-images.githubusercontent.com/108608/83779838-05883b80-a6bf-11ea-90d5-ebc1f7d76241.png)

![timerange-story](https://user-images.githubusercontent.com/108608/83780071-454f2300-a6bf-11ea-8514-72162db2b211.gif)

- Enzyme is required because `react-test-renderer` storyshot built-in cannot handle `Material-UI`'s portal (used in Material UI Modal that comprised of Material UI dropdown lists). Ref: https://github.com/storybookjs/storybook/tree/master/addons/storyshots/storyshots-core#renderer
- Adds `@storybook/addon-knobs` to demonstrate how `<TimeRange />` reacts to `range` prop change
- Removes brittle snapshot made by Material-UI internals by [implementing enzyme-to-json `map` function](https://github.com/adriantoine/enzyme-to-json/blob/master/docs/map.md)
- Splits snapshot files into one snapshot per story file (but currently there is only 1 story so far...) using `multiSnapshotWithOptions` and [corresponding setup](https://github.com/storybookjs/storybook/tree/master/addons/storyshots/storyshots-core#multisnapshotwithoptionsoptions)