### PR TITLE
Track rss, and add utm_source to each url that generated from feed.js

### DIFF
--- a/components/Subscribe/FeedDisplay.js
+++ b/components/Subscribe/FeedDisplay.js
@@ -120,7 +120,7 @@ function FeedDisplay({ listQueryVars }) {
           </ListItemLink>
           <ListItemLink
             href={`https://feedly.com/i/discover/sources/search/feed/${encodeURIComponent(
-              feedUrl + `&source=feedly`
+              feedUrl + `&source=Feedly`
             )}`}
             icon={feedlyIcon}
             onClick={handleClose}
@@ -130,7 +130,9 @@ function FeedDisplay({ listQueryVars }) {
 
           <ListItemCopy
             icon={rssIcon}
-            textToCopy={encodeURIComponent(feedUrl + `&source=others`)}
+            textToCopy={
+              feedUrl + `&source=others&utm_source=Others&utm_medium=Subcribe`
+            }
             onSuccess={() => copySuccess(t`Copied to clipboard!`)}
           >
             {t`Get RSS Feed Link`}
@@ -148,7 +150,7 @@ function FeedDisplay({ listQueryVars }) {
             <IFTTTItem
               icon={lineIcon}
               IFTTTAppletUrl={PUBLIC_LINE_IFTTT_APPLET_URL}
-              feedUrl={encodeURIComponent(feedUrl + `&source=IFTTT_Line`)}
+              feedUrl={feedUrl + `&source=IFTTT_Line`}
               tutorialYoutubeId={PUBLIC_LINE_IFTTT_TUTORIAL_YOUTUBEID}
             >
               {'Line'}
@@ -156,7 +158,7 @@ function FeedDisplay({ listQueryVars }) {
             <IFTTTItem
               icon={telegramIcon}
               IFTTTAppletUrl={PUBLIC_TELEGRAM_IFTTT_APPLET_URL}
-              feedUrl={encodeURIComponent(feedUrl + `&source=IFTTT_Telegram`)}
+              feedUrl={feedUrl + `&source=IFTTT_Telegram`}
               tutorialYoutubeId={PUBLIC_TELEGRAM_IFTTT_TUTORIAL_YOUTUBEID}
             >
               {'Telegram'}
@@ -164,7 +166,7 @@ function FeedDisplay({ listQueryVars }) {
             <IFTTTItem
               icon={slackIcon}
               IFTTTAppletUrl={PUBLIC_SLACK_IFTTT_APPLET_URL}
-              feedUrl={encodeURIComponent(feedUrl + `&source=IFTTT_Slack`)}
+              feedUrl={feedUrl + `&source=IFTTT_Slack`}
               tutorialYoutubeId={PUBLIC_SLACK_IFTTT_TUTORIAL_YOUTUBEID}
             >
               {'Slack'}

--- a/components/Subscribe/FeedDisplay.js
+++ b/components/Subscribe/FeedDisplay.js
@@ -130,9 +130,7 @@ function FeedDisplay({ listQueryVars }) {
 
           <ListItemCopy
             icon={rssIcon}
-            textToCopy={
-              feedUrl + `&source=others&utm_source=Others&utm_medium=Subcribe`
-            }
+            textToCopy={feedUrl + `&source=Others`}
             onSuccess={() => copySuccess(t`Copied to clipboard!`)}
           >
             {t`Get RSS Feed Link`}

--- a/components/Subscribe/FeedDisplay.js
+++ b/components/Subscribe/FeedDisplay.js
@@ -81,8 +81,6 @@ function FeedDisplay({ listQueryVars }) {
     handleClose();
   };
 
-  const encodedFeedUrl = encodeURIComponent(feedUrl);
-
   return (
     <>
       <Button onClick={handleClick} className={classes.button}>
@@ -105,7 +103,9 @@ function FeedDisplay({ listQueryVars }) {
         <List>
           <ListItemLink
             email={true}
-            href={`https://feedrabbit.com/?url=${encodedFeedUrl}`}
+            href={`https://feedrabbit.com/?url=${encodeURIComponent(
+              feedUrl + `&source=Feedrabbit`
+            )}`}
             icon={mailIcon}
             onClick={handleClose}
           >
@@ -119,7 +119,9 @@ function FeedDisplay({ listQueryVars }) {
             ></ListItemText>
           </ListItemLink>
           <ListItemLink
-            href={`https://feedly.com/i/discover/sources/search/feed/${encodedFeedUrl}`}
+            href={`https://feedly.com/i/discover/sources/search/feed/${encodeURIComponent(
+              feedUrl + `&source=feedly`
+            )}`}
             icon={feedlyIcon}
             onClick={handleClose}
           >
@@ -128,7 +130,7 @@ function FeedDisplay({ listQueryVars }) {
 
           <ListItemCopy
             icon={rssIcon}
-            textToCopy={feedUrl}
+            textToCopy={encodeURIComponent(feedUrl + `&source=others`)}
             onSuccess={() => copySuccess(t`Copied to clipboard!`)}
           >
             {t`Get RSS Feed Link`}
@@ -146,7 +148,7 @@ function FeedDisplay({ listQueryVars }) {
             <IFTTTItem
               icon={lineIcon}
               IFTTTAppletUrl={PUBLIC_LINE_IFTTT_APPLET_URL}
-              feedUrl={feedUrl}
+              feedUrl={encodeURIComponent(feedUrl + `&source=IFTTT_Line`)}
               tutorialYoutubeId={PUBLIC_LINE_IFTTT_TUTORIAL_YOUTUBEID}
             >
               {'Line'}
@@ -154,7 +156,7 @@ function FeedDisplay({ listQueryVars }) {
             <IFTTTItem
               icon={telegramIcon}
               IFTTTAppletUrl={PUBLIC_TELEGRAM_IFTTT_APPLET_URL}
-              feedUrl={feedUrl}
+              feedUrl={encodeURIComponent(feedUrl + `&source=IFTTT_Telegram`)}
               tutorialYoutubeId={PUBLIC_TELEGRAM_IFTTT_TUTORIAL_YOUTUBEID}
             >
               {'Telegram'}
@@ -162,7 +164,7 @@ function FeedDisplay({ listQueryVars }) {
             <IFTTTItem
               icon={slackIcon}
               IFTTTAppletUrl={PUBLIC_SLACK_IFTTT_APPLET_URL}
-              feedUrl={feedUrl}
+              feedUrl={encodeURIComponent(feedUrl + `&source=IFTTT_Slack`)}
               tutorialYoutubeId={PUBLIC_SLACK_IFTTT_TUTORIAL_YOUTUBEID}
             >
               {'Slack'}

--- a/package-lock.json
+++ b/package-lock.json
@@ -18787,7 +18787,7 @@
       "dependencies": {
         "json5": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
           "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
           "requires": {
             "minimist": "^1.2.0"
@@ -26808,6 +26808,64 @@
       "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "requires": {
         "imurmurhash": "^0.1.4"
+      }
+    },
+    "universal-analytics": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/universal-analytics/-/universal-analytics-0.4.23.tgz",
+      "integrity": "sha512-lgMIH7XBI6OgYn1woDEmxhGdj8yDefMKg7GkWdeATAlQZFrMrNyxSkpDzY57iY0/6fdlzTbBV03OawvvzG+q7A==",
+      "requires": {
+        "debug": "^4.1.1",
+        "request": "^2.88.2",
+        "uuid": "^3.0.0"
+      },
+      "dependencies": {
+        "punycode": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+        },
+        "qs": {
+          "version": "6.5.2",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+        },
+        "request": {
+          "version": "2.88.2",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
+          "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.8.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.6",
+            "extend": "~3.0.2",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.2",
+            "har-validator": "~5.1.3",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.19",
+            "oauth-sign": "~0.9.0",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.2",
+            "safe-buffer": "^5.1.2",
+            "tough-cookie": "~2.5.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.3.2"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
+          "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+          "requires": {
+            "psl": "^1.1.28",
+            "punycode": "^2.1.1"
+          }
+        }
       }
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "react-virtualized-auto-sizer": "^1.0.2",
     "rollbar": "^2.14.4",
     "stackimpact": "^1.3.23",
-    "ttag": "^1.7.22"
+    "ttag": "^1.7.22",
+    "universal-analytics": "^0.4.23"
   },
   "devDependencies": {
     "@apollo/react-testing": "^3.0.1",

--- a/pages/api/articles/[feed].js
+++ b/pages/api/articles/[feed].js
@@ -152,7 +152,7 @@ async function articleFeedHandler(req, res) {
   try {
     data.ListArticles.edges.forEach(({ node }) => {
       const text = getArticleText(node);
-      const url = `${PUBLIC_URL}/article/${node.id}`;
+      const url = `${PUBLIC_URL}/article/${node.id}?utm_source=${query.source}&utm_medium=RSS`;
       const articleReply = node.articleReplies[0];
       feedInstance.addItem({
         id: url,

--- a/pages/api/articles/[feed].js
+++ b/pages/api/articles/[feed].js
@@ -188,7 +188,7 @@ async function articleFeedHandler(req, res) {
     const visitor = ua(PUBLIC_GA_TRACKING_ID);
     const params = {
       ec: 'RSS',
-      ea: 'Subscribe',
+      ea: 'Poll',
       el: query.source,
       dp: JSON.stringify(listQueryVars), // filter, document path: maxlength 2048 bytes
       dt: JSON.stringify(req.headers), // some headers contain follower number, document title: maxlength 1500 bytes


### PR DESCRIPTION
Fixes #222 
## Feature
1. Track subscriber number by sending event: 
Event Category: RSS
Event Action: Subscribe
Event Label: `Source`(Feedly, Feedrabbit, IFTTT)
Document title: [response header](https://www.petefreitag.com/item/418.cfm)
Document path: query variables

    ##### Feedly
    - Sends subscriber number when subscribing.
    - Will cache the feed, it triggers the event when first time fetches the feed, and then each regular fetching(maybe [once an hour](https://www.feedly.com/fetcher.html)).

    ##### Feedrabbit 
    - Sends subscriber number each regular fetching.
    - Triggers the event every time.

2. Track article page through google tag manager by adding `utm_source` 
`utm_source`: `Source`(Feedly, Feedrabbit, IFTTT)
`utm_medium`: RSS

## Fix 
1. Copy URL function shouldn't encode URL

## Snapshots

Page title: res.header (subscriber number), Page path: query variables
![](https://user-images.githubusercontent.com/6376572/93049058-d0629080-f692-11ea-9351-4bb596221a08.png)

utm_source to article page
![](https://user-images.githubusercontent.com/6376572/93055630-d4e07680-f69d-11ea-861d-7babe20b8a44.png)

