### PR TITLE
Makeshift edit name function for the hackathon

### DIFF
--- a/components/AppLayout/AppHeader.js
+++ b/components/AppLayout/AppHeader.js
@@ -212,6 +212,7 @@ function AppHeader({
   onMenuButtonClick,
   onLoginModalOpen,
   onLogout,
+  onNameChange,
 }) {
   const [anchor, setAnchor] = useState(null);
   const [displayLogo, setDisplayLogo] = useState(true);
@@ -263,7 +264,7 @@ function AppHeader({
                     <strong>Lv. {user?.level}</strong>
                     {LEVEL_NAMES[(user?.level)]}
                   </Ribbon>
-                  <MenuItem onClick={closeProfileMenu}>
+                  <MenuItem onClick={onNameChange}>
                     <ListItemIcon>
                       <Widgets.Avatar user={user} size={40} />
                     </ListItemIcon>

--- a/components/AppLayout/AppLayout.js
+++ b/components/AppLayout/AppLayout.js
@@ -1,3 +1,4 @@
+import { t } from 'ttag';
 import React, { Fragment, useState, useEffect, useCallback } from 'react';
 import Container from '@material-ui/core/Container';
 import { makeStyles } from '@material-ui/core/styles';
@@ -7,9 +8,10 @@ import AppHeader from './AppHeader';
 import AppSidebar from './AppSidebar';
 import AppFooter from './AppFooter';
 import gql from 'graphql-tag';
-import { useLazyQuery } from '@apollo/react-hooks';
+import { useLazyQuery, useMutation } from '@apollo/react-hooks';
 import LoginModal from './LoginModal';
 import fetchAPI from 'lib/fetchAPI';
+import Snackbar from '@material-ui/core/Snackbar';
 
 const USER_QUERY = gql`
   query UserLevelQuery {
@@ -26,6 +28,16 @@ const USER_QUERY = gql`
     }
   }
 `;
+
+const CHANGE_NAME_QUERY = gql`
+  mutation ChangeUserName($name: String!) {
+    UpdateUser(name: $name) {
+      id
+      name
+    }
+  }
+`;
+
 const useStyles = makeStyles({
   container: {
     flex: 1,
@@ -43,14 +55,34 @@ function AppLayout({ children, container = true }) {
   const [isRouteChanging, setRouteChanging] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [loginModalOpen, setLoginModalOpen] = useState(false);
+  const [snackMsg, setSnackMsg] = useState('');
 
   const [loadUser, { data, refetch }] = useLazyQuery(USER_QUERY);
+  const [changeUserName] = useMutation(CHANGE_NAME_QUERY, {
+    onCompleted() {
+      setSnackMsg(t`Your display name has been updated.`);
+    },
+  });
 
   const toggleSidebar = useCallback(() => setSidebarOpen(open => !open), []);
 
   const openLoginModal = useCallback(() => setLoginModalOpen(true), []);
 
   const logout = useCallback(() => apiLogout().then(refetch), [refetch]);
+
+  const userName = data?.GetUser?.name;
+  const handleNameChange = useCallback(() => {
+    const newName = window.prompt(t`Please enter new display name`, userName);
+    if (newName === null) return;
+
+    const trimmed = newName.trim();
+    if (trimmed.length === 0) {
+      setSnackMsg(t`Display name cannot be empty.`);
+      return;
+    }
+
+    changeUserName({ variables: { name: trimmed } });
+  }, [userName, changeUserName]);
 
   const classes = useStyles();
 
@@ -85,6 +117,7 @@ function AppLayout({ children, container = true }) {
         onMenuButtonClick={toggleSidebar}
         onLoginModalOpen={openLoginModal}
         onLogout={logout}
+        onNameChange={handleNameChange}
       />
       <AppSidebar
         open={sidebarOpen}
@@ -92,6 +125,7 @@ function AppLayout({ children, container = true }) {
         user={data?.GetUser}
         onLoginModalOpen={openLoginModal}
         onLogout={logout}
+        onNameChange={handleNameChange}
       />
       {container ? (
         <Container className={classes.container}>{children}</Container>
@@ -102,6 +136,11 @@ function AppLayout({ children, container = true }) {
       {loginModalOpen && (
         <LoginModal onClose={() => setLoginModalOpen(false)} />
       )}
+      <Snackbar
+        open={snackMsg}
+        onClose={() => setSnackMsg('')}
+        message={snackMsg}
+      />
     </Fragment>
   );
 }

--- a/components/AppLayout/AppLayout.js
+++ b/components/AppLayout/AppLayout.js
@@ -91,6 +91,7 @@ function AppLayout({ children, container = true }) {
         toggle={setSidebarOpen}
         user={data?.GetUser}
         onLoginModalOpen={openLoginModal}
+        onLogout={logout}
       />
       {container ? (
         <Container className={classes.container}>{children}</Container>

--- a/components/AppLayout/AppSidebar.js
+++ b/components/AppLayout/AppSidebar.js
@@ -63,7 +63,14 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-function AppSidebar({ open, toggle, user, onLoginModalOpen }) {
+function AppSidebar({
+  open,
+  toggle,
+  user,
+  onLoginModalOpen,
+  onLogout,
+  onNameChange,
+}) {
   const classes = useStyles();
 
   return (
@@ -144,14 +151,16 @@ function AppSidebar({ open, toggle, user, onLoginModalOpen }) {
           <GoogleWebsiteTranslator />
         </ListItem>
       </List>
-      {true && (
+      {user && (
         <>
           <Divider classes={{ root: classes.divider }} />
           <List className={classes.list}>
-            <ListItem classes={{ root: classes.listItem }} button>
-              <NavLink external href="#">
-                {t`Logout`}
-              </NavLink>
+            <ListItem
+              classes={{ root: classes.listItem }}
+              button
+              onClick={onLogout}
+            >
+              {t`Logout`}
             </ListItem>
           </List>
         </>

--- a/components/AppLayout/AppSidebar.js
+++ b/components/AppLayout/AppSidebar.js
@@ -89,7 +89,13 @@ function AppSidebar({
           <Ribbon className={classes.level}>
             <strong>Lv. {user?.level}</strong> {LEVEL_NAMES[(user?.level)]}
           </Ribbon>
-          <Box px={1.5} pb={2} display="flex" alignItems="center">
+          <Box
+            px={1.5}
+            pb={2}
+            display="flex"
+            alignItems="center"
+            onClick={onNameChange}
+          >
             <Widgets.Avatar user={user} size={60} />
             <Typography className={classes.name} variant="h6">
               {user?.name}


### PR DESCRIPTION
Before the 10/24 hackathon I would like to add a very simple edit name function, so that editors can change their display name as they wish.

Also fixes logout in mobile menu.

![change-name-desktop](https://user-images.githubusercontent.com/108608/96909442-9fb31980-14d0-11eb-8ccc-45e8746e6a75.gif)
![change-name-mobile](https://user-images.githubusercontent.com/108608/96909468-a93c8180-14d0-11eb-9b1e-18a1222a0c9a.gif)

Also deployed to staging site for preview.
