### PR TITLE
Adjust global border-radius and primary color palatte

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -3,6 +3,7 @@ import { addDecorator } from '@storybook/react';
 import { ThemeProvider } from '@material-ui/core/styles';
 import CssBaseline from '@material-ui/core/CssBaseline';
 import { lightTheme } from '../lib/theme';
+import '../components/app.css';
 
 addDecorator(storyFn => (
   <ThemeProvider theme={lightTheme}>

--- a/__mocks__/styleMock.js
+++ b/__mocks__/styleMock.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.js
+++ b/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.js
@@ -5,6 +5,7 @@ import { useMutation } from '@apollo/react-hooks';
 import { makeStyles } from '@material-ui/core/styles';
 import { Popover, Typography } from '@material-ui/core';
 import Snackbar from '@material-ui/core/Snackbar';
+import Button from '@material-ui/core/Button';
 import CloseIcon from '@material-ui/icons/Close';
 import ReasonsDisplay from './ReasonsDisplay';
 import ButtonGroupDisplay from './ButtonGroupDisplay';
@@ -46,18 +47,8 @@ const useStyles = makeStyles(theme => ({
   },
   textCenter: { textAlign: 'center' },
   sendButton: {
-    outline: 'none',
-    border: 'none',
     marginTop: 10,
-    padding: '10px 25px',
-    background: theme.palette.primary[500],
-    color: theme.palette.common.white,
-    cursor: 'pointer',
     borderRadius: 30,
-    '&:disabled': {
-      opacity: 0.7,
-      cursor: 'not-allowed',
-    },
   },
 }));
 
@@ -220,9 +211,11 @@ function ArticleReplyFeedbackControl({ articleReply, className }) {
           rows={10}
         />
         <div className={classes.textCenter}>
-          <button
-            type="button"
+          <Button
             className={classes.sendButton}
+            color="primary"
+            variant="contained"
+            disableElevation
             disabled={updatingReplyFeedback}
             onClick={() => {
               createReplyFeedback({
@@ -234,7 +227,9 @@ function ArticleReplyFeedbackControl({ articleReply, className }) {
                 },
               });
             }}
-          >{t`Send`}</button>
+          >
+            {t`Send`}
+          </Button>
         </div>
       </Popover>
       <Snackbar

--- a/components/app.css
+++ b/components/app.css
@@ -10,3 +10,8 @@ button, input {
   font-family: inherit;
   font-size: inherit;
 }
+
+/* Primary button should get white color */
+.MuiButton-containedPrimary.MuiButton-containedPrimary {
+  color: #fff;
+}

--- a/components/app.css
+++ b/components/app.css
@@ -12,6 +12,7 @@ button, input {
 }
 
 /* Primary button should get white color */
-.MuiButton-containedPrimary.MuiButton-containedPrimary {
+.MuiButton-containedPrimary.MuiButton-containedPrimary,
+.MuiFab-primary.MuiFab-primary {
   color: #fff;
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,4 +6,9 @@ module.exports = {
     '^.+\\.stories\\.jsx?$': '@storybook/addon-storyshots/injectFileName',
     '^.+\\.jsx?$': 'babel-jest',
   },
+  moduleNameMapper: {
+    // Ignore CSS imports in jest
+    // Ref: https://jestjs.io/docs/en/webpack#handling-static-assets
+    '\\.css$': '<rootDir>/__mocks__/styleMock.js',
+  }
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -10,5 +10,5 @@ module.exports = {
     // Ignore CSS imports in jest
     // Ref: https://jestjs.io/docs/en/webpack#handling-static-assets
     '\\.css$': '<rootDir>/__mocks__/styleMock.js',
-  }
+  },
 };

--- a/lib/theme.js
+++ b/lib/theme.js
@@ -30,8 +30,6 @@ const baseThemeOption = {
       700: '#ff9200',
       800: '#ff7f00',
       900: '#ff6d00',
-      light: '#fafafa',
-      dark: '#e8e8e8',
     },
     secondary: {
       main: '#333333',
@@ -58,6 +56,9 @@ const baseThemeOption = {
     // Avoid flicker on devices that has Noto Sans installed
     fontFamily:
       '"Noto Sans TC", "Noto Sans CJK TC", "Source Han Sans", "思源黑體", sans-serif',
+  },
+  shape: {
+    borderRadius: 8,
   },
 };
 


### PR DESCRIPTION
This PR adjusts Material-UI theme used theme in Cofacts to better match [figma](https://www.figma.com/file/zpD45j8nqDB2XfA6m2QskO/Cofacts-website?node-id=681%3A0)

![button](https://user-images.githubusercontent.com/108608/94903082-d1d1ec80-04cb-11eb-9659-eb476b6a55cf.gif)

- Global border radius raised to 8px (default 4px)
  - This affects dropdowns, pop-overs, snackbars, etc.
- Remove incorrect primary dark / light color setup
  - The incorrect setup causes buttons in primary color turns grey when hovering on the button
  - Remove the color so that Material-UI can handle hovering color by themselves.
- Set primary button text color in global CSS
  - Material-UI uses `rgba(0,0,0,0.88)` by default
  - Set to #fff to match [figma](https://www.figma.com/file/zpD45j8nqDB2XfA6m2QskO/Cofacts-website?node-id=890%3A586)
  - Apply app.css to Storybook to reflect this change
  - Use Material-UI `Button` in `ArticleReplyFeedbackControl` to see primary color setup