### PR TITLE
Add search icon, placeholder, and enablef height adjustment

### DIFF
--- a/components/NewReplySection/ReplyForm/ReferenceInput.js
+++ b/components/NewReplySection/ReplyForm/ReferenceInput.js
@@ -13,7 +13,6 @@ const useStyles = makeStyles(theme => ({
     },
   },
   textarea: {
-    flex: 1,
     width: '100%',
     borderRadius: 8,
     border: 'none',

--- a/components/NewReplySection/ReplyForm/ReferenceInput.js
+++ b/components/NewReplySection/ReplyForm/ReferenceInput.js
@@ -13,12 +13,15 @@ const useStyles = makeStyles(theme => ({
     },
   },
   textarea: {
+    flex: 1,
     width: '100%',
     borderRadius: 8,
     border: 'none',
     outline: 'none',
     padding: '14px 17px',
     [theme.breakpoints.up('md')]: {
+      flex: 'none', // Disable flex so that user can enlarge textarea by themselves
+      minHeight: 144,
       border: `1px solid ${theme.palette.secondary[100]}`,
       '&:focus': {
         border: `1px solid ${theme.palette.primary[500]}`,

--- a/components/NewReplySection/ReplySearch/SearchBar.js
+++ b/components/NewReplySection/ReplySearch/SearchBar.js
@@ -42,7 +42,7 @@ const useStyles = makeStyles(theme => ({
   iconButtonLabel: {
     color: theme.palette.common.white,
     '& svg': {
-      fontSize: 10,
+      fontSize: 16,
     },
   },
 }));
@@ -112,6 +112,7 @@ export default function SearchBar({ className }) {
       <Box position="relative" width="100%" display="flex" alignItems="center">
         <input
           className={classes.input}
+          placeholder="參考過往回應"
           type="text"
           value={buffer}
           onChange={e => setBuffer(e.target.value)}
@@ -125,7 +126,24 @@ export default function SearchBar({ className }) {
           }}
         />
         {buffer && (
-          <Box position="absolute" left={10 + getWidth(inputRef, buffer)}>
+          <Box position="absolute" left={14 + getWidth(inputRef, buffer)}>
+            <IconButton
+              classes={{
+                root: classes.iconButtonRoot,
+                label: classes.iconButtonLabel,
+              }}
+              disableElevation
+              aria-label="search"
+              onClick={() => {
+                setSearch(buffer);
+              }}
+            >
+              <SearchIcon />
+            </IconButton>
+          </Box>
+        )}
+        {buffer && (
+          <Box position="absolute" left={44 + getWidth(inputRef, buffer)}>
             <IconButton
               classes={{
                 root: classes.iconButtonRoot,


### PR DESCRIPTION
Done
搜尋框加上「參考過往回應」的 placeholder
使理由與來源的 input 能垂直拉大
增加搜尋圖示提供搜尋功能，而不是只能用 Enter

TODOs
使理由與來源的 input 水平方向則固定
搜尋時加上 loading indicator
修正 iOS 點按「Add this reply to my reply」送出的問題