### PR TITLE
Make production build works by opt-out static build for search pages

### DIFF
--- a/pages/search.js
+++ b/pages/search.js
@@ -179,4 +179,10 @@ function SearchPage() {
   );
 }
 
-export default withApollo()(SearchPage);
+export default withApollo({
+  /**
+   * Although this page is mostly not server-rendered, we need this so that publicRuntimeConfig works.
+   * @see https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration
+   * */
+  ssr: true,
+})(SearchPage);


### PR DESCRIPTION
Currently staging build fail because `/search` page is using a runtime config.

![image](https://user-images.githubusercontent.com/108608/90665713-06bd1380-e27f-11ea-830c-80df5f9e118b.png)

According to [next.js doc](https://nextjs.org/docs/api-reference/next.config.js/runtime-configuration):
> A page that relies on publicRuntimeConfig must use getInitialProps to opt-out of Automatic Static Optimization. Runtime configuration won't be available to any page (or component in a page) without getInitialProps.

We should pass `{ssr: true}` to `withApollo` so that next-apollo attaches [`getInitialProps`](https://github.com/adamsoffer/next-apollo/blob/master/src/withApollo.js#L108) to search page and thus opt-out Automatic Static Optimization for `/search` page.

## Result

![image](https://user-images.githubusercontent.com/108608/90662601-25b9a680-e27b-11ea-94c3-4fe8f5f03bfb.png)
