### PR TITLE
Similar messages side section in article detail

### DIFF
--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -31,7 +31,6 @@ import NewReplySection from 'components/NewReplySection';
 import ArticleInfo from 'components/ArticleInfo';
 import ArticleCategories from 'components/ArticleCategories';
 import TrendPlot from 'components/TrendPlot';
-import cx from 'clsx';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -80,45 +79,82 @@ const useStyles = makeStyles(theme => ({
     },
   },
   aside: {
-    flex: 1,
-    background: 'transparent',
-    minWidth: 0,
     [theme.breakpoints.up('md')]: {
-      padding: '21px 19px',
-      background: theme.palette.common.white,
+      minWidth: 0,
+      flex: 1,
+      padding: '0 20px',
+      background: theme.palette.background.paper,
+      borderRadius: theme.shape.borderRadius,
     },
-    '& h4': {
-      [theme.breakpoints.up('md')]: {
-        marginBottom: 0,
-        paddingBottom: 16,
-        borderBottom: `1px solid ${theme.palette.secondary[500]}`,
+  },
+  asideHeader: {
+    lineHeight: '20px',
+    padding: '12px 0',
+    fontWeight: 700,
+    [theme.breakpoints.up('md')]: {
+      padding: '20px 0 12px',
+      borderBottom: `1px solid ${theme.palette.secondary[500]}`,
+    },
+  },
+  asideItems: {
+    display: 'flex',
+    flexFlow: 'row',
+    overflowX: 'auto',
+
+    '--gutter': `${theme.spacing(2)}px`,
+    margin: `0 calc(-1 * var(--gutter))`,
+    padding: `0 var(--gutter)`,
+
+    '&::after': {
+      // Right-most gutter after the last item
+      content: '""',
+      flex: '0 0 var(--gutter)',
+    },
+
+    [theme.breakpoints.up('sm')]: {
+      '--gutter': `${theme.spacing(3)}px`,
+    },
+    [theme.breakpoints.up('md')]: {
+      '--gutter': 0,
+      flexFlow: 'column',
+      overflowX: 'visible',
+      '&::after': {
+        display: 'none',
       },
     },
   },
-  similarMessageContainer: {
-    backgroundColor: theme.palette.common.white,
-    minWidth: '100%',
-    padding: '17px 19px',
-    marginRight: theme.spacing(2),
-    borderRadius: 8,
+  asideItem: {
+    // override <a> defaults
     textDecoration: 'none',
     color: 'inherit',
+
+    [theme.breakpoints.down('sm')]: {
+      padding: 16,
+      background: theme.palette.background.paper,
+      borderRadius: theme.shape.borderRadius,
+      flex: '0 0 320px',
+      maxWidth: '66vw',
+      '& + &': {
+        marginLeft: 12,
+      },
+    },
+
     [theme.breakpoints.up('md')]: {
-      padding: '16px 0 0 0 ',
-      margin: 0,
-      width: 'auto',
-      borderBottom: `1px solid ${theme.palette.secondary[100]}`,
-      '&:last-child': {
-        borderBottom: 'none',
+      padding: '16px 0',
+      '& + &': {
+        borderTop: `1px solid ${theme.palette.secondary[100]}`,
       },
     },
   },
-  text: {
-    display: 'box',
+  asideItemText: {
+    display: '-webkit-box',
     overflow: 'hidden',
     boxOrient: 'vertical',
     textOverflow: 'ellipsis',
     lineClamp: 5,
+
+    // distance between ArticleInfo
+    marginBottom: 12,
   },
   lineFab: {
     position: 'fixed',
@@ -426,33 +462,27 @@ function ArticlePage() {
           </Card>
         </div>
 
-        <div className={cx(classes.aside)}>
-          <h4>{t`Similar messages`}</h4>
+        <aside className={classes.aside}>
+          <header className={classes.asideHeader}>{t`Similar messages`}</header>
           {similarArticles.length ? (
-            <Box
-              display="flex"
-              flexDirection={{ xs: 'row', md: 'column' }}
-              overflow="auto"
-            >
+            <div className={classes.asideItems}>
               {similarArticles.map(({ node }) => (
                 <Link key={node.id} href={`/article/${node.id}`}>
-                  <a className={classes.similarMessageContainer}>
-                    <article className={classes.text}>{node.text}</article>
-                    <Box pt={1.5} pb={2}>
-                      <ArticleInfo article={node} />
-                    </Box>
+                  <a className={classes.asideItem}>
+                    <article className={classes.asideItemText}>
+                      {node.text}
+                    </article>
+                    <ArticleInfo article={node} />
                   </a>
                 </Link>
               ))}
-            </Box>
+            </div>
           ) : (
-            <Box
-              textAlign="center"
-              pt={4}
-              pb={3}
-            >{t`No similar messages found`}</Box>
+            <Box textAlign="center" pt={4} pb={3}>
+              {t`No similar messages found`}
+            </Box>
           )}
-        </div>
+        </aside>
       </div>
       <Snackbar
         open={!!flashMessage}


### PR DESCRIPTION
Rewrite "similar messages" side section.

- Figma: https://www.figma.com/file/zpD45j8nqDB2XfA6m2QskO/Cofacts-website?node-id=890%3A585
- Mobile / desktop differs a lot, thus `Card` cannot be reused here.
- use explicit class name for each component in the similar messages section
- Fix firefox similar message section
 
![image](https://user-images.githubusercontent.com/108608/95045806-5f544d00-0715-11eb-8056-4488e9a9d242.png)
![image](https://user-images.githubusercontent.com/108608/95045818-667b5b00-0715-11eb-9ac4-d6d0d1eb82c6.png)
![image](https://user-images.githubusercontent.com/108608/95045849-73984a00-0715-11eb-842e-5795b1935bab.png)

