### PR TITLE
Remove Google translate toolbar by loading Google site translate after click

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -2,10 +2,10 @@ import React from 'react';
 import { addDecorator } from '@storybook/react';
 import { ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import theme from '../lib/theme';
+import { lightTheme } from '../lib/theme';
 
 addDecorator(storyFn => (
-  <ThemeProvider theme={theme}>
+  <ThemeProvider theme={lightTheme}>
     <CssBaseline />
     {storyFn()}
   </ThemeProvider>

--- a/components/AppLayout/AppFooter.js
+++ b/components/AppLayout/AppFooter.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import { t } from 'ttag';
+import { withStyles, makeStyles } from '@material-ui/core/styles';
+import { Box, useMediaQuery } from '@material-ui/core';
+import MailIcon from '@material-ui/icons/Mail';
+import FacebookIcon from '@material-ui/icons/Facebook';
+import { withDarkTheme } from 'lib/theme';
 import {
   EDITOR_FACEBOOK_GROUP,
   PROJECT_HACKFOLDR,
   CONTACT_EMAIL,
 } from 'constants/urls';
 import NavLink from 'components/NavLink';
-import { withStyles, makeStyles } from '@material-ui/core/styles';
-import { Box, useMediaQuery } from '@material-ui/core';
-import MailIcon from '@material-ui/icons/Mail';
-import FacebookIcon from '@material-ui/icons/Facebook';
 import GoogleWebsiteTranslator from './GoogleWebsiteTranslator';
 
 const useStyles = makeStyles(theme => ({
@@ -23,7 +24,7 @@ const useStyles = makeStyles(theme => ({
   },
   container: {
     width: 800,
-    color: '#FFFFFF',
+    color: theme.palette.text.primary,
     margin: 60,
     display: 'flex',
   },
@@ -52,11 +53,12 @@ const CustomLink = withStyles(theme => ({
     alignItems: 'center',
   },
   link: {
-    color: '#FFFFFF',
+    color: 'inherit',
     textDecoration: 'none',
     lineHeight: '28px',
     fontSize: 20,
     fontWeight: 500,
+    '&:hover': { color: theme.palette.text.secondary },
   },
   linkActive: {
     color: theme.palette.primary[500],
@@ -64,9 +66,9 @@ const CustomLink = withStyles(theme => ({
   icon: {
     marginRight: 8,
   },
-}))(({ classes, icon, ...rest }) => (
+}))(({ classes, icon: Icon, ...rest }) => (
   <div className={classes.linkWrapper}>
-    {icon && React.createElement(icon, { className: classes.icon })}
+    {Icon && <Icon className={classes.icon} />}
     <NavLink
       className={classes.link}
       activeClassName={classes.linkActive}
@@ -134,4 +136,4 @@ function AppFooter() {
   );
 }
 
-export default React.memo(AppFooter);
+export default React.memo(withDarkTheme(AppFooter));

--- a/components/AppLayout/AppHeader.js
+++ b/components/AppLayout/AppHeader.js
@@ -2,7 +2,12 @@ import React, { useState } from 'react';
 import gql from 'graphql-tag';
 import { c, t } from 'ttag';
 
-import { makeStyles, withStyles, useTheme } from '@material-ui/core/styles';
+import {
+  makeStyles,
+  withStyles,
+  useTheme,
+  ThemeProvider,
+} from '@material-ui/core/styles';
 import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import Menu from '@material-ui/core/Menu';
@@ -18,6 +23,7 @@ import AccountCircleOutlinedIcon from '@material-ui/icons/AccountCircleOutlined'
 import ExitToAppRoundedIcon from '@material-ui/icons/ExitToAppRounded';
 import InfoIcon from '@material-ui/icons/Info';
 
+import { darkTheme } from 'lib/theme';
 import NavLink from 'components/NavLink';
 import GlobalSearch from './GlobalSearch';
 import * as Widgets from './Widgets';
@@ -94,7 +100,6 @@ const useStyles = makeStyles(theme => ({
   profileMenu: {
     marginTop: 50,
     backgroundColor: theme.palette.secondary.main,
-    color: theme.palette.common.white,
     overflow: 'inherit',
   },
   divider: {
@@ -237,43 +242,45 @@ function AppHeader({
           {user?.name ? (
             <>
               <Widgets.Avatar user={user} size={40} onClick={openProfileMenu} />
-              <Menu
-                id="profile-menu"
-                classes={{ paper: classes.profileMenu }}
-                anchorEl={anchor}
-                keepMounted
-                open={Boolean(anchor)}
-                onClose={closeProfileMenu}
-              >
-                <Widgets.Level user={user} />
-                <MenuItem onClick={closeProfileMenu}>
-                  <ListItemIcon>
-                    <Widgets.Avatar user={user} size={40} />
-                  </ListItemIcon>
-                  <Typography variant="inherit">{user?.name}</Typography>
-                </MenuItem>
-                <Divider classes={{ root: classes.divider }} />
-                <MenuItem onClick={closeProfileMenu}>
-                  <ListItemIcon className={classes.listIcon}>
-                    <AccountCircleOutlinedIcon />
-                  </ListItemIcon>
-                  <Typography variant="inherit">{t`My Profile`}</Typography>
-                </MenuItem>
-                <Divider classes={{ root: classes.divider }} />
-                <MenuItem onClick={closeProfileMenu}>
-                  <ListItemIcon className={classes.listIcon}>
-                    <InfoIcon />
-                  </ListItemIcon>
-                  <Typography variant="inherit">{t`About Cofacts`}</Typography>
-                </MenuItem>
-                <Divider classes={{ root: classes.divider }} />
-                <MenuItem onClick={onLogout}>
-                  <ListItemIcon className={classes.listIcon}>
-                    <ExitToAppRoundedIcon />
-                  </ListItemIcon>
-                  <Typography variant="inherit">{t`Logout`}</Typography>
-                </MenuItem>
-              </Menu>
+              <ThemeProvider theme={darkTheme}>
+                <Menu
+                  id="profile-menu"
+                  classes={{ paper: classes.profileMenu }}
+                  anchorEl={anchor}
+                  keepMounted
+                  open={Boolean(anchor)}
+                  onClose={closeProfileMenu}
+                >
+                  <Widgets.Level user={user} />
+                  <MenuItem onClick={closeProfileMenu}>
+                    <ListItemIcon>
+                      <Widgets.Avatar user={user} size={40} />
+                    </ListItemIcon>
+                    <Typography variant="inherit">{user?.name}</Typography>
+                  </MenuItem>
+                  <Divider classes={{ root: classes.divider }} />
+                  <MenuItem onClick={closeProfileMenu}>
+                    <ListItemIcon className={classes.listIcon}>
+                      <AccountCircleOutlinedIcon />
+                    </ListItemIcon>
+                    <Typography variant="inherit">{t`My Profile`}</Typography>
+                  </MenuItem>
+                  <Divider classes={{ root: classes.divider }} />
+                  <MenuItem onClick={closeProfileMenu}>
+                    <ListItemIcon className={classes.listIcon}>
+                      <InfoIcon />
+                    </ListItemIcon>
+                    <Typography variant="inherit">{t`About Cofacts`}</Typography>
+                  </MenuItem>
+                  <Divider classes={{ root: classes.divider }} />
+                  <MenuItem onClick={onLogout}>
+                    <ListItemIcon className={classes.listIcon}>
+                      <ExitToAppRoundedIcon />
+                    </ListItemIcon>
+                    <Typography variant="inherit">{t`Logout`}</Typography>
+                  </MenuItem>
+                </Menu>
+              </ThemeProvider>
             </>
           ) : (
             <Button

--- a/components/AppLayout/AppSidebar.js
+++ b/components/AppLayout/AppSidebar.js
@@ -1,12 +1,6 @@
 import React from 'react';
 import { t } from 'ttag';
 import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
-import {
-  EDITOR_FACEBOOK_GROUP,
-  PROJECT_HACKFOLDR,
-  CONTACT_EMAIL,
-  LINE_URL,
-} from 'constants/urls';
 import { makeStyles } from '@material-ui/core/styles';
 import {
   useMediaQuery,
@@ -18,15 +12,21 @@ import {
   ListItem,
 } from '@material-ui/core';
 import * as Widgets from './Widgets';
+import {
+  EDITOR_FACEBOOK_GROUP,
+  PROJECT_HACKFOLDR,
+  CONTACT_EMAIL,
+  LINE_URL,
+} from 'constants/urls';
 import NavLink from 'components/NavLink';
 import { NAVBAR_HEIGHT, TABS_HEIGHT } from 'constants/size';
+import { withDarkTheme } from 'lib/theme';
 import GoogleWebsiteTranslator from './GoogleWebsiteTranslator';
 
 const useStyles = makeStyles(theme => ({
   paper: {
     top: `${NAVBAR_HEIGHT + TABS_HEIGHT}px !important`,
-    background: theme.palette.secondary[600],
-    color: theme.palette.common.white,
+    background: theme.palette.background.default,
     overflow: 'inherit',
   },
   level: {
@@ -36,30 +36,29 @@ const useStyles = makeStyles(theme => ({
     marginLeft: 16,
   },
   login: {
-    color: theme.palette.common.white,
     margin: '24px auto',
-    border: `1px solid ${theme.palette.common.white}`,
     borderRadius: 70,
   },
   list: {
-    padding: 30,
+    padding: 0,
   },
   listItem: {
     justifyContent: 'center',
+    padding: '12px 42px',
+    textTransform: 'uppercase',
     '& a': {
-      color: theme.palette.common.white,
+      color: 'inherit',
       textDecoration: 'none',
     },
   },
   divider: {
-    backgroundColor: theme.palette.common.white,
-    margin: '0 30px',
+    backgroundColor: theme.palette.secondary[400],
+    margin: '12px 42px',
   },
 }));
 
 function AppSidebar({ open, toggle, user, onLoginModalOpen }) {
   const classes = useStyles();
-  const matches = useMediaQuery('(max-width:768px)');
 
   return (
     <SwipeableDrawer
@@ -103,9 +102,12 @@ function AppSidebar({ open, toggle, user, onLoginModalOpen }) {
         </div>
       ) : (
         <Button
+          variant="outlined"
           className={classes.login}
           onClick={onLoginModalOpen}
-        >{t`Login`}</Button>
+        >
+          {t`Login`}
+        </Button>
       )}
       <Divider classes={{ root: classes.divider }} />
       <List className={classes.list}>
@@ -130,11 +132,9 @@ function AppSidebar({ open, toggle, user, onLoginModalOpen }) {
             @cofacts
           </NavLink>
         </ListItem>
-        {matches && (
-          <ListItem classes={{ root: classes.listItem }}>
-            <GoogleWebsiteTranslator />
-          </ListItem>
-        )}
+        <ListItem classes={{ root: classes.listItem }}>
+          <GoogleWebsiteTranslator />
+        </ListItem>
       </List>
       {true && (
         <>
@@ -152,4 +152,4 @@ function AppSidebar({ open, toggle, user, onLoginModalOpen }) {
   );
 }
 
-export default React.memo(AppSidebar);
+export default React.memo(withDarkTheme(AppSidebar));

--- a/components/AppLayout/AppSidebar.js
+++ b/components/AppLayout/AppSidebar.js
@@ -3,7 +3,6 @@ import { t } from 'ttag';
 import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 import { makeStyles } from '@material-ui/core/styles';
 import {
-  useMediaQuery,
   Box,
   Button,
   Typography,

--- a/components/AppLayout/GoogleWebsiteTranslator.js
+++ b/components/AppLayout/GoogleWebsiteTranslator.js
@@ -1,16 +1,20 @@
 import React, { PureComponent } from 'react';
+import Button from '@material-ui/core/Button';
 
 class GoogleWebsiteTranslator extends PureComponent {
-  componentDidMount() {
-    window.googleTranslateElementInit = this.googleTranslateElementInit;
-    this.addGoogleTranslatorScript();
-  }
+  state = {
+    init: false,
+  };
 
-  addGoogleTranslatorScript = () => {
-    const newScript = document.createElement('script');
-    newScript.src =
-      '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
-    this.refContainer.appendChild(newScript);
+  handleScriptInsert = () => {
+    this.setState({ init: true }, () => {
+      window.googleTranslateElementInit = this.googleTranslateElementInit;
+
+      const newScript = document.createElement('script');
+      newScript.src =
+        '//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit';
+      this.refContainer.appendChild(newScript);
+    });
   };
 
   googleTranslateElementInit = () => {
@@ -26,6 +30,19 @@ class GoogleWebsiteTranslator extends PureComponent {
   };
 
   render() {
+    const { init } = this.state;
+    if (!init) {
+      return (
+        <Button
+          variant="outlined"
+          size="small"
+          onClick={this.handleScriptInsert}
+        >
+          Google Translate
+        </Button>
+      );
+    }
+
     return (
       <div ref={container => (this.refContainer = container)}>
         <div id="google_translate_element" />

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -1,8 +1,7 @@
-import { createMuiTheme } from '@material-ui/core/styles';
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles';
 import red from '@material-ui/core/colors/red';
 
-// Create a theme instance.
-const theme = createMuiTheme({
+const baseThemeOption = {
   palette: {
     primary: {
       main: '#ffb600',
@@ -44,6 +43,35 @@ const theme = createMuiTheme({
     fontFamily:
       '"Noto Sans TC", "Noto Sans CJK TC", "Source Han Sans", "思源黑體", sans-serif',
   },
+};
+
+// Create a theme instance.
+export const lightTheme = createMuiTheme(baseThemeOption);
+
+export const darkTheme = createMuiTheme({
+  ...baseThemeOption,
+  palette: {
+    ...baseThemeOption.palette,
+    type: 'dark',
+    background: {
+      default: '#2e2e2e',
+      paper: '#333',
+    },
+  },
 });
 
-export default theme;
+export function withDarkTheme(WrappedComponent) {
+  function Component(props) {
+    return (
+      <ThemeProvider theme={darkTheme}>
+        <WrappedComponent {...props} />
+      </ThemeProvider>
+    );
+  }
+
+  const componentName =
+    WrappedComponent.displayName || WrappedComponent.name || 'Component';
+  Component.displayName = `withDarkTheme(${componentName})`;
+
+  return Component;
+}

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,7 +2,7 @@ import App from 'next/app';
 import React from 'react';
 import { ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
-import theme from '../lib/theme';
+import { lightTheme } from '../lib/theme';
 
 // https://nextjs.org/docs/basic-features/built-in-css-support
 import '../components/app.css';
@@ -19,7 +19,7 @@ class MyApp extends App {
   render() {
     const { Component, pageProps } = this.props;
     return (
-      <ThemeProvider theme={theme}>
+      <ThemeProvider theme={lightTheme}>
         <CssBaseline />
         <Component {...pageProps} />
       </ThemeProvider>

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -3,7 +3,7 @@ import Document, { Head, Main, NextScript } from 'next/document';
 import getConfig from 'next/config';
 import { ServerStyleSheets } from '@material-ui/core/styles';
 import { AUTH_ERROR_MSG, NO_USER_FOR_ARTICLE } from 'constants/errors';
-import theme from 'lib/theme';
+import { lightTheme } from 'lib/theme';
 import agent from 'lib/stackimpact';
 import rollbar from 'lib/rollbar';
 
@@ -33,7 +33,7 @@ class MyDocument extends Document {
             content="minimum-scale=1, initial-scale=1, width=device-width, shrink-to-fit=no"
           />
           {/* PWA primary color */}
-          <meta name="theme-color" content={theme.palette.primary.main} />
+          <meta name="theme-color" content={lightTheme.palette.primary.main} />
           <link
             href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500&display=swap"
             rel="stylesheet"


### PR DESCRIPTION
Currently in iOS system, Google translate will show toolbar no matter user has interacted with Translate widget or not, which covers up screen, especially for create reply dialog.

![image](https://user-images.githubusercontent.com/108608/90317436-24773980-df5c-11ea-8f3a-a8e7f4440a91.png)

This PR:
- Initiates Google translate setup only after the user clicks "Google translate" button
- Fixes hover & ripple effect of button / list item by providing a [dark theme](https://material-ui.com/customization/palette/#dark-mode)
- Adjust sidebar style

![activate](https://user-images.githubusercontent.com/108608/90317600-3a392e80-df5d-11ea-8b3e-5ad3705ec848.gif)
- No translate toolbar at first; translate widget replaced with a "Google translate" button.
- As soon as the user clicks "Google translate" button, Google site translate loads and toolbar is added

The dark theme turns hover effect brighter (currently in production it darkens on hover, which is incorrect). The dark theme is required for `<Button variant="outlined">` to render in bright border and text.
![ripple](https://user-images.githubusercontent.com/108608/90317665-9dc35c00-df5d-11ea-9985-f6254baa1707.gif)
