### PR TITLE
Layout components for header

### DIFF
--- a/components/ArticlePageLayout.js
+++ b/components/ArticlePageLayout.js
@@ -1,5 +1,5 @@
 import gql from 'graphql-tag';
-import { t, jt, ngettext, msgid } from 'ttag';
+import { t, ngettext, msgid } from 'ttag';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { useQuery } from '@apollo/react-hooks';
@@ -9,7 +9,6 @@ import Typography from '@material-ui/core/Typography';
 
 import { makeStyles } from '@material-ui/core/styles';
 
-import { ellipsis } from 'lib/text';
 import useCurrentUser from 'lib/useCurrentUser';
 import * as FILTERS from 'constants/articleFilters';
 import ListPageCards from 'components/ListPageDisplays/ListPageCards';
@@ -129,7 +128,6 @@ function urlQuery2Filter({
   categoryIds,
   start,
   end,
-  searchUserByArticleId,
   types,
   timeRangeKey,
   userId,
@@ -169,10 +167,6 @@ function urlQuery2Filter({
       default:
     }
   });
-
-  if (searchUserByArticleId) {
-    filterObj.fromUserOfArticleId = searchUserByArticleId;
-  }
 
   if (start) {
     filterObj[timeRangeKey] = { ...filterObj[timeRangeKey], GTE: start };
@@ -264,22 +258,8 @@ function ArticlePageLayout({
   const articleEdges = listArticlesData?.ListArticles?.edges || [];
   const statsData = listStatData?.ListArticles || {};
 
-  // Flags
-  const searchedArticleEdge = articleEdges.find(
-    ({ node: { id } }) => id === query.searchUserByArticleId
-  );
-  const searchedUserArticleElem = (
-    <mark key="searched-user">
-      {ellipsis(searchedArticleEdge?.node?.text || '', { wordCount: 15 })}
-    </mark>
-  );
-
   return (
     <Box pt={2}>
-      {query.searchUserByArticleId && (
-        <h1>{jt`Messages reported by user that reported “${searchedUserArticleElem}”`}</h1>
-      )}
-
       <Box
         display="flex"
         alignItems="center"

--- a/components/ArticlePageLayout.js
+++ b/components/ArticlePageLayout.js
@@ -3,9 +3,6 @@ import { t, ngettext, msgid } from 'ttag';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { useQuery } from '@apollo/react-hooks';
-
-import Box from '@material-ui/core/Box';
-
 import { makeStyles } from '@material-ui/core/styles';
 
 import useCurrentUser from 'lib/useCurrentUser';
@@ -260,10 +257,12 @@ function ArticlePageLayout({
   const statsData = listStatData?.ListArticles || {};
 
   return (
-    <Box pt={2}>
-      <ListPageHeader title={title}>
-        <FeedDisplay listQueryVars={listQueryVars} />
-      </ListPageHeader>
+    <>
+      {title && (
+        <ListPageHeader title={title}>
+          <FeedDisplay listQueryVars={listQueryVars} />
+        </ListPageHeader>
+      )}
 
       <Tools>
         <TimeRange />
@@ -364,7 +363,7 @@ function ArticlePageLayout({
           />
         </>
       )}
-    </Box>
+    </>
   );
 }
 

--- a/components/ArticlePageLayout.js
+++ b/components/ArticlePageLayout.js
@@ -5,7 +5,6 @@ import Link from 'next/link';
 import { useQuery } from '@apollo/react-hooks';
 
 import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
 
 import { makeStyles } from '@material-ui/core/styles';
 
@@ -15,10 +14,12 @@ import ListPageCards from 'components/ListPageDisplays/ListPageCards';
 import ArticleCard from 'components/ListPageDisplays/ArticleCard';
 import ListPageCard from 'components/ListPageDisplays/ListPageCard';
 import ReplyItem from 'components/ListPageDisplays/ReplyItem';
+import ListPageHeader from 'components/ListPageDisplays/ListPageHeader';
 import Infos from 'components/Infos';
 import TimeInfo from 'components/Infos/TimeInfo';
 import FeedDisplay from 'components/Subscribe/FeedDisplay';
 import ExpandableText from 'components/ExpandableText';
+import Tools from 'components/ListPageControls/Tools';
 import Filters from 'components/ListPageControls/Filters';
 import ArticleStatusFilter from 'components/ListPageControls/ArticleStatusFilter';
 import CategoryFilter from 'components/ListPageControls/CategoryFilter';
@@ -260,20 +261,11 @@ function ArticlePageLayout({
 
   return (
     <Box pt={2}>
-      <Box
-        display="flex"
-        alignItems="center"
-        justifyContent={{ xs: 'center', md: 'space-between' }}
-        flexDirection={{ xs: 'column', md: 'row' }}
-        mb={2}
-      >
-        <Typography variant="h4">{title}</Typography>
-        <Box my={1}>
-          <FeedDisplay listQueryVars={listQueryVars} />
-        </Box>
-      </Box>
+      <ListPageHeader title={title}>
+        <FeedDisplay listQueryVars={listQueryVars} />
+      </ListPageHeader>
 
-      <Box display="flex" justifyContent="space-between" flexWrap="wrap">
+      <Tools>
         <TimeRange />
         <SortInput
           defaultOrderBy={defaultOrder}
@@ -283,7 +275,7 @@ function ArticlePageLayout({
             { value: 'replyRequestCount', label: t`Most asked` },
           ]}
         />
-      </Box>
+      </Tools>
 
       <Filters className={classes.filters}>
         {options.filters && <ArticleStatusFilter />}

--- a/components/ArticlePageLayout.js
+++ b/components/ArticlePageLayout.js
@@ -74,20 +74,6 @@ const LIST_STAT = gql`
 `;
 
 const useStyles = makeStyles(theme => ({
-  filters: {
-    margin: '12px 0',
-  },
-  articleList: {
-    padding: 0,
-  },
-  highlight: {
-    color: theme.palette.primary[500],
-  },
-  noStyleLink: {
-    // Canceling link styles
-    color: 'inherit',
-    textDecoration: 'none',
-  },
   bustHoaxDivider: {
     fontSize: theme.typography.htmlFontSize,
     position: 'relative',
@@ -276,7 +262,7 @@ function ArticlePageLayout({
         />
       </Tools>
 
-      <Filters className={classes.filters}>
+      <Filters>
         {options.filters && <ArticleStatusFilter />}
         {options.consider && <ReplyTypeFilter />}
         {options.category && <CategoryFilter />}

--- a/components/ListPageControls/BaseSortInput.js
+++ b/components/ListPageControls/BaseSortInput.js
@@ -7,7 +7,8 @@ import { t } from 'ttag';
 
 const useStyles = makeStyles(theme => ({
   root: {
-    flexDirection: 'row',
+    // Override TextField's inline-flex to extend to whole container
+    display: 'flex',
   },
   inputClass: {
     border: `1px solid ${theme.palette.secondary[100]}`,
@@ -27,7 +28,7 @@ const useStyles = makeStyles(theme => ({
     '&:focus': {
       backgroundColor: 'inherit',
     },
-    [theme.breakpoints.down('md')]: {
+    [theme.breakpoints.down('sm')]: {
       paddingTop: 2.5,
       paddingBottom: 2.5,
     },

--- a/components/ListPageControls/BaseTimeRange.js
+++ b/components/ListPageControls/BaseTimeRange.js
@@ -11,21 +11,24 @@ const useStyles = makeStyles(theme => ({
   },
   buttonGroup: {
     display: 'flex', // Override ButtonGroup default inline-flex
-    flex: 1,
+    minWidth: 0,
+    flex: '1 1 16px', // half of the calendar button to make the two button looks balanced
   },
   calendarButton: {
     background: theme.palette.common.white,
     borderColor: theme.palette.secondary[100],
-    padding: 5,
+    padding: '5px 0 4px',
+    minWidth: 32, // override ButtonGroup style
     [theme.breakpoints.up('md')]: {
-      padding: 8,
+      padding: 6,
     },
   },
   calendarIcon: {
-    fontSize: 14,
+    fontSize: 16,
+    lineHeight: 1,
     color: theme.palette.secondary[300],
     [theme.breakpoints.up('md')]: {
-      fontSize: 18,
+      fontSize: 21,
     },
   },
   selectButton: {
@@ -36,13 +39,17 @@ const useStyles = makeStyles(theme => ({
   startDate: {
     flex: 1,
     background: theme.palette.common.white,
-    marginLeft: '0 !important',
+    marginLeft: '0 !important', // ButtonGroup margin left
+    minWidth: '0',
     border: `1px solid ${theme.palette.secondary[100]}`,
     borderTopRightRadius: 4,
     borderBottomRightRadius: 4,
   },
   to: {
-    padding: '0 11px',
+    padding: '0 4px',
+    [theme.breakpoints.up('md')]: {
+      padding: '0 11px',
+    },
   },
   endDate: {
     flex: 1,
@@ -50,7 +57,6 @@ const useStyles = makeStyles(theme => ({
     border: `1px solid ${theme.palette.secondary[100]}`,
     borderRadius: 4,
     padding: '1.5px 0',
-    minWidth: 100,
     [theme.breakpoints.up('md')]: {
       padding: '5.5px 0',
     },

--- a/components/ListPageControls/BaseTimeRange.js
+++ b/components/ListPageControls/BaseTimeRange.js
@@ -10,19 +10,15 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
   },
   buttonGroup: {
-    border: `1px solid ${theme.palette.secondary[100]}`,
+    display: 'flex', // Override ButtonGroup default inline-flex
+    flex: 1,
   },
   calendarButton: {
     background: theme.palette.common.white,
+    borderColor: theme.palette.secondary[100],
     padding: 5,
-    minWidth: 0,
-
-    '&:hover': {
-      background: theme.palette.secondary[100],
-      color: theme.palette.secondary[300],
-    },
     [theme.breakpoints.up('md')]: {
-      padding: 7,
+      padding: 8,
     },
   },
   calendarIcon: {
@@ -33,10 +29,12 @@ const useStyles = makeStyles(theme => ({
     },
   },
   selectButton: {
+    flex: 1,
     background: theme.palette.common.white,
     padding: '0px 8px',
   },
   startDate: {
+    flex: 1,
     background: theme.palette.common.white,
     marginLeft: '0 !important',
     border: `1px solid ${theme.palette.secondary[100]}`,
@@ -47,6 +45,7 @@ const useStyles = makeStyles(theme => ({
     padding: '0 11px',
   },
   endDate: {
+    flex: 1,
     background: theme.palette.common.white,
     border: `1px solid ${theme.palette.secondary[100]}`,
     borderRadius: 4,
@@ -128,7 +127,7 @@ function BaseTimeRange({ start, end, onChange = () => null }) {
 
   return (
     <div className={classes.root}>
-      <ButtonGroup classes={{ contained: classes.buttonGroup }}>
+      <ButtonGroup className={classes.buttonGroup}>
         <Button className={classes.calendarButton} onClick={openMenu}>
           <DateRangeIcon className={classes.calendarIcon} />
         </Button>

--- a/components/ListPageControls/Filters.js
+++ b/components/ListPageControls/Filters.js
@@ -11,7 +11,7 @@ import cx from 'clsx';
 
 const useStyles = makeStyles(theme => ({
   desktop: {
-    margin: 0 /* Cancel default style for <dl> */,
+    margin: '12px 0' /* Cancel default style for <dl> */,
     display: 'none',
     [theme.breakpoints.up('md')]: {
       display: 'grid',
@@ -20,9 +20,7 @@ const useStyles = makeStyles(theme => ({
       borderRadius: 8,
     },
   },
-  mobile: {
-    margin: `${theme.spacing(3)} 0`,
-  },
+  mobile: {},
   fab: {
     position: 'fixed',
     zIndex: theme.zIndex.speedDial,

--- a/components/ListPageControls/Tools.js
+++ b/components/ListPageControls/Tools.js
@@ -4,11 +4,16 @@ import cx from 'clsx';
 const useStyles = makeStyles(theme => ({
   root: {
     // Mobile: non-flex stack
-    margin: `${theme.spacing(1.5)}px auto 0`, // margin bottom is handled by each item
+    margin: `${theme.spacing(1.5)}px auto`,
     width: 'fit-content',
     maxWidth: '100%',
+
+    // Vertical margin between items
     '& > *': {
       marginBottom: theme.spacing(1.5),
+    },
+    '& > *:last-child': {
+      marginBottom: 0,
     },
 
     // Tablet & desktop: horizontal flexbox
@@ -16,6 +21,10 @@ const useStyles = makeStyles(theme => ({
       width: 'auto',
       display: 'flex',
       justifyContent: 'space-between',
+      '& > *': {
+        // All items are layed-out horizontally so no margin is needed for each item
+        marginBottom: 0,
+      },
     },
   },
 }));

--- a/components/ListPageControls/Tools.js
+++ b/components/ListPageControls/Tools.js
@@ -1,0 +1,16 @@
+import Box from '@material-ui/core/Box';
+
+function Tools({ children, className }) {
+  return (
+    <Box
+      className={className}
+      display="flex"
+      justifyContent="space-between"
+      flexWrap="wrap"
+    >
+      {children}
+    </Box>
+  );
+}
+
+export default Tools;

--- a/components/ListPageControls/Tools.js
+++ b/components/ListPageControls/Tools.js
@@ -1,16 +1,28 @@
-import Box from '@material-ui/core/Box';
+import { makeStyles } from '@material-ui/core/styles';
+import cx from 'clsx';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    // Mobile: non-flex stack
+    margin: `${theme.spacing(1.5)}px auto 0`, // margin bottom is handled by each item
+    width: 'fit-content',
+    maxWidth: '100%',
+    '& > *': {
+      marginBottom: theme.spacing(1.5),
+    },
+
+    // Tablet & desktop: horizontal flexbox
+    [theme.breakpoints.up('sm')]: {
+      width: 'auto',
+      display: 'flex',
+      justifyContent: 'space-between',
+    },
+  },
+}));
 
 function Tools({ children, className }) {
-  return (
-    <Box
-      className={className}
-      display="flex"
-      justifyContent="space-between"
-      flexWrap="wrap"
-    >
-      {children}
-    </Box>
-  );
+  const classes = useStyles();
+  return <div className={cx(className, classes.root)}>{children}</div>;
 }
 
 export default Tools;

--- a/components/ListPageControls/Tools.stories.js
+++ b/components/ListPageControls/Tools.stories.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { withKnobs, text } from '@storybook/addon-knobs';
+import Tools from './Tools';
+
+export default {
+  title: 'ListPageControls/Tools',
+  component: 'Tools',
+  decorators: [withKnobs],
+};
+
+export const Header = () => (
+  <Tools>
+    <div>{text('Tool 1', 'Tool #1 control')}</div>
+    <div>{text('Tool 2', 'Tool #2 control')}</div>
+  </Tools>
+);

--- a/components/ListPageControls/Tools.stories.js
+++ b/components/ListPageControls/Tools.stories.js
@@ -9,8 +9,12 @@ export default {
 };
 
 export const Header = () => (
-  <Tools>
-    <div>{text('Tool 1', 'Tool #1 control')}</div>
-    <div>{text('Tool 2', 'Tool #2 control')}</div>
-  </Tools>
+  <div>
+    Content above tools
+    <Tools>
+      <div>{text('Tool 1', 'Tool #1 control')}</div>
+      <div>{text('Tool 2', 'Tool #2 control')}</div>
+    </Tools>
+    Content below tools
+  </div>
 );

--- a/components/ListPageControls/__snapshots__/BaseTimeRange.stories.storyshot
+++ b/components/ListPageControls/__snapshots__/BaseTimeRange.stories.storyshot
@@ -8,7 +8,7 @@ exports[`Storyshots ListPageControls/BaseTimeRange No Start End Given 1`] = `
     className="makeStyles-root"
   >
     <div
-      className="MuiButtonGroup-root"
+      className="MuiButtonGroup-root makeStyles-buttonGroup"
       role="group"
     >
       <button
@@ -329,7 +329,7 @@ exports[`Storyshots ListPageControls/BaseTimeRange Set Start End From Props 1`] 
       className="makeStyles-root"
     >
       <div
-        className="MuiButtonGroup-root"
+        className="MuiButtonGroup-root makeStyles-buttonGroup"
         role="group"
       >
         <button
@@ -635,7 +635,7 @@ exports[`Storyshots ListPageControls/BaseTimeRange Set Start End From Props 1`] 
       className="makeStyles-root"
     >
       <div
-        className="MuiButtonGroup-root"
+        className="MuiButtonGroup-root makeStyles-buttonGroup"
         role="group"
       >
         <button
@@ -950,7 +950,7 @@ exports[`Storyshots ListPageControls/BaseTimeRange Set Start End From Props 1`] 
       className="makeStyles-root"
     >
       <div
-        className="MuiButtonGroup-root"
+        className="MuiButtonGroup-root makeStyles-buttonGroup"
         role="group"
       >
         <button

--- a/components/ListPageControls/__snapshots__/Tools.stories.storyshot
+++ b/components/ListPageControls/__snapshots__/Tools.stories.storyshot
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots ListPageControls/Tools Header 1`] = `
+<Tools>
+  <div
+    className="MuiBox-root MuiBox-root"
+  >
+    <div>
+      Tool #1 control
+    </div>
+    <div>
+      Tool #2 control
+    </div>
+  </div>
+</Tools>
+`;

--- a/components/ListPageControls/__snapshots__/Tools.stories.storyshot
+++ b/components/ListPageControls/__snapshots__/Tools.stories.storyshot
@@ -1,16 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots ListPageControls/Tools Header 1`] = `
-<Tools>
-  <div
-    className="MuiBox-root MuiBox-root"
-  >
-    <div>
-      Tool #1 control
+<div>
+  Content above tools
+  <Tools>
+    <div
+      className="makeStyles-root"
+    >
+      <div>
+        Tool #1 control
+      </div>
+      <div>
+        Tool #2 control
+      </div>
     </div>
-    <div>
-      Tool #2 control
-    </div>
-  </div>
-</Tools>
+  </Tools>
+  Content below tools
+</div>
 `;

--- a/components/ListPageDisplays/ListPageHeader.js
+++ b/components/ListPageDisplays/ListPageHeader.js
@@ -1,0 +1,20 @@
+import Box from '@material-ui/core/Box';
+import Typography from '@material-ui/core/Typography';
+
+function ListPageHeader({ title, children, className }) {
+  return (
+    <Box
+      className={className}
+      display="flex"
+      alignItems="center"
+      justifyContent={{ xs: 'center', md: 'space-between' }}
+      flexDirection={{ xs: 'column', md: 'row' }}
+      mb={2}
+    >
+      <Typography variant="h4">{title}</Typography>
+      <Box my={1}>{children}</Box>
+    </Box>
+  );
+}
+
+export default ListPageHeader;

--- a/components/ListPageDisplays/ListPageHeader.js
+++ b/components/ListPageDisplays/ListPageHeader.js
@@ -1,19 +1,36 @@
-import Box from '@material-ui/core/Box';
-import Typography from '@material-ui/core/Typography';
+import { makeStyles } from '@material-ui/core/styles';
+import cx from 'clsx';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    display: 'flex',
+    margin: '24px 0 20px',
+    alignItems: 'center',
+    justifyContent: 'center',
+
+    '& > h1': {
+      fontSize: 18,
+      fontWeight: 500,
+      margin: '0 22px 0 0',
+    },
+
+    [theme.breakpoints.up('md')]: {
+      margin: '48px 0 24px',
+      '& > h1': {
+        fontSize: 34,
+      },
+      justifyContent: 'space-between',
+    },
+  },
+}));
 
 function ListPageHeader({ title, children, className }) {
+  const classes = useStyles();
   return (
-    <Box
-      className={className}
-      display="flex"
-      alignItems="center"
-      justifyContent={{ xs: 'center', md: 'space-between' }}
-      flexDirection={{ xs: 'column', md: 'row' }}
-      mb={2}
-    >
-      <Typography variant="h4">{title}</Typography>
-      <Box my={1}>{children}</Box>
-    </Box>
+    <header className={cx(className, classes.root)}>
+      <h1>{title}</h1>
+      {children}
+    </header>
   );
 }
 

--- a/components/ListPageDisplays/ListPageHeader.stories.js
+++ b/components/ListPageDisplays/ListPageHeader.stories.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { withKnobs, text } from '@storybook/addon-knobs';
+import ListPageHeader from './ListPageHeader';
+
+export default {
+  title: 'ListPageDisplays/ListPageHeader',
+  component: 'ListPageHeader',
+  decorators: [withKnobs],
+};
+
+export const Header = () => (
+  <ListPageHeader title={text('title', 'Header text')}>
+    {text('children', 'children content')}
+  </ListPageHeader>
+);

--- a/components/ListPageDisplays/__snapshots__/ListPageHeader.stories.storyshot
+++ b/components/ListPageDisplays/__snapshots__/ListPageHeader.stories.storyshot
@@ -4,19 +4,13 @@ exports[`Storyshots ListPageDisplays/ListPageHeader Header 1`] = `
 <ListPageHeader
   title="Header text"
 >
-  <div
-    className="MuiBox-root MuiBox-root"
+  <header
+    className="makeStyles-root"
   >
-    <h4
-      className="MuiTypography-root MuiTypography-h4"
-    >
+    <h1>
       Header text
-    </h4>
-    <div
-      className="MuiBox-root MuiBox-root"
-    >
-      children content
-    </div>
-  </div>
+    </h1>
+    children content
+  </header>
 </ListPageHeader>
 `;

--- a/components/ListPageDisplays/__snapshots__/ListPageHeader.stories.storyshot
+++ b/components/ListPageDisplays/__snapshots__/ListPageHeader.stories.storyshot
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots ListPageDisplays/ListPageHeader Header 1`] = `
+<ListPageHeader
+  title="Header text"
+>
+  <div
+    className="MuiBox-root MuiBox-root"
+  >
+    <h4
+      className="MuiTypography-root MuiTypography-h4"
+    >
+      Header text
+    </h4>
+    <div
+      className="MuiBox-root MuiBox-root"
+    >
+      children content
+    </div>
+  </div>
+</ListPageHeader>
+`;

--- a/components/ReplyRequestReason/ReplyRequestReason.js
+++ b/components/ReplyRequestReason/ReplyRequestReason.js
@@ -77,32 +77,6 @@ const UPDATE_VOTE = gql`
   ${ReplyRequestInfo}
 `;
 
-// @todo: temporarily remove this
-/*
-const AuthorArticleLink = withStyles(theme => ({
-  linkAuthor: {
-    color: theme.palette.secondary[300],
-    alignSelf: 'flex-end',
-    whiteSpace: 'nowrap',
-  },
-}))(({ classes, articleId }) => (
-  <Link
-    href={url.format({
-      pathname: '/articles',
-      query: {
-        searchUserByArticleId: articleId,
-        filter: 'all',
-        replyRequestCount: 1,
-      },
-    })}
-  >
-    <a className={classes.linkAuthor}>
-      {t`All messages reported by this user`}
-    </a>
-  </Link>
-));
-*/
-
 const UserIcon = props => (
   <SvgIcon {...props} viewBox="0 0 41 42">
     <path d="M20.4167 0.800049C9.34879 0.800049 0 10.1488 0 21.2167C0 32.2846 9.34879 41.6334 20.4167 41.6334C31.4845 41.6334 40.8333 32.2846 40.8333 21.2167C40.8333 10.1488 31.4845 0.800049 20.4167 0.800049ZM20.4167 11.0084C23.9426 11.0084 26.5417 13.6054 26.5417 17.1334C26.5417 20.6614 23.9426 23.2584 20.4167 23.2584C16.8927 23.2584 14.2917 20.6614 14.2917 17.1334C14.2917 13.6054 16.8927 11.0084 20.4167 11.0084ZM9.99192 30.9595C11.8233 28.2645 14.8776 26.4679 18.375 26.4679H22.4583C25.9577 26.4679 29.01 28.2645 30.8414 30.9595C28.2322 33.7525 24.5306 35.5084 20.4167 35.5084C16.3027 35.5084 12.6012 33.7525 9.99192 30.9595Z" />
@@ -121,7 +95,7 @@ const ThumbDownIcon = props => (
   </SvgIcon>
 );
 
-function ReplyRequestReason({ isArticleCreator, replyRequest }) {
+function ReplyRequestReason({ replyRequest }) {
   const {
     id: replyRequestId,
     reason: replyRequestReason,
@@ -137,7 +111,7 @@ function ReplyRequestReason({ isArticleCreator, replyRequest }) {
 
   const classes = useStyles();
 
-  if (!(isArticleCreator || replyRequestReason)) return null;
+  if (!replyRequestReason) return null;
 
   return (
     <div>
@@ -176,9 +150,6 @@ function ReplyRequestReason({ isArticleCreator, replyRequest }) {
                     <ThumbDownIcon className={classes.thumbIcon} />
                   </button>
                 </Box>
-                {/* isArticleCreator && (
-                  <AuthorArticleLink articleId={articleId} />
-                ) */}
               </Box>
             </Box>
           </>
@@ -192,7 +163,6 @@ function ReplyRequestReason({ isArticleCreator, replyRequest }) {
 ReplyRequestReason.propTypes = {
   articleId: PropTypes.string,
   replyRequest: PropTypes.object.isRequired,
-  isArticleCreator: PropTypes.bool.isRequired, // should display link of searchUserByArticleId, no matter have reason or not
 };
 
 ReplyRequestReason.fragments = { ReplyRequestInfo, ReplyRequestInfoForUser };

--- a/components/ReplySearchPageLayout.js
+++ b/components/ReplySearchPageLayout.js
@@ -145,7 +145,7 @@ function ReplySearchPageLayout() {
   const statsData = listStatData?.ListReplies || {};
 
   return (
-    <Box pt={2}>
+    <>
       <Tools>
         <TimeRange />
       </Tools>
@@ -189,7 +189,7 @@ function ReplySearchPageLayout() {
           />
         </>
       )}
-    </Box>
+    </>
   );
 }
 

--- a/components/ReplySearchPageLayout.js
+++ b/components/ReplySearchPageLayout.js
@@ -11,6 +11,7 @@ import Filters from 'components/ListPageControls/Filters';
 import ReplyTypeFilter from 'components/ListPageControls/ReplyTypeFilter';
 import TimeRange from 'components/ListPageControls/TimeRange';
 import LoadMore from 'components/ListPageControls/LoadMore';
+import Tools from 'components/ListPageControls/Tools';
 
 const MAX_KEYWORD_LENGTH = 100;
 
@@ -145,9 +146,9 @@ function ReplySearchPageLayout() {
 
   return (
     <Box pt={2}>
-      <Box display="flex" justifyContent="space-between" flexWrap="wrap">
+      <Tools>
         <TimeRange />
-      </Box>
+      </Tools>
 
       <Filters className={classes.filters}>
         <ReplyTypeFilter />

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -350,12 +350,11 @@ function ArticlePage() {
               <TrendPlot data={article.stats} />
               <Divider />
               <footer>
-                {article.replyRequests.map((replyRequest, idx) => (
+                {article.replyRequests.map(replyRequest => (
                   <ReplyRequestReason
                     key={replyRequest.id}
                     articleId={article.id}
                     replyRequest={replyRequest}
-                    isArticleCreator={idx === 0}
                   />
                 ))}
                 <CreateReplyRequestForm


### PR DESCRIPTION
- Adjust page header's margins and font size so that it matches [the design](https://www.figma.com/file/zpD45j8nqDB2XfA6m2QskO/Cofacts-website?node-id=79%3A9)
- `<Tools>`
  - hosts controls like `TimeRange` and `SortInput`
  - in mobile, all controls are stacked and have the same width
  - on desktop, all controls are laid out horizontally
- `<ListPageHeader>`
  - layout title text and other items horizontally
  - adjust font size on mobile and desktop
- Adjustments are made to `BaseTimeRange` and `BaseSortInput` so that they have same size and relax their width to work with `<Tools>`

## Screenshots

### mobile
![image](https://user-images.githubusercontent.com/108608/92987245-521bb800-f4f3-11ea-8303-293356d23ba0.png)

### Desktop
![image](https://user-images.githubusercontent.com/108608/92987274-a161e880-f4f3-11ea-8f33-fc829af4daaf.png)

### `BaseTimeRange` and `BaseSortInput`
Their width are now controlled by its container, thus shows 100% width in storybook

![image](https://user-images.githubusercontent.com/108608/92987412-b5f2b080-f4f4-11ea-908f-a8aad700dabd.png)

![image](https://user-images.githubusercontent.com/108608/92987429-d1f65200-f4f4-11ea-8204-4470e4d4dfbc.png)
