### PR TITLE
[Profile-04] Edit profile dialog

### DIFF
--- a/components/ProfilePage/EditProfileDialog.js
+++ b/components/ProfilePage/EditProfileDialog.js
@@ -12,6 +12,7 @@ import TextField from '@material-ui/core/TextField';
 
 const EditProfileDialogUserData = gql`
   fragment EditProfileDialogUserData on User {
+    id
     name
     slug
     bio
@@ -39,7 +40,11 @@ function EditProfileDialog({ user, onClose = () => {} }) {
     e.preventDefault();
     const form = e.target;
     updateUser({
-      variables: { name: form.name, slug: form.slug, bio: form.bio },
+      variables: {
+        name: form.name.value,
+        slug: form.slug.value,
+        bio: form.bio.value,
+      },
     });
   };
 

--- a/components/ProfilePage/EditProfileDialog.js
+++ b/components/ProfilePage/EditProfileDialog.js
@@ -61,6 +61,8 @@ function EditProfileDialog({ user, onClose = () => {} }) {
             label={t`Display name`}
             name="name"
             defaultValue={user.name}
+            fullWidth
+            margin="dense"
             required
           />
           <TextField
@@ -69,12 +71,17 @@ function EditProfileDialog({ user, onClose = () => {} }) {
             value={slug || ''}
             onChange={e => setSlug(e.target.value)}
             helperText={t`Your profile URL will become ${profileURL}`}
+            fullWidth
+            margin="dense"
           />
           <TextField
             label={t`Bio`}
             name="bio"
             defaultValue={user.bio}
             multiline
+            rows={3}
+            fullWidth
+            margin="dense"
           />
         </DialogContent>
         <DialogActions>

--- a/components/ProfilePage/EditProfileDialog.js
+++ b/components/ProfilePage/EditProfileDialog.js
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { t } from 'ttag';
+import gql from 'graphql-tag';
+import { useMutation } from '@apollo/react-hooks';
+
+import Dialog from '@material-ui/core/Dialog';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
+import DialogActions from '@material-ui/core/DialogActions';
+import Button from '@material-ui/core/Button';
+import TextField from '@material-ui/core/TextField';
+
+const EditProfileDialogUserData = gql`
+  fragment EditProfileDialogUserData on User {
+    name
+    slug
+    bio
+  }
+`;
+
+const UPDATE_USER = gql`
+  mutation UpdateSelfProfile($name: String, $slug: String, $bio: String) {
+    UpdateUser(name: $name, slug: $slug, bio: $bio) {
+      ...EditProfileDialogUserData
+    }
+  }
+  ${EditProfileDialogUserData}
+`;
+
+function EditProfileDialog({ user, onClose = () => {} }) {
+  const [updateUser, { loading }] = useMutation(UPDATE_USER, {
+    onCompleted() {
+      onClose();
+    },
+  });
+  const [slug, setSlug] = useState(user.slug);
+
+  const handleSubmit = e => {
+    e.preventDefault();
+    const form = e.target;
+    updateUser({
+      variables: { name: form.name, slug: form.slug, bio: form.bio },
+    });
+  };
+
+  const profileURL = `${location.origin}/user/${
+    slug ? encodeURIComponent(slug) : `[${t`Username`}]`
+  }`;
+
+  return (
+    <Dialog onClose={onClose} open>
+      <DialogTitle>{t`Edit profile`}</DialogTitle>
+      <form onSubmit={handleSubmit}>
+        <DialogContent dividers>
+          <TextField
+            label={t`Display name`}
+            name="name"
+            defaultValue={user.name}
+            required
+          />
+          <TextField
+            label={t`Username`}
+            name="slug"
+            value={slug || ''}
+            onChange={e => setSlug(e.target.value)}
+            helperText={t`Your profile URL will become ${profileURL}`}
+          />
+          <TextField
+            label={t`Bio`}
+            name="bio"
+            defaultValue={user.bio}
+            multiline
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={onClose}>{t`Cancel`}</Button>
+          <Button
+            color="primary"
+            type="submit"
+            disabled={loading}
+          >{t`Submit`}</Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  );
+}
+
+EditProfileDialog.fragments = { EditProfileDialogUserData };
+
+export default EditProfileDialog;

--- a/components/ProfilePage/ProfilePage.js
+++ b/components/ProfilePage/ProfilePage.js
@@ -1,6 +1,8 @@
+import { useEffect } from 'react';
 import gql from 'graphql-tag';
 import { t } from 'ttag';
 import { useQuery } from '@apollo/react-hooks';
+import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Container from '@material-ui/core/Container';
 
@@ -41,6 +43,17 @@ function ProfilePage({ id, slug }) {
   });
 
   const isSelf = currentUser && data?.GetUser?.id === currentUser.id;
+
+  // Automatic redirect to (new) slug
+  //
+  const router = useRouter();
+  const latestSlug = data?.GetUser?.slug; // slug may update after user edits
+  useEffect(() => {
+    const targetPath = `/user/${latestSlug}`;
+    if (latestSlug && window.location.pathname !== targetPath) {
+      router.replace(targetPath);
+    }
+  }, [latestSlug, router]);
 
   if (loading) {
     return (

--- a/components/ProfilePage/UserPageHeader.js
+++ b/components/ProfilePage/UserPageHeader.js
@@ -65,9 +65,17 @@ const useStyles = makeStyles(theme => ({
       padding: '0 16px',
     },
   },
-  name: {
+  nameSection: {
     display: 'flex',
     alignItems: 'center',
+  },
+  name: {
+    flex: '1 1 0',
+    display: '-webkit-box',
+    overflow: 'hidden',
+    boxOrient: 'vertical',
+    textOverflow: 'ellipsis',
+    lineClamp: 2,
   },
   editButton: { borderRadius: 15 },
   progress: {
@@ -149,11 +157,11 @@ function UserPageHeader({ user, isSelf }) {
           <Avatar user={user} size={100} />
         </Hidden>
         <div className={classes.info}>
-          <div className={classes.name}>
+          <div className={classes.nameSection}>
             <Hidden implementation="css" mdUp>
               <Avatar user={user} size={60} style={{ marginRight: 12 }} />
             </Hidden>
-            <Typography variant="h6" style={{ marginRight: 'auto' }}>
+            <Typography variant="h6" className={classes.name}>
               {user.name}
             </Typography>
             <Hidden implementation="css" mdUp>

--- a/components/ProfilePage/UserPageHeader.js
+++ b/components/ProfilePage/UserPageHeader.js
@@ -1,11 +1,12 @@
+import { useState } from 'react';
 import gql from 'graphql-tag';
 import { t, jt } from 'ttag';
 import Button from '@material-ui/core/Button';
 import Typography from '@material-ui/core/Typography';
 import Hidden from '@material-ui/core/Hidden';
-import { makeStyles } from '@material-ui/core/styles';
+import { makeStyles, ThemeProvider } from '@material-ui/core/styles';
 
-import { withDarkTheme } from 'lib/theme';
+import { lightTheme, withDarkTheme } from 'lib/theme';
 import { linkify, nl2br } from 'lib/text';
 import LEVEL_NAMES from 'constants/levelNames';
 import { LINE_URL } from 'constants/urls';
@@ -15,6 +16,7 @@ import LevelIcon from 'components/LevelIcon';
 import LevelProgressBar from 'components/AppLayout/Widgets/LevelProgressBar';
 import Avatar from 'components/AppLayout/Widgets/Avatar';
 import Stats from './Stats';
+import EditProfileDialog from './EditProfileDialog';
 
 import cx from 'clsx';
 
@@ -110,9 +112,15 @@ const useStyles = makeStyles(theme => ({
  */
 function UserPageHeader({ user, isSelf }) {
   const classes = useStyles();
+  const [isEditDialogOpen, setEditDialogOpen] = useState(false);
 
   const editButtonElem = isSelf && (
-    <Button className={classes.editButton} size="small" variant="outlined">
+    <Button
+      className={classes.editButton}
+      size="small"
+      variant="outlined"
+      onClick={() => setEditDialogOpen(true)}
+    >
       {t`Edit`}
     </Button>
   );
@@ -177,6 +185,15 @@ function UserPageHeader({ user, isSelf }) {
           <Stats userId={user.id} />
         </aside>
       </div>
+
+      {isEditDialogOpen && (
+        <ThemeProvider theme={lightTheme}>
+          <EditProfileDialog
+            user={user}
+            onClose={() => setEditDialogOpen(false)}
+          />
+        </ThemeProvider>
+      )}
     </header>
   );
 }
@@ -197,10 +214,12 @@ exported.fragments = {
       }
       ...AvatarData
       ...LevelProgressBarData
+      ...EditProfileDialogUserData
     }
 
     ${Avatar.fragments.AvatarData}
     ${LevelProgressBar.fragments.LevelProgressBarData}
+    ${EditProfileDialog.fragments.EditProfileDialogUserData}
   `,
 };
 


### PR DESCRIPTION
This feature doesn't have figma.

- Allows user to edit display name, username (in URL), and bio.
- Updates UI after edit
- When the user have a slug (or updates a slug), redirect to URL with slug (`/user/[slug]`)
- App menu should always show progress bar as [in figma](https://www.figma.com/file/zpD45j8nqDB2XfA6m2QskO/Cofacts-website?node-id=0%3A1)
- remove the makeshift rename function introduced in #352 

## Screenshots

### Normal edit
![no slug change](https://user-images.githubusercontent.com/108608/102719441-25184600-4329-11eb-9666-8c60635ae0c5.gif)

### Edit involves slug

Notice the URL changes as we save the new slug.

![slug-change](https://user-images.githubusercontent.com/108608/102719444-28133680-4329-11eb-95b8-e0ef166db375.gif)

### Redirect `/user?id=xxx` to slug when available
![redirect userid](https://user-images.githubusercontent.com/108608/102719496-7b858480-4329-11eb-9333-3e2b26a9c383.gif)

### Long names
<img width="573" alt="image" src="https://user-images.githubusercontent.com/108608/102744554-19faff80-4395-11eb-957d-efab9756beb9.png">

### Side menu
<img width="575" alt="image" src="https://user-images.githubusercontent.com/108608/102744573-25e6c180-4395-11eb-9bcc-009eff0c9407.png">

<img width="1186" alt="image" src="https://user-images.githubusercontent.com/108608/102744612-39922800-4395-11eb-8b91-f024da4a479c.png">

