### PR TITLE
[LandingPage] change links to tutorial instead

### DIFF
--- a/components/LandingPage/SectionContribute.js
+++ b/components/LandingPage/SectionContribute.js
@@ -1,11 +1,12 @@
 import { useEffect, useRef } from 'react';
+import Link from 'next/link';
 import cx from 'clsx';
 import { c, t } from 'ttag';
 import { makeStyles } from '@material-ui/core/styles';
 import Button from '@material-ui/core/Button';
 import { animated, useSpring } from 'react-spring';
 
-import { TUTORIAL, EDITOR_ENTRANCE, DEVELOPER_HOMEPAGE } from 'constants/urls';
+import { DEVELOPER_HOMEPAGE } from 'constants/urls';
 import { withDarkTheme } from 'lib/theme';
 
 import bg from './images/contribute-bg.png';
@@ -135,24 +136,16 @@ const SectionContribute = ({ className }) => {
                is the way to transcend this program into something great.`}
         </div>
         <div className={classes.actions}>
-          <Button
-            color="primary"
-            variant="contained"
-            href={TUTORIAL}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {t`I want to learn how to use Cofacts`}
-          </Button>
-          <Button
-            color="primary"
-            variant="contained"
-            href={EDITOR_ENTRANCE}
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            {t`I can help bust hoaxes`}
-          </Button>
+          <Link href="/tutorial?tab=check-rumors" passHref>
+            <Button color="primary" variant="contained">
+              {t`I want to learn how to use Cofacts`}
+            </Button>
+          </Link>
+          <Link href="/tutorial?tab=bust-hoaxes" passHref>
+            <Button color="primary" variant="contained">
+              {t`I can help bust hoaxes`}
+            </Button>
+          </Link>
           <Button
             color="primary"
             variant="contained"

--- a/components/LandingPage/SectionJoin.js
+++ b/components/LandingPage/SectionJoin.js
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import Link from 'next/link';
 import cx from 'clsx';
 import { c } from 'ttag';
 import { makeStyles } from '@material-ui/core/styles';
@@ -8,13 +9,6 @@ import { animated, useSpring } from 'react-spring';
 import { withDarkTheme } from 'lib/theme';
 import leftImage from './images/join-left.png';
 import rightImage from './images/join-right.png';
-
-const buttonLink = {
-  en_US:
-    'https://hackmd.io/@mrorz/SklM4dV9m/https%3A%2F%2Fg0v.hackmd.io%2Fz7PY2mQeSMyWBoZpaVhAPg?type=book',
-  zh_TW:
-    'https://beta.hackfoldr.org/1yXwRJwFNFHNJibKENnLCAV5xB8jnUvEwY_oUq-KcETU/https%253A%252F%252Fhackmd.io%252Fs%252FSyMRyrfEl',
-}[process.env.LOCALE];
 
 const useStyles = makeStyles(theme => ({
   sectionJoin: {
@@ -217,15 +211,11 @@ const SectionJoin = ({ className }) => {
               or are just full of a sense of justice and a desire for truth,
               YOU could be the next misinformation-busting warrior!`}
         </p>
-        <Button
-          className={classes.button}
-          variant="outlined"
-          href={buttonLink}
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          {c('landing page').t`Count me in!`}
-        </Button>
+        <Link href="/tutorial?bust-hoaxes" passHref>
+          <Button className={classes.button} variant="outlined">
+            {c('landing page').t`Count me in!`}
+          </Button>
+        </Link>
       </div>
       <animated.div
         className={classes.image}


### PR DESCRIPTION
"I want to learn how to use Cofacts" --> check hoax tutorial
![check-hoax](https://user-images.githubusercontent.com/108608/108720978-6cef5f80-755c-11eb-948e-2f4792436c91.gif)

"I can help bust hoax" --> bust hoax tutorial
![help-bust](https://user-images.githubusercontent.com/108608/108721250-c22b7100-755c-11eb-845b-8dc332a9ef5b.gif)

"Count me in" --> bust hoax tutorial
![count-me-in](https://user-images.githubusercontent.com/108608/108721280-c8b9e880-755c-11eb-8e39-fd12940578c2.gif)

