### PR TITLE
[Profile-06] Replied messages in profile page

### DIFF
--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -49,7 +49,7 @@ const useStyles = makeStyles(theme => ({
       color: theme.palette.secondary[500],
       overflow: 'hidden',
       margin: 0,
-      display: 'box',
+      display: '-webkit-box',
       boxOrient: 'vertical',
       textOverflow: 'ellipsis',
       lineClamp: 2,

--- a/components/ProfilePage/ProfilePage.js
+++ b/components/ProfilePage/ProfilePage.js
@@ -22,6 +22,19 @@ const useStyles = makeStyles(theme => ({
       marginBottom: theme.spacing(2),
     },
   },
+  tabs: {
+    margin: '0 var(--card-px)',
+    paddingTop: theme.spacing(1),
+    position: 'relative', // for ::after
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      bottom: 0,
+      left: 0,
+      right: 0,
+      borderBottom: `1px solid ${theme.palette.secondary[100]}`,
+    },
+  },
 }));
 
 const LOAD_USER = gql`
@@ -123,7 +136,10 @@ function ProfilePage({ id, slug }) {
         />
         <Card>
           <Tabs
+            classes={{ root: classes.tabs }}
             value={tab}
+            indicatorColor="primary"
+            textColor="primary"
             onChange={(e, tab) => {
               router.push({ query: { tab } });
             }}

--- a/components/ProfilePage/ProfilePage.js
+++ b/components/ProfilePage/ProfilePage.js
@@ -41,6 +41,9 @@ const LOAD_CONTRIBUTION = gql`
     ) {
       totalCount
     }
+    commentedReplies: ListArticleReplyFeedbacks(filter: { userId: $id }) {
+      totalCount
+    }
   }
 `;
 
@@ -110,7 +113,14 @@ function ProfilePage({ id, slug }) {
         <title>{data.GetUser.name}</title>
       </Head>
       <Container maxWidth="md" className={classes.container}>
-        <UserPageHeader user={data.GetUser} isSelf={isSelf} />
+        <UserPageHeader
+          user={data.GetUser}
+          isSelf={isSelf}
+          stats={{
+            repliedArticles: contributionData?.repliedArticles?.totalCount,
+            commentedReplies: contributionData?.commentedReplies?.totalCount,
+          }}
+        />
         <Card>
           <Tabs
             value={tab}

--- a/components/ProfilePage/ProfilePage.js
+++ b/components/ProfilePage/ProfilePage.js
@@ -1,15 +1,28 @@
 import { useEffect } from 'react';
+import { useRouter } from 'next/router';
 import gql from 'graphql-tag';
 import { t } from 'ttag';
 import { useQuery } from '@apollo/react-hooks';
-import { useRouter } from 'next/router';
 import Head from 'next/head';
 import Container from '@material-ui/core/Container';
+import { Tabs, Tab } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
 
 import useCurrentUser from 'lib/useCurrentUser';
 
 import AppLayout from 'components/AppLayout';
+import { Card } from 'components/Card';
 import UserPageHeader from './UserPageHeader';
+import RepliedArticleTab from './RepliedArticleTab';
+
+const useStyles = makeStyles(theme => ({
+  container: {
+    flex: 1,
+    '& > *': {
+      marginBottom: theme.spacing(2),
+    },
+  },
+}));
 
 const LOAD_USER = gql`
   query LoadProfilePage($id: String, $slug: String) {
@@ -17,29 +30,29 @@ const LOAD_USER = gql`
       id
       ...UserHeaderData
     }
-    ListReplies(filter: { userId: $id }, orderBy: [{ createdAt: DESC }]) {
-      edges {
-        node {
-          id
-          text
-          articleReplies(status: NORMAL) {
-            article {
-              id
-              text
-            }
-          }
-        }
-      }
-    }
   }
   ${UserPageHeader.fragments.UserHeaderData}
 `;
 
-function ProfilePage({ id, slug }) {
-  const currentUser = useCurrentUser();
+const LOAD_CONTRIBUTION = gql`
+  query LoadContribution($id: String!) {
+    repliedArticles: ListArticles(
+      filter: { articleRepliesFrom: { userId: $id, exists: true } }
+    ) {
+      totalCount
+    }
+  }
+`;
 
+function ProfilePage({ id, slug }) {
+  const classes = useStyles();
+  const currentUser = useCurrentUser();
   const { data, loading } = useQuery(LOAD_USER, {
     variables: { id, slug },
+  });
+  const { data: contributionData } = useQuery(LOAD_CONTRIBUTION, {
+    variables: { id: data?.GetUser?.id },
+    skip: !data?.GetUser?.id,
   });
 
   const isSelf = currentUser && data?.GetUser?.id === currentUser.id;
@@ -61,7 +74,9 @@ function ProfilePage({ id, slug }) {
         <Head>
           <title>{t`Loading`}</title>
         </Head>
-        <Container maxWidth="md">Loading...</Container>
+        <Container maxWidth="md" className={classes.container}>
+          Loading...
+        </Container>
       </AppLayout>
     );
   }
@@ -72,9 +87,21 @@ function ProfilePage({ id, slug }) {
         <Head>
           <title>{t`User not found`}</title>
         </Head>
-        <Container maxWidth="md">{t`The user does not exist`}</Container>
+        <Container maxWidth="md" className={classes.container}>
+          {t`The user does not exist`}
+        </Container>
       </AppLayout>
     );
+  }
+
+  const {
+    query: { tab = 'replies' },
+  } = router;
+  let contentElem = null;
+  switch (tab) {
+    case 'replies':
+    default:
+      contentElem = <RepliedArticleTab userId={data?.GetUser?.id} />;
   }
 
   return (
@@ -82,13 +109,24 @@ function ProfilePage({ id, slug }) {
       <Head>
         <title>{data.GetUser.name}</title>
       </Head>
-      <Container maxWidth="md">
+      <Container maxWidth="md" className={classes.container}>
         <UserPageHeader user={data.GetUser} isSelf={isSelf} />
-
-        <div style={{ minHeight: '100vh' /* temp stub */ }}>
-          {/* <pre>{JSON.stringify(data, null, '  ')}</pre> */}
-          {/* {isSelf ? 'self' : 'not self'} */}
-        </div>
+        <Card>
+          <Tabs
+            value={tab}
+            onChange={(e, tab) => {
+              router.push({ query: { tab } });
+            }}
+          >
+            <Tab
+              value="replies"
+              label={`${t`Replied messages`} ${
+                contributionData?.repliedArticles?.totalCount
+              }`}
+            />
+          </Tabs>
+          {contentElem}
+        </Card>
       </Container>
     </AppLayout>
   );

--- a/components/ProfilePage/RepliedArticleTab.js
+++ b/components/ProfilePage/RepliedArticleTab.js
@@ -94,8 +94,12 @@ const useStyles = makeStyles(theme => ({
     margin: '0 var(--card-px)',
     background: theme.palette.secondary[50],
   },
+  articleReply: {
+    '& + &': { marginTop: 24 },
+  },
   bustHoaxDivider: {
     border: 0,
+    margin: '16px 0',
     borderBottom: `1px dashed ${theme.palette.secondary[100]}`,
   },
   infos: {
@@ -104,6 +108,8 @@ const useStyles = makeStyles(theme => ({
       marginBottom: 12,
     },
   },
+  reply: { marginLeft: 56 },
+  replyControl: { marginTop: 16 },
 }));
 
 function ArticleReply({ articleReply }) {
@@ -112,22 +118,32 @@ function ArticleReply({ articleReply }) {
   const { user, reply, createdAt } = articleReply;
 
   return (
-    <>
-      <Box component="header" display="flex" alignItems="center">
-        {user && <Avatar user={user} className={classes.avatar} hasLink />}
+    <article className={classes.articleReply}>
+      <Box
+        component="header"
+        display="flex"
+        alignItems="center"
+        mb={1}
+        style={{ gap: '16px' }}
+      >
+        {user && (
+          <Avatar size={40} user={user} className={classes.avatar} hasLink />
+        )}
         <Box flexGrow={1}>
           <ArticleReplySummary articleReply={articleReply} />
           <ReplyInfo reply={reply} articleReplyCreatedAt={createdAt} />
         </Box>
       </Box>
-      <section className={classes.content}>
-        <ExpandableText lineClamp={10}>
+      <section className={classes.reply}>
+        <ExpandableText lineClamp={4}>
           {nl2br(linkify(reply.text))}
         </ExpandableText>
+        <ArticleReplyFeedbackControl
+          className={classes.replyControl}
+          articleReply={articleReply}
+        />
       </section>
-
-      <ArticleReplyFeedbackControl articleReply={articleReply} />
-    </>
+    </article>
   );
 }
 
@@ -233,7 +249,7 @@ function RepliedArticleTab({ userId }) {
                   {timeAgo => t`First reported ${timeAgo} ago`}
                 </TimeInfo>
               </Infos>
-              <ExpandableText lineClamp={2}>{article.text}</ExpandableText>
+              <ExpandableText lineClamp={3}>{article.text}</ExpandableText>
 
               <hr className={classes.bustHoaxDivider} />
 

--- a/components/ProfilePage/RepliedArticleTab.js
+++ b/components/ProfilePage/RepliedArticleTab.js
@@ -1,5 +1,217 @@
+import gql from 'graphql-tag';
+import { useQuery } from '@apollo/react-hooks';
+import Link from 'next/link';
+import { t, ngettext, msgid } from 'ttag';
+import { makeStyles } from '@material-ui/core/styles';
+import {
+  Tools,
+  Filters,
+  CategoryFilter,
+  ReplyTypeFilter,
+  TimeRange,
+  SortInput,
+  LoadMore,
+} from 'components/ListPageControls';
+import {
+  ListPageCards,
+  ListPageCard,
+  ReplyItem,
+} from 'components/ListPageDisplays';
+import Infos from 'components/Infos';
+import TimeInfo from 'components/Infos/TimeInfo';
+import ExpandableText from 'components/ExpandableText';
+
+const REPLIES_ORDER = [
+  { value: 'lastRepliedAt', label: t`Most recently replied` },
+  { value: 'lastRequestedAt', label: t`Most recently asked` },
+  { value: 'replyRequestCount', label: t`Most asked` },
+];
+const DEFAULT_ORDER = REPLIES_ORDER[0].value;
+
+const LOAD_REPLIED_ARTICLES = gql`
+  query LoadRepliedArticles($userId: String!) {
+    ListArticles(
+      filter: { articleRepliesFrom: { userId: $userId, exists: true } }
+    ) {
+      edges {
+        node {
+          id
+          replyRequestCount
+          createdAt
+          text
+          articleReplies(status: NORMAL) {
+            user {
+              id
+            }
+            reply {
+              id
+              ...ReplyItem
+            }
+            ...ReplyItemArticleReplyData
+          }
+        }
+        ...LoadMoreEdge
+      }
+    }
+  }
+  ${ReplyItem.fragments.ReplyItem}
+  ${ReplyItem.fragments.ReplyItemArticleReplyData}
+  ${LoadMore.fragments.LoadMoreEdge}
+`;
+
+const LOAD_REPLIED_ARTICLES_STAT = gql`
+  query LoadRepliedArticlesStat($userId: String!) {
+    ListArticles(
+      filter: { articleRepliesFrom: { userId: $userId, exists: true } }
+    ) {
+      ...LoadMoreConnectionForStats
+    }
+  }
+  ${LoadMore.fragments.LoadMoreConnectionForStats}
+`;
+
+const useStyles = makeStyles(theme => ({
+  bustHoaxDivider: {
+    fontSize: theme.typography.htmlFontSize,
+    textAlign: 'center',
+    position: 'relative', // For ::before
+    zIndex: 0, // Make a stacking context
+    margin: '8px 0 -8px',
+
+    '&:before': {
+      position: 'absolute',
+      top: '50%',
+      display: 'block',
+      height: '1px',
+      zIndex: -1,
+      width: '100%',
+      backgroundColor: theme.palette.secondary[100],
+      content: '""',
+    },
+    '& a': {
+      display: 'inline-block',
+      borderRadius: 30,
+      padding: '10px 26px',
+      fontSize: 14,
+      lineHeight: '16px',
+      textAlign: 'center',
+      backgroundColor: theme.palette.primary.main,
+      color: theme.palette.common.white,
+      border: `5px solid ${theme.palette.common.white}`,
+      [theme.breakpoints.up('md')]: {
+        fontSize: 16,
+      },
+    },
+  },
+  infos: {
+    marginBottom: 4,
+    [theme.breakpoints.up('md')]: {
+      marginBottom: 12,
+    },
+  },
+}));
+
 function RepliedArticleTab({ userId }) {
-  return <>Replied articles for {userId}</>;
+  const classes = useStyles();
+  const {
+    loading,
+    fetchMore,
+    data: listArticlesData,
+    error: listArticlesError,
+  } = useQuery(LOAD_REPLIED_ARTICLES, {
+    variables: { userId },
+    notifyOnNetworkStatusChange: true, // Make loading true on `fetchMore`
+  });
+
+  // Separate these stats query so that it will be cached by apollo-client and sends no network request
+  // on page change, but still works when filter options are updated.
+  //
+  const { data: listStatData } = useQuery(LOAD_REPLIED_ARTICLES_STAT);
+
+  // List data
+  const articleEdges = listArticlesData?.ListArticles?.edges || [];
+  const statsData = listStatData?.ListArticles || {};
+
+  return (
+    <>
+      <Tools>
+        <TimeRange />
+        <SortInput defaultOrderBy={DEFAULT_ORDER} options={REPLIES_ORDER} />
+      </Tools>
+      <Filters>
+        <ReplyTypeFilter />
+        <CategoryFilter />
+      </Filters>
+      {loading && !articleEdges.length ? (
+        t`Loading...`
+      ) : listArticlesError ? (
+        listArticlesError.toString()
+      ) : (
+        <>
+          <ListPageCards>
+            {articleEdges.map(({ node: article }) => (
+              <ListPageCard key={article.id}>
+                <Infos className={classes.infos}>
+                  <>
+                    {ngettext(
+                      msgid`${article.replyRequestCount} occurrence`,
+                      `${article.replyRequestCount} occurrences`,
+                      article.replyRequestCount
+                    )}
+                  </>
+                  <TimeInfo time={article.createdAt}>
+                    {timeAgo => t`First reported ${timeAgo} ago`}
+                  </TimeInfo>
+                </Infos>
+                <ExpandableText lineClamp={2}>{article.text}</ExpandableText>
+
+                <div
+                  className={classes.bustHoaxDivider}
+                  data-ga="Bust hoax button"
+                >
+                  <Link href="/article/[id]" as={`/article/${article.id}`}>
+                    <a>{t`Bust Hoaxes`}</a>
+                  </Link>
+                </div>
+
+                {article.articleReplies
+                  .filter(articleReply => userId === articleReply.user.id)
+                  .map(({ reply, ...articleReply }) => (
+                    <ReplyItem
+                      key={reply.id}
+                      articleReply={articleReply}
+                      reply={reply}
+                    />
+                  ))}
+              </ListPageCard>
+            ))}
+          </ListPageCards>
+
+          <LoadMore
+            edges={articleEdges}
+            pageInfo={statsData?.pageInfo}
+            loading={loading}
+            onMoreRequest={args =>
+              fetchMore({
+                variables: args,
+                updateQuery(prev, { fetchMoreResult }) {
+                  if (!fetchMoreResult) return prev;
+                  const newArticleData = fetchMoreResult?.ListArticles;
+                  return {
+                    ...prev,
+                    ListArticles: {
+                      ...newArticleData,
+                      edges: [...articleEdges, ...newArticleData.edges],
+                    },
+                  };
+                },
+              })
+            }
+          />
+        </>
+      )}
+    </>
+  );
 }
 
 export default RepliedArticleTab;

--- a/components/ProfilePage/RepliedArticleTab.js
+++ b/components/ProfilePage/RepliedArticleTab.js
@@ -230,9 +230,11 @@ function RepliedArticleTab({ userId }) {
         <CategoryFilter />
       </Filters>
       {loading && !articleEdges.length ? (
-        t`Loading...`
+        <CardContent>{t`Loading...`}</CardContent>
       ) : listArticlesError ? (
-        listArticlesError.toString()
+        <CardContent>{listArticlesError.toString()}</CardContent>
+      ) : articleEdges.length === 0 ? (
+        <CardContent>{t`No replied messages.`}</CardContent>
       ) : (
         <>
           {articleEdges.map(({ node: article }) => (

--- a/components/ProfilePage/RepliedArticleTab.js
+++ b/components/ProfilePage/RepliedArticleTab.js
@@ -1,7 +1,6 @@
 import gql from 'graphql-tag';
 import { useQuery } from '@apollo/react-hooks';
 import { useRouter } from 'next/router';
-import Link from 'next/link';
 import { t, ngettext, msgid } from 'ttag';
 import { Box } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
@@ -85,6 +84,16 @@ const LOAD_REPLIED_ARTICLES_STAT = gql`
 `;
 
 const useStyles = makeStyles(theme => ({
+  tools: {
+    [theme.breakpoints.up('sm')]: {
+      marginLeft: 'var(--card-px)',
+      marginRight: 'var(--card-px)',
+    },
+  },
+  filters: {
+    margin: '0 var(--card-px)',
+    background: theme.palette.secondary[50],
+  },
   bustHoaxDivider: {
     border: 0,
     borderBottom: `1px dashed ${theme.palette.secondary[100]}`,
@@ -196,11 +205,11 @@ function RepliedArticleTab({ userId }) {
 
   return (
     <>
-      <Tools>
+      <Tools className={classes.tools}>
         <TimeRange />
         <SortInput defaultOrderBy={DEFAULT_ORDER} options={REPLIES_ORDER} />
       </Tools>
-      <Filters>
+      <Filters className={classes.filters}>
         <ReplyTypeFilter />
         <CategoryFilter />
       </Filters>

--- a/components/ProfilePage/RepliedArticleTab.js
+++ b/components/ProfilePage/RepliedArticleTab.js
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 import { useQuery } from '@apollo/react-hooks';
 import { useRouter } from 'next/router';
 import Link from 'next/link';
-import { t, jt, ngettext, msgid } from 'ttag';
+import { t, ngettext, msgid } from 'ttag';
 import { Box } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 import {
@@ -19,12 +19,11 @@ import Infos from 'components/Infos';
 import TimeInfo from 'components/Infos/TimeInfo';
 import ExpandableText from 'components/ExpandableText';
 import ArticleReplyFeedbackControl from 'components/ArticleReplyFeedbackControl';
-import ProfileLink from 'components/ProfileLink';
+import ArticleReplySummary from 'components/ArticleReplySummary';
 import Avatar from 'components/AppLayout/Widgets/Avatar';
 import ReplyInfo from 'components/ReplyInfo';
 
 import { nl2br, linkify } from 'lib/text';
-import { TYPE_NAME } from 'constants/replyType';
 
 const REPLIES_ORDER = [
   { value: 'lastRepliedAt', label: t`Most recently replied` },
@@ -48,19 +47,17 @@ const LOAD_REPLIED_ARTICLES = gql`
           text
           articleReplies(status: NORMAL) {
             replyId
-            replyType
             createdAt
             user {
               id
-              name
               ...AvatarData
-              ...ProfileLinkUserData
             }
             reply {
               id
               text
               ...ReplyInfo
             }
+            ...ArticleReplySummaryData
             ...ArticleReplyFeedbackControlData
           }
         }
@@ -72,7 +69,7 @@ const LOAD_REPLIED_ARTICLES = gql`
   ${LoadMore.fragments.LoadMoreEdge}
   ${ReplyInfo.fragments.replyInfo}
   ${Avatar.fragments.AvatarData}
-  ${ProfileLink.fragments.ProfileLinkUserData}
+  ${ArticleReplySummary.fragments.ArticleReplySummaryData}
 `;
 
 const LOAD_REPLIED_ARTICLES_STAT = gql`
@@ -103,22 +100,14 @@ const useStyles = makeStyles(theme => ({
 function ArticleReply({ articleReply }) {
   const classes = useStyles();
 
-  const { replyType, user, reply, createdAt } = articleReply;
-
-  const authorElem = (
-    <ProfileLink key="editor" user={user}>
-      <span>{user?.name || t`Someone`}</span>
-    </ProfileLink>
-  );
+  const { user, reply, createdAt } = articleReply;
 
   return (
     <>
       <Box component="header" display="flex" alignItems="center">
         {user && <Avatar user={user} className={classes.avatar} hasLink />}
         <Box flexGrow={1}>
-          <div className={classes.replyType}>
-            {jt`${authorElem} mark this message ${TYPE_NAME[replyType]}`}
-          </div>
+          <ArticleReplySummary articleReply={articleReply} />
           <ReplyInfo reply={reply} articleReplyCreatedAt={createdAt} />
         </Box>
       </Box>

--- a/components/ProfilePage/RepliedArticleTab.js
+++ b/components/ProfilePage/RepliedArticleTab.js
@@ -1,0 +1,5 @@
+function RepliedArticleTab({ userId }) {
+  return <>Replied articles for {userId}</>;
+}
+
+export default RepliedArticleTab;

--- a/components/ProfilePage/Stats.js
+++ b/components/ProfilePage/Stats.js
@@ -1,23 +1,8 @@
-import gql from 'graphql-tag';
 import { useSpring, animated } from 'react-spring';
 import { t } from 'ttag';
-import { useQuery } from '@apollo/react-hooks';
 import Typography from '@material-ui/core/Typography';
 
 import { makeStyles } from '@material-ui/core/styles';
-
-const LOAD_USER_STATS = gql`
-  query LoadUserStats($userId: String!) {
-    repliedArticles: ListArticles(
-      filter: { articleRepliesFrom: { userId: $userId, exists: true } }
-    ) {
-      totalCount
-    }
-    commentedReplies: ListArticleReplyFeedbacks(filter: { userId: $userId }) {
-      totalCount
-    }
-  }
-`;
 
 const useStyles = makeStyles(() => ({
   root: {
@@ -62,23 +47,18 @@ function Stat({ value, label }) {
   );
 }
 
-function Stats({ userId }) {
+/**
+ *
+ * @param {string} props.userId
+ * @param {{repliedArticles: number, commentedReplies: number}} props.stats
+ */
+function Stats({ stats }) {
   const classes = useStyles();
-  const { data } = useQuery(LOAD_USER_STATS, {
-    ssr: false, // Calculating these numbers are expensive; cralwers also don't need these numbers.
-    variables: { userId },
-  });
 
   return (
     <ul className={classes.root}>
-      <Stat
-        label={t`replied messages`}
-        value={data?.repliedArticles?.totalCount}
-      />
-      <Stat
-        label={t`voted replies`}
-        value={data?.commentedReplies?.totalCount}
-      />
+      <Stat label={t`replied messages`} value={stats?.repliedArticles} />
+      <Stat label={t`voted replies`} value={stats?.commentedReplies} />
     </ul>
   );
 }

--- a/components/ProfilePage/UserPageHeader.js
+++ b/components/ProfilePage/UserPageHeader.js
@@ -87,7 +87,7 @@ const useStyles = makeStyles(theme => ({
   bio: {
     marginTop: 8,
     overflow: 'hidden',
-    display: 'box',
+    display: '-webkit-box',
     boxOrient: 'vertical',
     textOverflow: 'ellipsis',
     lineClamp: 3,

--- a/components/ProfilePage/UserPageHeader.js
+++ b/components/ProfilePage/UserPageHeader.js
@@ -117,8 +117,9 @@ const useStyles = makeStyles(theme => ({
  *
  * @param {object} props.user
  * @param {boolean} props.isSelf - If the current user is the one in `user` prop
+ * @param {{repliedArticles: number, commentedReplies: number}} props.stats
  */
-function UserPageHeader({ user, isSelf }) {
+function UserPageHeader({ user, isSelf, stats }) {
   const classes = useStyles();
   const [isEditDialogOpen, setEditDialogOpen] = useState(false);
 
@@ -190,7 +191,7 @@ function UserPageHeader({ user, isSelf }) {
           <Hidden implementation="css" smDown>
             {isSelf && editButtonElem}
           </Hidden>
-          <Stats userId={user.id} />
+          <Stats stats={stats} />
         </aside>
       </div>
 


### PR DESCRIPTION
- Implements "Replied article" tab in Profile page
    - [Figma](https://www.figma.com/file/zpD45j8nqDB2XfA6m2QskO/Cofacts-website?node-id=3752%3A444)
    - Supports filtering & sorting
    - Known issue: `?slug=xxx` will be included in URL when filtering & sorting for users with slug.
- Move statistics data loading up, from `Stats` to `ProfilePage`
    - As tabs will also include number of replied articles / feedback etc, we should load once in `ProfilePage` and pass down
- Refactor: fix `line-clamp` on Firefox
    - `line-clamp` requires `display: -webkit-box`. The `-webkit` prefix is mandatory even on Firefox.

## Desktop
![image](https://user-images.githubusercontent.com/108608/103482582-9b827100-4e1c-11eb-95b7-0081e5ace48b.png)

## Mobile
![image](https://user-images.githubusercontent.com/108608/103482660-059b1600-4e1d-11eb-992b-5269446c7fdd.png)

## Articles replied two times
![image](https://user-images.githubusercontent.com/108608/103482600-b1903180-4e1c-11eb-8a69-96837e0e0c7a.png)

## Firefox
![image](https://user-images.githubusercontent.com/108608/103482543-66761e80-4e1c-11eb-96f1-5390368cb409.png)
