### PR TITLE
Add Object.fromEntries polyfill to support iOS Safari 11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10687,8 +10687,7 @@
     "core-js": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
-      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
-      "dev": true
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA=="
     },
     "core-js-compat": {
       "version": "3.1.4",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "apollo-link-error": "^1.1.12",
     "clipboard": "^2.0.4",
     "clsx": "^1.0.4",
+    "core-js": "^3.6.5",
     "date-fns": "^2.0.1",
     "dotenv": "^8.0.0",
     "emoji-mart": "^3.0.0",
@@ -50,8 +51,6 @@
   "devDependencies": {
     "@babel/core": "^7.9.0",
     "@babel/plugin-proposal-optional-chaining": "^7.6.0",
-    "@babel/preset-env": "^7.9.0",
-    "@babel/preset-react": "^7.8.3",
     "@storybook/addon-actions": "^5.3.17",
     "@storybook/addon-knobs": "^5.3.17",
     "@storybook/addon-storyshots": "^5.3.17",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,3 +1,10 @@
+// Polyfills
+// Note: It's not safe to use noModule here. For instance, iOS 11 skips loading <script nomodule>
+// but needs polyfills to support Object.fromEntries.
+// @see https://nextjs.org/docs/basic-features/supported-browsers-features#custom-polyfills
+//
+import 'core-js/features/object/from-entries';
+
 import App from 'next/app';
 import React from 'react';
 import { ThemeProvider } from '@material-ui/core/styles';


### PR DESCRIPTION
According to #313 we should support Safari >= 10.3; however, currently our usage of `Object.fromEntries` breaks iOS safari.

This PR:
- Removes unused babel preset (they are already [included in Next.js 9.3](https://nextjs.org/blog/next-9-3#32-kb-smaller-runtime-15-kb-gzip))
- Adds `core-js/features/object/from-entries` to `_app.js`
    - putting polyfill in `_app` is the suggested way of adding custom polyfills in [official doc](https://nextjs.org/docs/basic-features/supported-browsers-features#custom-polyfills)
    - [`nomodule` trick](https://3perf.com/blog/polyfills/) can't be used because iOS 11 supports nomodule (don't load nomodule scripts) but still does not support `Object.fromEntries` and needs to be polyfilled.

Fixes #313 .

### iOS 10, iPhone 7
![image](https://user-images.githubusercontent.com/108608/90317358-74a1cc00-df5b-11ea-8b90-f565ae2f2939.png)


### iOS 11, iPhone 6
![image](https://user-images.githubusercontent.com/108608/90317334-4623f100-df5b-11ea-8158-ae8a39cf825e.png)
