### PR TITLE
Avoid attaching text for logged in users

### DIFF
--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -394,7 +394,10 @@ function ArticlePage() {
             </div>
           )}
 
-          <Card ref={replySectionRef} onCopy={handleCopy}>
+          <Card
+            ref={replySectionRef}
+            onCopy={currentUser ? undefined : handleCopy}
+          >
             <CardHeader>
               {ngettext(
                 msgid`There is ${replyCount} fact-checking reply to the message`,


### PR DESCRIPTION
Avoid attaching text for logged in users so that editors' copy-paste works better.

Fixes #350.

## Not logged in
Copied text will have footer text attached.
![with-footer](https://user-images.githubusercontent.com/108608/105948364-c53e5900-60a5-11eb-93fe-b5847e133e2c.gif)

## Logged in
Copied text will contain the selected text only.
![without-footer](https://user-images.githubusercontent.com/108608/105948387-cf605780-60a5-11eb-8a23-02e435ddb7a6.gif)
