### PR TITLE
<Card> for detail pages

### DIFF
--- a/Storyshots.test.js
+++ b/Storyshots.test.js
@@ -9,7 +9,7 @@ import MockDate from 'mockdate';
 Enzyme.configure({ adapter: new Adapter() });
 
 /* makeStyle + useStyle hook, <Box> and withStyle HOC */
-const MAKE_STYLE_REGEXP = /((?:makeStyles|MuiBox|Component|WithStyles)\W.+?)-\d+/g;
+const MAKE_STYLE_REGEXP = /((?:makeStyles|MuiBox|Component|WithStyles|ForwardRef)\W.+?)-\d+/g;
 
 function removeMaterialUIInternals(json) {
   // Remove props we don't want to snapshot

--- a/components/Card.js
+++ b/components/Card.js
@@ -1,0 +1,43 @@
+import { withStyles } from '@material-ui/core/styles';
+import MuiCard from '@material-ui/core/Card';
+import MuiCardContent from '@material-ui/core/CardContent';
+
+import cx from 'clsx';
+
+export function Card(props) {
+  return <MuiCard elevation={0} {...props} />;
+}
+
+export const CardHeader = withStyles(theme => ({
+  root: {
+    margin: '0 16px',
+    padding: '12px 0 8px',
+    fontSize: 12,
+    lineHeight: '20px',
+    fontWeight: 700,
+    letterSpacing: 0.25,
+    color: theme.palette.secondary[500],
+    borderBottom: `1px solid ${theme.palette.secondary[500]}`,
+
+    [theme.breakpoints.up('md')]: {
+      margin: '0 36px',
+      padding: '20px 0 12px',
+      fontSize: 14,
+    },
+  },
+}))(({ classes, children, className, ...props }) => {
+  return (
+    <header className={cx(classes.root, className)} {...props}>
+      {children}
+    </header>
+  );
+});
+
+export const CardContent = withStyles(theme => ({
+  root: {
+    // Card has 16px padding in mobile already
+    [theme.breakpoints.up('md')]: {
+      padding: '20px 36px 24px',
+    },
+  },
+}))(MuiCardContent);

--- a/components/Card.js
+++ b/components/Card.js
@@ -4,13 +4,21 @@ import MuiCardContent from '@material-ui/core/CardContent';
 
 import cx from 'clsx';
 
-export function Card(props) {
-  return <MuiCard elevation={0} {...props} />;
-}
+/**
+ * Provides custom CSS property --horizontal-padding
+ */
+export const Card = withStyles(theme => ({
+  root: {
+    '--horizontal-padding': '16px',
+    [theme.breakpoints.up('md')]: {
+      '--horizontal-padding': '36px',
+    },
+  },
+}))(props => <MuiCard elevation={0} {...props} />);
 
 export const CardHeader = withStyles(theme => ({
   root: {
-    margin: '0 16px',
+    margin: '0 var(--horizontal-padding)',
     padding: '12px 0 8px',
     fontSize: 12,
     lineHeight: '20px',
@@ -20,7 +28,6 @@ export const CardHeader = withStyles(theme => ({
     borderBottom: `1px solid ${theme.palette.secondary[500]}`,
 
     [theme.breakpoints.up('md')]: {
-      margin: '0 36px',
       padding: '20px 0 12px',
       fontSize: 14,
     },
@@ -35,9 +42,9 @@ export const CardHeader = withStyles(theme => ({
 
 export const CardContent = withStyles(theme => ({
   root: {
-    // Card has 16px padding in mobile already
+    padding: '16px var(--horizontal-padding)',
     [theme.breakpoints.up('md')]: {
-      padding: '20px 36px 24px',
+      padding: '20px var(--horizontal-padding) 24px',
     },
   },
 }))(MuiCardContent);

--- a/components/Card.js
+++ b/components/Card.js
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import { withStyles } from '@material-ui/core/styles';
 import MuiCard from '@material-ui/core/Card';
 import MuiCardContent from '@material-ui/core/CardContent';
@@ -15,7 +16,7 @@ export const Card = withStyles(theme => ({
       '--card-px': '36px',
     },
   },
-}))(props => <MuiCard elevation={0} {...props} />);
+}))(forwardRef((props, ref) => <MuiCard ref={ref} elevation={0} {...props} />));
 
 export const CardHeader = withStyles(theme => ({
   root: {

--- a/components/Card.js
+++ b/components/Card.js
@@ -42,9 +42,14 @@ export const CardHeader = withStyles(theme => ({
 
 export const CardContent = withStyles(theme => ({
   root: {
-    padding: '16px var(--horizontal-padding)',
+    padding: '16px 0',
+    margin: '0 var(--horizontal-padding)',
     [theme.breakpoints.up('md')]: {
-      padding: '20px var(--horizontal-padding) 24px',
+      padding: '24px 0',
+    },
+
+    '& + &': {
+      borderTop: `1px solid ${theme.palette.secondary[100]}`,
     },
   },
 }))(MuiCardContent);

--- a/components/Card.js
+++ b/components/Card.js
@@ -5,20 +5,21 @@ import MuiCardContent from '@material-ui/core/CardContent';
 import cx from 'clsx';
 
 /**
- * Provides custom CSS property --horizontal-padding
+ * Provides custom CSS property --card-px
  */
 export const Card = withStyles(theme => ({
   root: {
-    '--horizontal-padding': '16px',
+    overflow: 'visible',
+    '--card-px': '16px',
     [theme.breakpoints.up('md')]: {
-      '--horizontal-padding': '36px',
+      '--card-px': '36px',
     },
   },
 }))(props => <MuiCard elevation={0} {...props} />);
 
 export const CardHeader = withStyles(theme => ({
   root: {
-    margin: '0 var(--horizontal-padding)',
+    margin: '0 var(--card-px)',
     padding: '12px 0 8px',
     fontSize: 12,
     lineHeight: '20px',
@@ -43,7 +44,7 @@ export const CardHeader = withStyles(theme => ({
 export const CardContent = withStyles(theme => ({
   root: {
     padding: '16px 0',
-    margin: '0 var(--horizontal-padding)',
+    margin: '0 var(--card-px)',
     [theme.breakpoints.up('md')]: {
       padding: '24px 0',
     },

--- a/components/Card.stories.js
+++ b/components/Card.stories.js
@@ -12,6 +12,9 @@ export const CardWithContent = () => (
   <Card>
     <CardContent>Card content 1</CardContent>
     <CardContent>Card content 2</CardContent>
+    <div>Something else</div>
+    <CardContent>Card content 3</CardContent>
+    <CardContent>Card content 4</CardContent>
   </Card>
 );
 

--- a/components/Card.stories.js
+++ b/components/Card.stories.js
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Card, CardHeader, CardContent } from './Card';
+
+export default {
+  title: 'Card',
+  component: 'Card',
+};
+
+export const BasicCard = () => <Card>Basic card</Card>;
+
+export const CardWithContent = () => (
+  <Card>
+    <CardContent>Card content 1</CardContent>
+    <CardContent>Card content 2</CardContent>
+  </Card>
+);
+
+export const CardWithHeader = () => (
+  <Card>
+    <CardHeader>Card header here</CardHeader>
+    <CardContent>Card content</CardContent>
+  </Card>
+);

--- a/components/Infos/__snapshots__/Infos.stories.storyshot
+++ b/components/Infos/__snapshots__/Infos.stories.storyshot
@@ -87,10 +87,10 @@ exports[`Storyshots Infos With Reply Count Info 1`] = `
         arrow={true}
         title={
           <div
-            className="makeStyles-opinions-155"
+            className="makeStyles-opinions-250"
           >
             <span
-              className="makeStyles-opinion-156"
+              className="makeStyles-opinion-251"
             >
               <NOT_ARTICLE
                 fontSize="inherit"
@@ -100,7 +100,7 @@ exports[`Storyshots Infos With Reply Count Info 1`] = `
               </span>
             </span>
             <span
-              className="makeStyles-opinion-156"
+              className="makeStyles-opinion-251"
             >
               <OPINIONATED
                 fontSize="inherit"
@@ -110,7 +110,7 @@ exports[`Storyshots Infos With Reply Count Info 1`] = `
               </span>
             </span>
             <span
-              className="makeStyles-opinion-156"
+              className="makeStyles-opinion-251"
             >
               <NOT_RUMOR
                 fontSize="inherit"
@@ -120,7 +120,7 @@ exports[`Storyshots Infos With Reply Count Info 1`] = `
               </span>
             </span>
             <span
-              className="makeStyles-opinion-156"
+              className="makeStyles-opinion-251"
             >
               <RUMOR
                 fontSize="inherit"

--- a/components/Ribbon.js
+++ b/components/Ribbon.js
@@ -1,3 +1,4 @@
+import { forwardRef } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import cx from 'clsx';
 
@@ -32,10 +33,10 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function Ribbon({ className, children, ...props }) {
+function Ribbon({ className, children, ...props }, ref) {
   const classes = useStyles();
   return (
-    <aside className={cx(classes.root, className)} {...props}>
+    <aside className={cx(classes.root, className)} ref={ref} {...props}>
       {children}
       <svg className={cx(classes.tail)} viewBox="0 0 1 2">
         <path d="M0 0 H1 L0 1 L1 2 H0 Z" />
@@ -44,4 +45,4 @@ function Ribbon({ className, children, ...props }) {
   );
 }
 
-export default Ribbon;
+export default forwardRef(Ribbon);

--- a/components/__snapshots__/Card.stories.storyshot
+++ b/components/__snapshots__/Card.stories.storyshot
@@ -1,0 +1,64 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Storyshots Card Basic Card 1`] = `
+<Component>
+  <div
+    className="MuiPaper-root MuiCard-root Component-root MuiPaper-elevation0 MuiPaper-rounded"
+  >
+    Basic card
+  </div>
+</Component>
+`;
+
+exports[`Storyshots Card Card With Content 1`] = `
+<Component>
+  <div
+    className="MuiPaper-root MuiCard-root Component-root MuiPaper-elevation0 MuiPaper-rounded"
+  >
+    <div
+      className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
+    >
+      Card content 1
+    </div>
+    <div
+      className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
+    >
+      Card content 2
+    </div>
+    <div>
+      Something else
+    </div>
+    <div
+      className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
+    >
+      Card content 3
+    </div>
+    <div
+      className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
+    >
+      Card content 4
+    </div>
+  </div>
+</Component>
+`;
+
+exports[`Storyshots Card Card With Header 1`] = `
+<Component>
+  <div
+    className="MuiPaper-root MuiCard-root Component-root MuiPaper-elevation0 MuiPaper-rounded"
+  >
+    <Component>
+      <header
+        className="Component-root"
+      >
+        Card header here
+      </header>
+    </Component>
+    <div
+      className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
+    >
+      Card content
+    </div>
+  </div>
+</Component>
+`;

--- a/components/__snapshots__/Card.stories.storyshot
+++ b/components/__snapshots__/Card.stories.storyshot
@@ -1,64 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Storyshots Card Basic Card 1`] = `
-<Component>
-  <div
-    className="MuiPaper-root MuiCard-root Component-root MuiPaper-elevation0 MuiPaper-rounded"
-  >
-    Basic card
-  </div>
-</Component>
+<div
+  className="MuiPaper-root MuiCard-root ForwardRef-root MuiPaper-elevation0 MuiPaper-rounded"
+>
+  Basic card
+</div>
 `;
 
 exports[`Storyshots Card Card With Content 1`] = `
-<Component>
+<div
+  className="MuiPaper-root MuiCard-root ForwardRef-root MuiPaper-elevation0 MuiPaper-rounded"
+>
   <div
-    className="MuiPaper-root MuiCard-root Component-root MuiPaper-elevation0 MuiPaper-rounded"
+    className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
   >
-    <div
-      className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
-    >
-      Card content 1
-    </div>
-    <div
-      className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
-    >
-      Card content 2
-    </div>
-    <div>
-      Something else
-    </div>
-    <div
-      className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
-    >
-      Card content 3
-    </div>
-    <div
-      className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
-    >
-      Card content 4
-    </div>
+    Card content 1
   </div>
-</Component>
+  <div
+    className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
+  >
+    Card content 2
+  </div>
+  <div>
+    Something else
+  </div>
+  <div
+    className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
+  >
+    Card content 3
+  </div>
+  <div
+    className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
+  >
+    Card content 4
+  </div>
+</div>
 `;
 
 exports[`Storyshots Card Card With Header 1`] = `
-<Component>
-  <div
-    className="MuiPaper-root MuiCard-root Component-root MuiPaper-elevation0 MuiPaper-rounded"
-  >
-    <Component>
-      <header
-        className="Component-root"
-      >
-        Card header here
-      </header>
-    </Component>
-    <div
-      className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
+<div
+  className="MuiPaper-root MuiCard-root ForwardRef-root MuiPaper-elevation0 MuiPaper-rounded"
+>
+  <Component>
+    <header
+      className="Component-root"
     >
-      Card content
-    </div>
+      Card header here
+    </header>
+  </Component>
+  <div
+    className="MuiCardContent-root WithStyles(ForwardRef(CardContent))-root"
+  >
+    Card content
   </div>
-</Component>
+</div>
 `;

--- a/components/__snapshots__/Ribbon.stories.storyshot
+++ b/components/__snapshots__/Ribbon.stories.storyshot
@@ -10,21 +10,19 @@ exports[`Storyshots Ribbon Default 1`] = `
   }
 >
   Text content
-  <Ribbon>
-    <aside
-      className="makeStyles-root"
+  <aside
+    className="makeStyles-root"
+  >
+    ribbon children
+    <svg
+      className="makeStyles-tail"
+      viewBox="0 0 1 2"
     >
-      ribbon children
-      <svg
-        className="makeStyles-tail"
-        viewBox="0 0 1 2"
-      >
-        <path
-          d="M0 0 H1 L0 1 L1 2 H0 Z"
-        />
-      </svg>
-    </aside>
-  </Ribbon>
+      <path
+        d="M0 0 H1 L0 1 L1 2 H0 Z"
+      />
+    </svg>
+  </aside>
   Text content
 </div>
 `;


### PR DESCRIPTION
## Refactor

This PR introduces `<Card>`, a common layout that can be seen in [article detail](https://www.figma.com/file/zpD45j8nqDB2XfA6m2QskO/Cofacts-website?node-id=1273%3A176), and will be applied to [reply detail](https://www.figma.com/file/zpD45j8nqDB2XfA6m2QskO/Cofacts-website?node-id=912%3A190) and [profile page](https://www.figma.com/file/zpD45j8nqDB2XfA6m2QskO/Cofacts-website?node-id=912%3A385) in the future.

![image](https://user-images.githubusercontent.com/108608/94900490-a8af5d00-04c7-11eb-8dc9-e721aede8e10.png)
![image](https://user-images.githubusercontent.com/108608/94900528-ba910000-04c7-11eb-9295-f06ccd23c9fd.png)
![image](https://user-images.githubusercontent.com/108608/94900553-c67cc200-04c7-11eb-913a-61b3e7cfa45a.png)

Also I add I add `forwardRef` to `Card` and `Ribbon` because in future PRs we are going to need them.

## Design philosophy

In the design, the card has so many different appearances.
- They share the same mobile & desktop padding, so these styles should be shared
- But in some cases there are different headers or full-width footer buttons that don't respect the paddings.

Therefore the design of components are:

- `<Card>`
  - Basically just Material-UI `<Paper>` with no shadow.
  - It sets `--card-px` custom property, which is different in desktop & mobile.
  - However, the card itself has no `padding` property set.
- `<CardContent>`
  - Sets padding according to `--card-px`.
  - Consecutive `<CardContent>` would have a separator line in between.
- `<CardHeader>`
  - Provides the "header look" (bold text with bottom border)
  - Sets padding according to `--card-px`.

These components are basically following [Material-UI's Card component design](https://material-ui.com/components/cards), where "components providing a background" and "components providing margins and paddings" are separate to provide more flexibility at the cost of verboseness.

Applying `Card` and related component to article detail is in future PRs (#344 )