### PR TITLE
Fix dev "cannot invoke map of undefined" bug

### DIFF
--- a/components/ArticleInfo.js
+++ b/components/ArticleInfo.js
@@ -99,6 +99,11 @@ ArticleInfo.fragments = {
       replyRequestCount
       replyCount
       createdAt
+      articleReplies(status: NORMAL) {
+        reply {
+          type
+        }
+      }
     }
   `,
 };


### PR DESCRIPTION
ArticleInfo should query for articleReplies as it is using articleReply data.

## Before
Staging:
![image](https://user-images.githubusercontent.com/108608/88452851-9b0ca400-ce94-11ea-9b1f-15e8fdf0547e.png)

Localhost:
![image](https://user-images.githubusercontent.com/108608/88452996-c9d74a00-ce95-11ea-971f-dade9b3dfe1c.png)


## After
Detail page can load without problem

## Analysis
`<ArticleInfo>` in `ArticleDetail` page actually uses `articleReplies` field. However, It's not declared in its fragment, thus `articleReplies` fields are not populated properly in detail page.

This PR adds the field in loading sequence so that the field exists no matter where `<ArticleInfo>` is used.