### PR TITLE
Remove weird replyRequestCount setup

### DIFF
--- a/components/ArticlePageLayout.js
+++ b/components/ArticlePageLayout.js
@@ -137,8 +137,6 @@ function urlQuery2Filter({
     return undefined;
   }
 
-  filterObj.replyRequestCount = { GTE: replyRequestCount };
-
   return filterObj;
 }
 

--- a/components/ArticlePageLayout.js
+++ b/components/ArticlePageLayout.js
@@ -20,7 +20,6 @@ import TimeRange from 'components/ListPageControls/TimeRange';
 import SortInput from 'components/ListPageControls/SortInput';
 import LoadMore from 'components/ListPageControls/LoadMore';
 
-const DEFAULT_REPLY_REQUEST_COUNT = 1;
 const MAX_KEYWORD_LENGTH = 100;
 
 const LIST_ARTICLES = gql`
@@ -75,7 +74,6 @@ function urlQuery2Filter({
   categoryIds,
   start,
   end,
-  replyRequestCount = DEFAULT_REPLY_REQUEST_COUNT,
   searchUserByArticleId,
   types,
   timeRangeKey,


### PR DESCRIPTION
Removes weird `replyRequestCount` setup because it is causing errors if an user is visiting Cofacts with legacy URL (with `replyRequestCount` in its URL, such as `https://cofacts.org/articles?q=ooo&replyRequestCount=1`)

Also, it does not make sense to set `filterObj` without any condition. The line overrides the `replyRequestCount` filter set by `FILTERS.ASKED_MANY_TIMES`, thus it must be removed for `ASKED_MANY_TIMES` to work properly.