### PR TITLE
[Trivial] Remove serial number from makeStyle className in storyshots

### DIFF
--- a/Storyshots.test.js
+++ b/Storyshots.test.js
@@ -7,6 +7,8 @@ import { createSerializer } from 'enzyme-to-json';
 
 Enzyme.configure({ adapter: new Adapter() });
 
+const MAKE_STYLE_REGEXP = /(makeStyles-.+?)-\d+/g;
+
 function removeMaterialUIInternals(json) {
   // Remove Portal containerInfo
   if (json.type === 'Portal') {
@@ -31,7 +33,25 @@ function removeMaterialUIInternals(json) {
   if (json.type.match(/^(ForwardRef|WithStyles|ThemeProvider|Styled)/)) {
     // When skipping HOC or wrapper, the first children are usually setups (such as <CssBaseline>),
     // we should ignore together
-    return json.children && json.children[json.children.length - 1];
+    return (
+      json.children &&
+      removeMaterialUIInternals(json.children[json.children.length - 1])
+    );
+  }
+
+  // Remove makeStyle className serial numbers
+  if (
+    json.props &&
+    json.props.className &&
+    json.props.className.match(MAKE_STYLE_REGEXP)
+  ) {
+    json = {
+      ...json,
+      props: {
+        ...json.props,
+        className: json.props.className.replace(MAKE_STYLE_REGEXP, '$1'),
+      },
+    };
   }
 
   return json;

--- a/Storyshots.test.js
+++ b/Storyshots.test.js
@@ -7,7 +7,7 @@ import { createSerializer } from 'enzyme-to-json';
 
 Enzyme.configure({ adapter: new Adapter() });
 
-const MAKE_STYLE_REGEXP = /(makeStyles-.+?)-\d+/g;
+const MAKE_STYLE_REGEXP = /((?:makeStyles|MuiBox)-.+?)-\d+/g;
 
 function removeMaterialUIInternals(json) {
   // Remove Portal containerInfo

--- a/Storyshots.test.js
+++ b/Storyshots.test.js
@@ -40,11 +40,7 @@ function removeMaterialUIInternals(json) {
   }
 
   // Remove makeStyle className serial numbers
-  if (
-    json.props &&
-    json.props.className &&
-    json.props.className.match(MAKE_STYLE_REGEXP)
-  ) {
+  if (json.props?.className?.match(MAKE_STYLE_REGEXP)) {
     json = {
       ...json,
       props: {

--- a/components/ListPage/__snapshots__/BaseSortInput.stories.storyshot
+++ b/components/ListPage/__snapshots__/BaseSortInput.stories.storyshot
@@ -3,14 +3,14 @@
 exports[`Storyshots ListPage/BaseSortInput No Props Given 1`] = `
 <BaseSortInput>
   <div
-    className="MuiFormControl-root MuiTextField-root makeStyles-root-6"
+    className="MuiFormControl-root MuiTextField-root makeStyles-root"
   >
     <div
-      className="MuiInputBase-root MuiInput-root makeStyles-inputClass-7 makeStyles-inputClass-10 Mui-disabled Mui-disabled MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedStart"
+      className="MuiInputBase-root MuiInput-root makeStyles-inputClass makeStyles-inputClass Mui-disabled Mui-disabled MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedStart"
       onClick={[Function]}
     >
       <div
-        className="MuiInputAdornment-root makeStyles-adornment-8 MuiInputAdornment-positionStart"
+        className="MuiInputAdornment-root makeStyles-adornment MuiInputAdornment-positionStart"
       >
         <p
           className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"
@@ -50,14 +50,14 @@ exports[`Storyshots ListPage/BaseSortInput With Options 1`] = `
   }
 >
   <div
-    className="MuiFormControl-root MuiTextField-root makeStyles-root-108"
+    className="MuiFormControl-root MuiTextField-root makeStyles-root"
   >
     <div
-      className="MuiInputBase-root MuiInput-root makeStyles-inputClass-109 makeStyles-inputClass-112 MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedStart"
+      className="MuiInputBase-root MuiInput-root makeStyles-inputClass makeStyles-inputClass MuiInputBase-formControl MuiInput-formControl MuiInputBase-adornedStart"
       onClick={[Function]}
     >
       <div
-        className="MuiInputAdornment-root makeStyles-adornment-110 MuiInputAdornment-positionStart"
+        className="MuiInputAdornment-root makeStyles-adornment MuiInputAdornment-positionStart"
       >
         <p
           className="MuiTypography-root MuiTypography-body1 MuiTypography-colorTextSecondary"

--- a/components/ListPage/__snapshots__/BaseTimeRange.stories.storyshot
+++ b/components/ListPage/__snapshots__/BaseTimeRange.stories.storyshot
@@ -5,14 +5,14 @@ exports[`Storyshots ListPage/BaseTimeRange No Start End Given 1`] = `
   onChange={[Function]}
 >
   <div
-    className="makeStyles-root-210"
+    className="makeStyles-root"
   >
     <div
       className="MuiButtonGroup-root"
       role="group"
     >
       <button
-        className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-212"
+        className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -34,7 +34,7 @@ exports[`Storyshots ListPage/BaseTimeRange No Start End Given 1`] = `
         >
           <svg
             aria-hidden="true"
-            className="MuiSvgIcon-root makeStyles-calendarIcon-213"
+            className="MuiSvgIcon-root makeStyles-calendarIcon"
             focusable="false"
             viewBox="0 0 24 24"
           >
@@ -56,7 +56,7 @@ exports[`Storyshots ListPage/BaseTimeRange No Start End Given 1`] = `
         </NoSsr>
       </button>
       <button
-        className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-214"
+        className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton"
         disabled={false}
         onBlur={[Function]}
         onClick={[Function]}
@@ -326,14 +326,14 @@ exports[`Storyshots ListPage/BaseTimeRange Set Start End From Props 1`] = `
     start=""
   >
     <div
-      className="makeStyles-root-343"
+      className="makeStyles-root"
     >
       <div
         className="MuiButtonGroup-root"
         role="group"
       >
         <button
-          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-345"
+          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -355,7 +355,7 @@ exports[`Storyshots ListPage/BaseTimeRange Set Start End From Props 1`] = `
           >
             <svg
               aria-hidden="true"
-              className="MuiSvgIcon-root makeStyles-calendarIcon-346"
+              className="MuiSvgIcon-root makeStyles-calendarIcon"
               focusable="false"
               viewBox="0 0 24 24"
             >
@@ -377,7 +377,7 @@ exports[`Storyshots ListPage/BaseTimeRange Set Start End From Props 1`] = `
           </NoSsr>
         </button>
         <input
-          className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate-348"
+          className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate"
           color="default"
           disableFocusRipple={false}
           disableRipple={false}
@@ -391,7 +391,7 @@ exports[`Storyshots ListPage/BaseTimeRange Set Start End From Props 1`] = `
           variant="outlined"
         >
           <input
-            className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate-348"
+            className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate"
             onChange={[Function]}
             type="date"
             value=""
@@ -399,12 +399,12 @@ exports[`Storyshots ListPage/BaseTimeRange Set Start End From Props 1`] = `
         </input>
       </div>
       <span
-        className="makeStyles-to-349"
+        className="makeStyles-to"
       >
         to
       </span>
       <input
-        className="makeStyles-endDate-350"
+        className="makeStyles-endDate"
         onChange={[Function]}
         type="date"
         value=""
@@ -632,14 +632,14 @@ exports[`Storyshots ListPage/BaseTimeRange Set Start End From Props 1`] = `
     start="now-1d/d"
   >
     <div
-      className="makeStyles-root-343"
+      className="makeStyles-root"
     >
       <div
         className="MuiButtonGroup-root"
         role="group"
       >
         <button
-          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-345"
+          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -661,7 +661,7 @@ exports[`Storyshots ListPage/BaseTimeRange Set Start End From Props 1`] = `
           >
             <svg
               aria-hidden="true"
-              className="MuiSvgIcon-root makeStyles-calendarIcon-346"
+              className="MuiSvgIcon-root makeStyles-calendarIcon"
               focusable="false"
               viewBox="0 0 24 24"
             >
@@ -683,7 +683,7 @@ exports[`Storyshots ListPage/BaseTimeRange Set Start End From Props 1`] = `
           </NoSsr>
         </button>
         <button
-          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton-347"
+          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-selectButton"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -947,14 +947,14 @@ exports[`Storyshots ListPage/BaseTimeRange Set Start End From Props 1`] = `
     start="1989-06-04"
   >
     <div
-      className="makeStyles-root-343"
+      className="makeStyles-root"
     >
       <div
         className="MuiButtonGroup-root"
         role="group"
       >
         <button
-          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton-345"
+          className="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-calendarButton"
           disabled={false}
           onBlur={[Function]}
           onClick={[Function]}
@@ -976,7 +976,7 @@ exports[`Storyshots ListPage/BaseTimeRange Set Start End From Props 1`] = `
           >
             <svg
               aria-hidden="true"
-              className="MuiSvgIcon-root makeStyles-calendarIcon-346"
+              className="MuiSvgIcon-root makeStyles-calendarIcon"
               focusable="false"
               viewBox="0 0 24 24"
             >
@@ -998,7 +998,7 @@ exports[`Storyshots ListPage/BaseTimeRange Set Start End From Props 1`] = `
           </NoSsr>
         </button>
         <input
-          className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate-348"
+          className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate"
           color="default"
           disableFocusRipple={false}
           disableRipple={false}
@@ -1012,7 +1012,7 @@ exports[`Storyshots ListPage/BaseTimeRange Set Start End From Props 1`] = `
           variant="outlined"
         >
           <input
-            className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate-348"
+            className="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedOutlined MuiButtonGroup-groupedOutlinedHorizontal MuiButtonGroup-groupedOutlined makeStyles-startDate"
             onChange={[Function]}
             type="date"
             value="1989-06-04"
@@ -1020,12 +1020,12 @@ exports[`Storyshots ListPage/BaseTimeRange Set Start End From Props 1`] = `
         </input>
       </div>
       <span
-        className="makeStyles-to-349"
+        className="makeStyles-to"
       >
         to
       </span>
       <input
-        className="makeStyles-endDate-350"
+        className="makeStyles-endDate"
         onChange={[Function]}
         type="date"
         value="2019-06-04"

--- a/components/ListPage/__snapshots__/Filters.stories.storyshot
+++ b/components/ListPage/__snapshots__/Filters.stories.storyshot
@@ -3,7 +3,7 @@
 exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
 <Filters>
   <dl
-    className="makeStyles-desktop-476"
+    className="makeStyles-desktop"
   >
     <BaseFilter
       onChange={[Function]}
@@ -22,12 +22,12 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
       title="Normal filter"
     >
       <dt
-        className="makeStyles-title-481"
+        className="makeStyles-title"
       >
         Normal filter
       </dt>
       <dd
-        className="makeStyles-body-486"
+        className="makeStyles-body"
       >
         <BaseFilterOption
           key="option1"
@@ -36,7 +36,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
           value="option1"
         >
           <div
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-493 MuiChip-outlined MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -53,7 +53,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Option 1
             </span>
@@ -77,7 +77,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
           value="option2"
         >
           <div
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-527 MuiChip-outlined MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -94,7 +94,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Option 2
             </span>
@@ -151,12 +151,12 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
       title="Has selected"
     >
       <dt
-        className="makeStyles-title-481"
+        className="makeStyles-title"
       >
         Has selected
       </dt>
       <dd
-        className="makeStyles-body-486"
+        className="makeStyles-body"
       >
         <BaseFilterOption
           key="option1"
@@ -165,7 +165,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
           value="option1"
         >
           <div
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-528 MuiChip-outlined MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -182,7 +182,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Option 1
             </span>
@@ -207,7 +207,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
           value="option2"
         >
           <div
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-529 MuiChip-outlined MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -224,7 +224,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Option 2
             </span>
@@ -250,7 +250,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
         >
           <div
             aria-disabled={true}
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-530 MuiChip-outlined Mui-disabled MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined Mui-disabled MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -267,7 +267,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Disabled
             </span>
@@ -292,7 +292,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
           value="option4"
         >
           <div
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-531 MuiChip-outlined MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -309,7 +309,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Chip
             </span>
@@ -335,7 +335,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
           value="option5"
         >
           <div
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-532 MuiChip-outlined MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -352,7 +352,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Selected Chip
             </span>
@@ -411,12 +411,12 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
       title="Expandable"
     >
       <dt
-        className="makeStyles-title-481 makeStyles-expandable-482"
+        className="makeStyles-title makeStyles-expandable"
       >
         Expandable
         <svg
           aria-hidden="true"
-          className="MuiSvgIcon-root makeStyles-icon-484"
+          className="MuiSvgIcon-root makeStyles-icon"
           focusable="false"
           viewBox="0 0 24 24"
         >
@@ -426,7 +426,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
         </svg>
       </dt>
       <dd
-        className="makeStyles-body-486"
+        className="makeStyles-body"
       >
         <BaseFilterOption
           key="option1"
@@ -436,7 +436,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
           value="option1"
         >
           <div
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-542 MuiChip-outlined MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -453,7 +453,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Option 1
             </span>
@@ -477,7 +477,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
           value="option2"
         >
           <div
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-543 MuiChip-outlined MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -494,7 +494,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Option 2
             </span>
@@ -518,7 +518,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
           value="option3"
         >
           <div
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-544 MuiChip-outlined MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -535,7 +535,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Option 3
             </span>
@@ -559,7 +559,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
           value="option4"
         >
           <div
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-545 MuiChip-outlined MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -576,7 +576,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Option 4
             </span>
@@ -600,7 +600,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
           value="option5"
         >
           <div
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-546 MuiChip-outlined MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -617,7 +617,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Option 5
             </span>
@@ -643,7 +643,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
         >
           <div
             aria-disabled={true}
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-547 MuiChip-outlined Mui-disabled MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined Mui-disabled MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -660,7 +660,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Disabled
             </span>
@@ -698,12 +698,12 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
       title="Placehold"
     >
       <dt
-        className="makeStyles-title-481 makeStyles-expandable-482"
+        className="makeStyles-title makeStyles-expandable"
       >
         Placehold
         <svg
           aria-hidden="true"
-          className="MuiSvgIcon-root makeStyles-icon-484"
+          className="MuiSvgIcon-root makeStyles-icon"
           focusable="false"
           viewBox="0 0 24 24"
         >
@@ -713,10 +713,10 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
         </svg>
       </dt>
       <dd
-        className="makeStyles-body-486"
+        className="makeStyles-body"
       >
         <div
-          className="makeStyles-placeholder-488"
+          className="makeStyles-placeholder"
         >
           Placeholder only shows when nothing is selected on desktop
         </div>
@@ -727,7 +727,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
           value="option1"
         >
           <div
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-548 MuiChip-outlined MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -744,7 +744,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Option 1
             </span>
@@ -768,7 +768,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
           value="option2"
         >
           <div
-            className="MuiButtonBase-root MuiChip-root makeStyles-root-491 makeStyles-root-549 MuiChip-outlined MuiChip-clickable"
+            className="MuiButtonBase-root MuiChip-root makeStyles-root makeStyles-root MuiChip-outlined MuiChip-clickable"
             onBlur={[Function]}
             onClick={[Function]}
             onDragLeave={[Function]}
@@ -785,7 +785,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
             tabIndex={0}
           >
             <span
-              className="MuiChip-label makeStyles-label-492"
+              className="MuiChip-label makeStyles-label"
             >
               Option 2
             </span>
@@ -807,7 +807,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
   </dl>
   <button
     aria-label="filters"
-    className="MuiButtonBase-root MuiFab-root makeStyles-fab-478 MuiFab-extended MuiFab-sizeMedium"
+    className="MuiButtonBase-root MuiFab-root makeStyles-fab MuiFab-extended MuiFab-sizeMedium"
     data-ga="Mobile filter button"
     disabled={false}
     onBlur={[Function]}
@@ -830,7 +830,7 @@ exports[`Storyshots ListPage/Filters Filters And Options 1`] = `
     >
       <svg
         aria-hidden="true"
-        className="MuiSvgIcon-root makeStyles-fabIcon-479"
+        className="MuiSvgIcon-root makeStyles-fabIcon"
         focusable="false"
         viewBox="0 0 24 24"
       >

--- a/components/ListPage/__snapshots__/LoadMore.stories.storyshot
+++ b/components/ListPage/__snapshots__/LoadMore.stories.storyshot
@@ -35,7 +35,7 @@ exports[`Storyshots ListPage/LoadMore Shows Up 1`] = `
   }
 >
   <div
-    className="MuiBox-root MuiBox-root-588"
+    className="MuiBox-root MuiBox-root"
   >
     <button
       className="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-loadMore"

--- a/components/ListPage/__snapshots__/LoadMore.stories.storyshot
+++ b/components/ListPage/__snapshots__/LoadMore.stories.storyshot
@@ -38,7 +38,7 @@ exports[`Storyshots ListPage/LoadMore Shows Up 1`] = `
     className="MuiBox-root MuiBox-root-588"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-loadMore-585"
+      className="MuiButtonBase-root MuiButton-root MuiButton-outlined makeStyles-loadMore"
       data-ga="LoadMore"
       disabled={false}
       onBlur={[Function]}

--- a/components/PlainList.js
+++ b/components/PlainList.js
@@ -1,13 +1,16 @@
-import { withStyles } from '@material-ui/core/styles';
+import { makeStyles } from '@material-ui/core/styles';
 import cx from 'clsx';
 
-const PlainList = withStyles({
+const useStyles = makeStyles({
   root: {
     listStyleType: 'none',
     paddingLeft: 0,
   },
-})(({ classes, className, ...props }) => (
-  <ul className={cx(classes.root, className)} {...props} />
-));
+});
+
+function PlainList({ className, ...otherProps }) {
+  const classes = useStyles();
+  return <ul className={cx(classes.root, className)} {...otherProps} />;
+}
 
 export default PlainList;

--- a/components/__snapshots__/ExpandableText.stories.storyshot
+++ b/components/__snapshots__/ExpandableText.stories.storyshot
@@ -25,7 +25,7 @@ exports[`Storyshots ExpandableText With Line Clamp Given 1`] = `
     >
       <div>
         <div
-          className="makeStyles-root-4"
+          className="makeStyles-root"
           style={
             Object {
               "maxHeight": 42,

--- a/components/__snapshots__/PlainList.stories.storyshot
+++ b/components/__snapshots__/PlainList.stories.storyshot
@@ -5,15 +5,9 @@ exports[`Storyshots PlainList Description 1`] = `
   <p>
     Just an unordered list (ul) without default list-style. small utility.
   </p>
-  <Component
-    classes={
-      Object {
-        "root": "Component-root-633",
-      }
-    }
-  >
+  <PlainList>
     <ul
-      className="Component-root-633"
+      className="makeStyles-root"
     >
       <li>
         item 1
@@ -25,6 +19,6 @@ exports[`Storyshots PlainList Description 1`] = `
         item 3
       </li>
     </ul>
-  </Component>
+  </PlainList>
 </div>
 `;


### PR DESCRIPTION
`makeStyle`'s serial number in classnames often cause storyshots to change as we write new stories, resulting in irrelevant code changes in pull requests.

This PR:
- removes the serial number from snapshots
    - supports `makeStyle` and `MuiBox`
    - This makes snapshots more independent from each other.
- replaces `withStyle` with `makeStyle` for components in storyshot
    - The snapshot of `withStyle` is difficult to modify, thus change to use the latter.
- updates all snapshots