### PR TITLE
Reasons dialog in <ArticleReplyFeedbacks> component

### DIFF
--- a/components/AppLayout/Widgets/Avatar.js
+++ b/components/AppLayout/Widgets/Avatar.js
@@ -5,6 +5,9 @@ import { makeStyles, withStyles } from '@material-ui/core/styles';
 import { Badge } from '@material-ui/core';
 import { TYPE_ICON } from 'constants/replyType';
 
+const NULL_USER_IMG =
+  'https://www.gravatar.com/avatar/00000000000000000000000000000000?d=mp';
+
 const useStyles = makeStyles({
   root: {
     width: size => size,
@@ -78,7 +81,7 @@ function Avatar({
   let avatar = (
     <img
       className={cx(classes.root, className)}
-      src={user?.avatarUrl}
+      src={user ? user.avatarUrl : NULL_USER_IMG}
       alt=""
       {...rest}
     />

--- a/components/ArticleReply/index.js
+++ b/components/ArticleReply/index.js
@@ -144,7 +144,6 @@ const ArticleReply = React.memo(
           {showFeedback && (
             <ArticleReplyFeedbackControl
               articleReply={articleReply}
-              reply={reply}
               className={classes.feedbacks}
             />
           )}

--- a/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.js
+++ b/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { t } from 'ttag';
 import gql from 'graphql-tag';
 import { useMutation } from '@apollo/react-hooks';
@@ -118,6 +118,7 @@ function ArticleReplyFeedbackControl({ articleReply, className }) {
   const [reason, setReason] = useState('');
   const [reasonsPopoverAnchorEl, setReasonsPopoverAnchorEl] = useState(null);
   const [votePopoverAnchorEl, setVotePopoverAnchorEl] = useState(null);
+  const reasonsPopoverRef = useRef();
 
   const [showReorderSnack, setReorderSnackShow] = useState(false);
   const [createReplyFeedback, { loading: updatingReplyFeedback }] = useMutation(
@@ -151,6 +152,12 @@ function ArticleReplyFeedbackControl({ articleReply, className }) {
     setVote(null);
   };
 
+  const handleReasonReposition = useCallback(() => {
+    if (reasonsPopoverRef.current) {
+      reasonsPopoverRef.current.updatePosition();
+    }
+  }, []);
+
   return (
     <div className={cx(classes.root, className)}>
       <ButtonGroupDisplay
@@ -162,6 +169,7 @@ function ArticleReplyFeedbackControl({ articleReply, className }) {
       <Popover
         open={!!reasonsPopoverAnchorEl}
         anchorEl={reasonsPopoverAnchorEl}
+        action={reasonsPopoverRef}
         onClose={closeReasonsPopover}
         anchorOrigin={{
           vertical: 'top',
@@ -177,7 +185,10 @@ function ArticleReplyFeedbackControl({ articleReply, className }) {
           <CloseIcon />
         </button>
         {!!reasonsPopoverAnchorEl && (
-          <ReasonsDisplay articleReply={articleReply} />
+          <ReasonsDisplay
+            articleReply={articleReply}
+            onSizeChange={handleReasonReposition}
+          />
         )}
       </Popover>
       <Popover

--- a/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.js
+++ b/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.js
@@ -2,12 +2,11 @@ import React, { useState } from 'react';
 import { t } from 'ttag';
 import gql from 'graphql-tag';
 import { useMutation } from '@apollo/react-hooks';
-import { makeStyles, withStyles } from '@material-ui/core/styles';
-import { Tabs, Tab, Box, Popover, Typography } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { Popover, Typography } from '@material-ui/core';
 import Snackbar from '@material-ui/core/Snackbar';
 import CloseIcon from '@material-ui/icons/Close';
-import Avatar from 'components/AppLayout/Widgets/Avatar';
-import { ThumbUpIcon, ThumbDownIcon } from 'components/icons';
+import ReasonsDisplay from './ReasonsDisplay';
 import ButtonGroupDisplay from './ButtonGroupDisplay';
 import cx from 'clsx';
 
@@ -30,11 +29,6 @@ const useStyles = makeStyles(theme => ({
     border: 'none',
     outline: 'none',
     color: theme.palette.secondary[100],
-  },
-  feedbacks: {
-    marginTop: 16,
-    maxHeight: 300,
-    overflow: 'auto',
   },
   popupTitle: {
     fontSize: 18,
@@ -67,41 +61,6 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-const CustomTab = withStyles({
-  root: {
-    position: 'relative',
-    minHeight: 0,
-  },
-  wrapper: {
-    '& > svg': {
-      position: 'absolute',
-      left: 0,
-    },
-  },
-})(Tab);
-
-const Feedback = withStyles(theme => ({
-  root: {
-    marginTop: 16,
-    display: 'flex',
-    borderBottom: `1px solid ${theme.palette.secondary[100]}`,
-    alignItems: ({ comment }) => (comment ? 'flex-start' : 'center'),
-    paddingBottom: 10,
-  },
-  name: {
-    color: ({ comment }) =>
-      comment ? theme.palette.primary[500] : theme.palette.secondary[300],
-  },
-}))(({ comment, user, classes }) => (
-  <div className={classes.root}>
-    <Avatar user={user} size={48} />
-    <Box px={2}>
-      <div className={classes.name}>{user.name}</div>
-      <div>{comment}</div>
-    </Box>
-  </div>
-));
-
 // Subset of fields that needs to be updated after login
 //
 const ArticleReplyFeedbackControlDataForUser = gql`
@@ -116,25 +75,15 @@ const ArticleReplyFeedbackControlDataForUser = gql`
 
 const ArticleReplyFeedbackControlData = gql`
   fragment ArticleReplyFeedbackControlData on ArticleReply {
-    positiveFeedbackCount
-    negativeFeedbackCount
-    ownVote
-    feedbacks {
-      id
-      comment
-      vote
-      user {
-        id
-        name
-        ...AvatarData
-      }
-    }
+    articleId
+    replyId
     ...ArticleReplyFeedbackControlDataForUser
     ...ButtonGroupDisplayArticleReply
+    ...ReasonsDisplayData
   }
   ${ArticleReplyFeedbackControlDataForUser}
   ${ButtonGroupDisplay.fragments.ButtonGroupDisplayArticleReply}
-  ${Avatar.fragments.AvatarData}
+  ${ReasonsDisplay.fragments.ReasonsDisplayData}
 `;
 
 export const CREATE_REPLY_FEEDBACK = gql`
@@ -163,13 +112,13 @@ export const CREATE_REPLY_FEEDBACK = gql`
  *   Isolated because not all use case have reply nested under articleReply.
  * @param {string?} props.className
  */
-function ArticleReplyFeedbackControl({ articleReply, reply = {}, className }) {
+function ArticleReplyFeedbackControl({ articleReply, className }) {
   const classes = useStyles();
   const [vote, setVote] = useState(null);
   const [reason, setReason] = useState('');
   const [reasonsPopoverAnchorEl, setReasonsPopoverAnchorEl] = useState(null);
   const [votePopoverAnchorEl, setVotePopoverAnchorEl] = useState(null);
-  const [tab, setTab] = useState(0);
+
   const [showReorderSnack, setReorderSnackShow] = useState(false);
   const [createReplyFeedback, { loading: updatingReplyFeedback }] = useMutation(
     CREATE_REPLY_FEEDBACK,
@@ -211,7 +160,6 @@ function ArticleReplyFeedbackControl({ articleReply, reply = {}, className }) {
         onReasonClick={openReasonsPopover}
       />
       <Popover
-        id={`reply-reasons-${reply.id}`}
         open={!!reasonsPopoverAnchorEl}
         anchorEl={reasonsPopoverAnchorEl}
         onClose={closeReasonsPopover}
@@ -228,46 +176,11 @@ function ArticleReplyFeedbackControl({ articleReply, reply = {}, className }) {
         >
           <CloseIcon />
         </button>
-        {reply.text}
-        <Tabs
-          value={tab}
-          onChange={(e, value) => setTab(value)}
-          indicatorColor="primary"
-          textColor="primary"
-          variant="fullWidth"
-        >
-          <CustomTab
-            icon={<ThumbUpIcon />}
-            label={t`Helpful ${articleReply.positiveFeedbackCount}`}
-          />
-          <CustomTab
-            icon={<ThumbDownIcon />}
-            label={t`Not Helpful ${articleReply.negativeFeedbackCount}`}
-          />
-        </Tabs>
-        <Box
-          display={tab === 0 ? 'block' : 'none'}
-          className={classes.feedbacks}
-        >
-          {articleReply.feedbacks
-            .filter(({ vote, user }) => vote === 'UPVOTE' && user)
-            .map(feedback => (
-              <Feedback key={feedback.id} {...feedback} />
-            ))}
-        </Box>
-        <Box
-          display={tab === 1 ? 'block' : 'none'}
-          className={classes.feedbacks}
-        >
-          {articleReply.feedbacks
-            .filter(({ vote, user }) => vote === 'DOWNVOTE' && user)
-            .map(feedback => (
-              <Feedback key={feedback.id} {...feedback} />
-            ))}
-        </Box>
+        {!!reasonsPopoverAnchorEl && (
+          <ReasonsDisplay articleReply={articleReply} />
+        )}
       </Popover>
       <Popover
-        id={`feedback-reasons-${reply.id}`}
         open={!!votePopoverAnchorEl}
         anchorEl={votePopoverAnchorEl}
         onClose={closeVotePopover}
@@ -325,12 +238,6 @@ function ArticleReplyFeedbackControl({ articleReply, reply = {}, className }) {
 ArticleReplyFeedbackControl.fragments = {
   ArticleReplyFeedbackControlData,
   ArticleReplyFeedbackControlDataForUser,
-  ArticleReplyFeedbackControlReply: gql`
-    fragment ArticleReplyFeedbackControlReply on Reply {
-      id
-      text
-    }
-  `,
 };
 
 export default ArticleReplyFeedbackControl;

--- a/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.stories.js
+++ b/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.stories.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { MockedProvider } from '@apollo/react-testing';
 import ArticleReplyFeedbackControl from './';
 import { CREATE_REPLY_FEEDBACK } from './ArticleReplyFeedbackControl';
+import { LOAD_FEEDBACKS } from './ReasonsDisplay';
 import { USER_QUERY } from 'lib/useCurrentUser';
 
 // Mocked objects
@@ -13,25 +14,21 @@ const mockArticleReply = {
   positiveFeedbackCount: 1,
   negativeFeedbackCount: 1,
   ownVote: null,
-  feedbacks: [
-    { id: 'feedback1', comment: 'test comment', vote: 'UPVOTE', user: null },
-    {
-      id: 'feedback1',
-      comment: 'test comment',
-      vote: 'DOWNVOTE',
-      user: {
-        id: 'webUser1',
-        name: 'Web User',
-        avatarUrl: 'https://placekitten.com/100/100',
-      },
-    },
-  ],
 };
 
-// const mockReply = {
-//   id: mockArticleReply.replyId,
-//   text: 'Text reply text',
-// };
+const mockArticleReplyFeedbacks = [
+  { id: 'feedback1', comment: 'test comment', vote: 'UPVOTE', user: null },
+  {
+    id: 'feedback1',
+    comment: 'test comment',
+    vote: 'DOWNVOTE',
+    user: {
+      id: 'webUser1',
+      name: 'Web User',
+      avatarUrl: 'https://placekitten.com/100/100',
+    },
+  },
+];
 
 // MockedProvider mocks
 //
@@ -51,6 +48,7 @@ const mocks = [
       data: {
         CreateOrUpdateArticleReplyFeedback: {
           ...mockArticleReply,
+          feedbacks: mockArticleReplyFeedbacks,
           positiveFeedbackCount: mockArticleReply.positiveFeedbackCount + 1,
         },
       },
@@ -71,7 +69,31 @@ const mocks = [
       data: {
         CreateOrUpdateArticleReplyFeedback: {
           ...mockArticleReply,
+          feedbacks: mockArticleReplyFeedbacks,
           negativeFeedbackCount: mockArticleReply.negativeFeedbackCount + 1,
+        },
+      },
+    },
+  },
+  // Load reply mock
+  {
+    request: {
+      query: LOAD_FEEDBACKS,
+      variables: {
+        articleId: mockArticleReply.articleId,
+        replyId: mockArticleReply.replyId,
+      },
+    },
+    result: {
+      data: {
+        ListArticleReplyFeedbacks: {
+          edges: mockArticleReplyFeedbacks.map(feedback => ({
+            node: feedback,
+          })),
+        },
+        GetReply: {
+          id: mockArticleReply.replyId,
+          text: 'Text reply text',
         },
       },
     },

--- a/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.stories.js
+++ b/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.stories.js
@@ -25,6 +25,7 @@ const mockArticleReplyFeedbacks = [
     user: {
       id: 'webUser1',
       name: 'Web User',
+      level: 12,
       avatarUrl: 'https://placekitten.com/100/100',
     },
   },
@@ -106,7 +107,11 @@ const otherUserMock = {
   request: { query: USER_QUERY },
   result: {
     data: {
-      GetUser: { id: 'other user' },
+      GetUser: {
+        id: 'other user',
+        name: 'Other User',
+        avatarUrl: 'https://placekitten.com/84/84',
+      },
     },
   },
 };
@@ -133,7 +138,7 @@ export default {
 };
 
 export const WithArticleReplyAndReplySet = () => (
-  <MockedProvider mocks={[...mocks, otherUserMock]}>
+  <MockedProvider mocks={[...mocks, otherUserMock]} addTypename={false}>
     <>
       <p>Not voted yet</p>
       <ArticleReplyFeedbackControl articleReply={mockArticleReply} />

--- a/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.stories.js
+++ b/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.stories.js
@@ -28,10 +28,10 @@ const mockArticleReply = {
   ],
 };
 
-const mockReply = {
-  id: mockArticleReply.replyId,
-  text: 'Text reply text',
-};
+// const mockReply = {
+//   id: mockArticleReply.replyId,
+//   text: 'Text reply text',
+// };
 
 // MockedProvider mocks
 //
@@ -114,14 +114,10 @@ export const WithArticleReplyAndReplySet = () => (
   <MockedProvider mocks={[...mocks, otherUserMock]}>
     <>
       <p>Not voted yet</p>
-      <ArticleReplyFeedbackControl
-        articleReply={mockArticleReply}
-        reply={mockReply}
-      />
+      <ArticleReplyFeedbackControl articleReply={mockArticleReply} />
       <p>Upvoted</p>
       <ArticleReplyFeedbackControl
         articleReply={{ ...mockArticleReply, ownVote: 'UPVOTE' }}
-        reply={mockReply}
       />
     </>
   </MockedProvider>

--- a/components/ArticleReplyFeedbackControl/Feedback.js
+++ b/components/ArticleReplyFeedbackControl/Feedback.js
@@ -34,7 +34,7 @@ function Feedback({ feedback }) {
 
 Feedback.fragments = {
   ReasonDisplayFeedbackData: gql`
-    fragment ReasonDisplayFeedbackData on Feedback {
+    fragment ReasonDisplayFeedbackData on ArticleReplyFeedback {
       id
       user {
         name

--- a/components/ArticleReplyFeedbackControl/Feedback.js
+++ b/components/ArticleReplyFeedbackControl/Feedback.js
@@ -1,6 +1,6 @@
 import { makeStyles } from '@material-ui/core/styles';
 import { Box } from '@material-ui/core';
-import { gql } from '@apollo/client';
+import gql from 'graphql-tag';
 import Avatar from 'components/AppLayout/Widgets/Avatar';
 
 const useStyles = makeStyles(theme => ({

--- a/components/ArticleReplyFeedbackControl/Feedback.js
+++ b/components/ArticleReplyFeedbackControl/Feedback.js
@@ -20,12 +20,11 @@ const useStyles = makeStyles(theme => ({
 function Feedback({ feedback }) {
   const classes = useStyles();
 
-  if (!feedback.user) return null;
   return (
     <div className={classes.root}>
       <Avatar user={feedback.user} size={48} />
       <Box px={2}>
-        <div className={classes.name}>{feedback.user.name}</div>
+        <div className={classes.name}>{feedback.user?.name}</div>
         <div>{feedback.comment}</div>
       </Box>
     </div>

--- a/components/ArticleReplyFeedbackControl/Feedback.js
+++ b/components/ArticleReplyFeedbackControl/Feedback.js
@@ -1,0 +1,49 @@
+import { makeStyles } from '@material-ui/core/styles';
+import { Box } from '@material-ui/core';
+import { gql } from '@apollo/client';
+import Avatar from 'components/AppLayout/Widgets/Avatar';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    marginTop: 16,
+    display: 'flex',
+    borderBottom: `1px solid ${theme.palette.secondary[100]}`,
+    alignItems: ({ comment }) => (comment ? 'flex-start' : 'center'),
+    paddingBottom: 10,
+  },
+  name: {
+    color: ({ comment }) =>
+      comment ? theme.palette.primary[500] : theme.palette.secondary[300],
+  },
+}));
+
+function Feedback({ feedback }) {
+  const classes = useStyles();
+
+  if (!feedback.user) return null;
+  return (
+    <div className={classes.root}>
+      <Avatar user={feedback.user} size={48} />
+      <Box px={2}>
+        <div className={classes.name}>{feedback.user.name}</div>
+        <div>{feedback.comment}</div>
+      </Box>
+    </div>
+  );
+}
+
+Feedback.fragments = {
+  ReasonDisplayFeedbackData: gql`
+    fragment ReasonDisplayFeedbackData on Feedback {
+      id
+      user {
+        name
+        ...AvatarData
+      }
+      comment
+    }
+    ${Avatar.fragments.AvatarData}
+  `,
+};
+
+export default Feedback;

--- a/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
+++ b/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
@@ -31,9 +31,6 @@ const ReasonsDisplayData = gql`
   fragment ReasonsDisplayData on ArticleReply {
     articleId
     replyId
-    reply {
-      text
-    }
     positiveFeedbackCount
     negativeFeedbackCount
   }
@@ -56,6 +53,10 @@ const LOAD_FEEDBACKS = gql`
         }
       }
     }
+    GetReply(id: $replyId) {
+      id
+      text
+    }
   }
   ${Feedback.fragments.ReasonDisplayFeedbackData}
 `;
@@ -74,9 +75,17 @@ function ReasonsDisplay({ articleReply }) {
   const feedbacks =
     data?.ListArticleReplyFeedbacks.edges.map(({ node }) => node) || [];
 
+  if (loading) {
+    return (
+      <Box textAlign="center">
+        <CircularProgress />
+      </Box>
+    );
+  }
+
   return (
     <>
-      {articleReply.reply.text}
+      {data?.GetReply.text}
       <Tabs
         value={tab}
         onChange={(e, value) => setTab(value)}
@@ -93,32 +102,20 @@ function ReasonsDisplay({ articleReply }) {
           label={t`Not Helpful ${articleReply.negativeFeedbackCount}`}
         />
       </Tabs>
-      {loading ? (
-        <CircularProgress />
-      ) : (
-        <>
-          <Box
-            display={tab === 0 ? 'block' : 'none'}
-            className={classes.feedbacks}
-          >
-            {feedbacks
-              .filter(({ vote, user }) => vote === 'UPVOTE' && user)
-              .map(feedback => (
-                <Feedback key={feedback.id} feedback={feedback} />
-              ))}
-          </Box>
-          <Box
-            display={tab === 1 ? 'block' : 'none'}
-            className={classes.feedbacks}
-          >
-            {feedbacks
-              .filter(({ vote, user }) => vote === 'DOWNVOTE' && user)
-              .map(feedback => (
-                <Feedback key={feedback.id} feedback={feedback} />
-              ))}
-          </Box>
-        </>
-      )}
+      <Box display={tab === 0 ? 'block' : 'none'} className={classes.feedbacks}>
+        {feedbacks
+          .filter(({ vote, user }) => vote === 'UPVOTE' && user)
+          .map(feedback => (
+            <Feedback key={feedback.id} feedback={feedback} />
+          ))}
+      </Box>
+      <Box display={tab === 1 ? 'block' : 'none'} className={classes.feedbacks}>
+        {feedbacks
+          .filter(({ vote, user }) => vote === 'DOWNVOTE' && user)
+          .map(feedback => (
+            <Feedback key={feedback.id} feedback={feedback} />
+          ))}
+      </Box>
     </>
   );
 }

--- a/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
+++ b/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
@@ -117,14 +117,14 @@ function ReasonsDisplay({ articleReply, onSizeChange = () => {} }) {
       </Tabs>
       <Box display={tab === 0 ? 'block' : 'none'} className={classes.feedbacks}>
         {feedbacks
-          .filter(({ vote, user }) => vote === 'UPVOTE' && user)
+          .filter(({ vote }) => vote === 'UPVOTE')
           .map(feedback => (
             <Feedback key={feedback.id} feedback={feedback} />
           ))}
       </Box>
       <Box display={tab === 1 ? 'block' : 'none'} className={classes.feedbacks}>
         {feedbacks
-          .filter(({ vote, user }) => vote === 'DOWNVOTE' && user)
+          .filter(({ vote }) => vote === 'DOWNVOTE')
           .map(feedback => (
             <Feedback key={feedback.id} feedback={feedback} />
           ))}

--- a/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
+++ b/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { t } from 'ttag';
-import { useQuery, gql } from '@apollo/client';
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
 import { withStyles, makeStyles } from '@material-ui/core/styles';
 import { Box, Tab, Tabs, CircularProgress } from '@material-ui/core';
 import { ThumbUpIcon, ThumbDownIcon } from 'components/icons';

--- a/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
+++ b/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
@@ -86,7 +86,7 @@ function ReasonsDisplay({ articleReply, onSizeChange = () => {} }) {
   }, [tab, onSizeChange]);
 
   const feedbacks =
-    data?.ListArticleReplyFeedbacks.edges.map(({ node }) => node) || [];
+    data?.ListArticleReplyFeedbacks?.edges.map(({ node }) => node) || [];
 
   if (loading) {
     return (
@@ -98,7 +98,7 @@ function ReasonsDisplay({ articleReply, onSizeChange = () => {} }) {
 
   return (
     <>
-      {data?.GetReply.text}
+      {data?.GetReply?.text}
       <Tabs
         value={tab}
         onChange={(e, value) => setTab(value)}

--- a/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
+++ b/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
@@ -36,7 +36,7 @@ const ReasonsDisplayData = gql`
   }
 `;
 
-const LOAD_FEEDBACKS = gql`
+export const LOAD_FEEDBACKS = gql`
   query LoadFeadbacksForArticleReply($articleId: String!, $replyId: String!) {
     ListArticleReplyFeedbacks(
       filter: { articleId: $articleId, replyId: $replyId }

--- a/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
+++ b/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
@@ -1,6 +1,130 @@
-function ReasonsDisplay() {
-  // TODO: Move data loading & display logic of other's reasons here
-  return null;
+import React, { useState } from 'react';
+import { t } from 'ttag';
+import { useQuery, gql } from '@apollo/client';
+import { withStyles, makeStyles } from '@material-ui/core/styles';
+import { Box, Tab, Tabs, CircularProgress } from '@material-ui/core';
+import { ThumbUpIcon, ThumbDownIcon } from 'components/icons';
+import Feedback from './Feedback';
+
+const useStyles = makeStyles(() => ({
+  feedbacks: {
+    marginTop: 16,
+    maxHeight: 300,
+    overflow: 'auto',
+  },
+}));
+
+const CustomTab = withStyles({
+  root: {
+    position: 'relative',
+    minHeight: 0,
+  },
+  wrapper: {
+    '& > svg': {
+      position: 'absolute',
+      left: 0,
+    },
+  },
+})(Tab);
+
+const ReasonsDisplayData = gql`
+  fragment ReasonsDisplayData on ArticleReply {
+    articleId
+    replyId
+    reply {
+      text
+    }
+    positiveFeedbackCount
+    negativeFeedbackCount
+  }
+`;
+
+const LOAD_FEEDBACKS = gql`
+  query LoadFeadbacksForArticleReply($articleId: String!, $replyId: String!) {
+    ListArticleReplyFeedbacks(
+      filter: { articleId: $articleId, replyId: $replyId }
+      first: 100
+    ) {
+      edges {
+        node {
+          id
+          vote
+          user {
+            id
+          }
+          ...ReasonDisplayFeedbackData
+        }
+      }
+    }
+  }
+  ${Feedback.fragments.ReasonDisplayFeedbackData}
+`;
+
+function ReasonsDisplay({ articleReply }) {
+  const classes = useStyles();
+  const [tab, setTab] = useState(0);
+  const { data, loading } = useQuery(LOAD_FEEDBACKS, {
+    variables: {
+      articleId: articleReply.articleId,
+      replyId: articleReply.replyId,
+    },
+    ssr: false,
+  });
+
+  const feedbacks =
+    data?.ListArticleReplyFeedbacks.edges.map(({ node }) => node) || [];
+
+  return (
+    <>
+      {articleReply.reply.text}
+      <Tabs
+        value={tab}
+        onChange={(e, value) => setTab(value)}
+        indicatorColor="primary"
+        textColor="primary"
+        variant="fullWidth"
+      >
+        <CustomTab
+          icon={<ThumbUpIcon />}
+          label={t`Helpful ${articleReply.positiveFeedbackCount}`}
+        />
+        <CustomTab
+          icon={<ThumbDownIcon />}
+          label={t`Not Helpful ${articleReply.negativeFeedbackCount}`}
+        />
+      </Tabs>
+      {loading ? (
+        <CircularProgress />
+      ) : (
+        <>
+          <Box
+            display={tab === 0 ? 'block' : 'none'}
+            className={classes.feedbacks}
+          >
+            {feedbacks
+              .filter(({ vote, user }) => vote === 'UPVOTE' && user)
+              .map(feedback => (
+                <Feedback key={feedback.id} feedback={feedback} />
+              ))}
+          </Box>
+          <Box
+            display={tab === 1 ? 'block' : 'none'}
+            className={classes.feedbacks}
+          >
+            {feedbacks
+              .filter(({ vote, user }) => vote === 'DOWNVOTE' && user)
+              .map(feedback => (
+                <Feedback key={feedback.id} feedback={feedback} />
+              ))}
+          </Box>
+        </>
+      )}
+    </>
+  );
 }
+
+ReasonsDisplay.fragments = {
+  ReasonsDisplayData,
+};
 
 export default ReasonsDisplay;

--- a/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
+++ b/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { t } from 'ttag';
 import { useQuery, gql } from '@apollo/client';
 import { withStyles, makeStyles } from '@material-ui/core/styles';
@@ -61,7 +61,7 @@ const LOAD_FEEDBACKS = gql`
   ${Feedback.fragments.ReasonDisplayFeedbackData}
 `;
 
-function ReasonsDisplay({ articleReply }) {
+function ReasonsDisplay({ articleReply, onSizeChange = () => {} }) {
   const classes = useStyles();
   const [tab, setTab] = useState(0);
   const { data, loading } = useQuery(LOAD_FEEDBACKS, {
@@ -71,6 +71,18 @@ function ReasonsDisplay({ articleReply }) {
     },
     ssr: false,
   });
+
+  // Invoking onSizeChange on load and tab switch
+  //
+  useEffect(() => {
+    if (!loading && onSizeChange) {
+      return onSizeChange();
+    }
+  }, [loading, onSizeChange]);
+
+  useEffect(() => {
+    if (onSizeChange) return onSizeChange();
+  }, [tab, onSizeChange]);
 
   const feedbacks =
     data?.ListArticleReplyFeedbacks.edges.map(({ node }) => node) || [];

--- a/components/ArticleReplyFeedbackControl/__snapshots__/ArticleReplyFeedbackControl.stories.storyshot
+++ b/components/ArticleReplyFeedbackControl/__snapshots__/ArticleReplyFeedbackControl.stories.storyshot
@@ -5,24 +5,6 @@ exports[`Storyshots ArticleReplyFeedbackControl With Article Reply And Reply Set
   articleReply={
     Object {
       "articleId": "article1",
-      "feedbacks": Array [
-        Object {
-          "comment": "test comment",
-          "id": "feedback1",
-          "user": null,
-          "vote": "UPVOTE",
-        },
-        Object {
-          "comment": "test comment",
-          "id": "feedback1",
-          "user": Object {
-            "avatarUrl": "https://placekitten.com/100/100",
-            "id": "webUser1",
-            "name": "Web User",
-          },
-          "vote": "DOWNVOTE",
-        },
-      ],
       "negativeFeedbackCount": 1,
       "ownVote": "UPVOTE",
       "positiveFeedbackCount": 1,
@@ -30,12 +12,6 @@ exports[`Storyshots ArticleReplyFeedbackControl With Article Reply And Reply Set
       "user": Object {
         "id": "authorId",
       },
-    }
-  }
-  reply={
-    Object {
-      "id": "reply1",
-      "text": "Text reply text",
     }
   }
 >
@@ -46,24 +22,6 @@ exports[`Storyshots ArticleReplyFeedbackControl With Article Reply And Reply Set
       articleReply={
         Object {
           "articleId": "article1",
-          "feedbacks": Array [
-            Object {
-              "comment": "test comment",
-              "id": "feedback1",
-              "user": null,
-              "vote": "UPVOTE",
-            },
-            Object {
-              "comment": "test comment",
-              "id": "feedback1",
-              "user": Object {
-                "avatarUrl": "https://placekitten.com/100/100",
-                "id": "webUser1",
-                "name": "Web User",
-              },
-              "vote": "DOWNVOTE",
-            },
-          ],
           "negativeFeedbackCount": 1,
           "ownVote": "UPVOTE",
           "positiveFeedbackCount": 1,

--- a/components/ListPageDisplays/ReplyItem.js
+++ b/components/ListPageDisplays/ReplyItem.js
@@ -96,10 +96,7 @@ function ReplyItem({ articleReply, reply, query }) {
           {highlight(text, { query, highlightClassName: classes.highlight })}
         </ExpandableText>
         <div className={classes.status}>
-          <ArticleReplyFeedbackControl
-            articleReply={articleReply}
-            reply={reply}
-          />
+          <ArticleReplyFeedbackControl articleReply={articleReply} />
           <Box display={['none', 'none', 'block']}>
             <ReplyInfo
               reply={reply}
@@ -121,10 +118,8 @@ ReplyItem.fragments = {
       text
       type
       ...ReplyInfo
-      ...ArticleReplyFeedbackControlReply
     }
     ${ReplyInfo.fragments.replyInfo}
-    ${ArticleReplyFeedbackControl.fragments.ArticleReplyFeedbackControlReply}
   `,
   ReplyItemArticleReplyData: gql`
     fragment ReplyItemArticleReplyData on ArticleReply {

--- a/components/__snapshots__/ExpandableText.stories.storyshot
+++ b/components/__snapshots__/ExpandableText.stories.storyshot
@@ -100,7 +100,7 @@ exports[`Storyshots ExpandableText With Word Count Given 1`] = `
       <Component
         classes={
           Object {
-            "root": "Component-root-98",
+            "root": "Component-root-97",
           }
         }
         expanded={false}


### PR DESCRIPTION
![reasons-dialog](https://user-images.githubusercontent.com/108608/92262954-746b6f80-ef0e-11ea-869b-bf34db1b21a6.gif)

- extract reasons dialog to individual component
- load reply & feedbacks only when reasons dialog is open
    - this reduces `ArticleReplyFeedbackControlData` fragment a lot, make `ArticleReplyFeedbackControl` a lot lighter on initial page load
    - loads 100 feedbacks from new API `ListArticleReplyFeedbacks` that fetches articlereplyfeedbacks directly
    - still show feedback for null users (usually from LINE; fixes #291 )
- removes `reply` prop from `ArticleReplyFeedbackControl`
    - So the component props are simpler
    - Loads reply text only when reasons dialog is open