### PR TITLE
Make impact page server-rendered for GA env vars

### DIFF
--- a/pages/impact.js
+++ b/pages/impact.js
@@ -88,4 +88,9 @@ const Report = () => {
   );
 };
 
+// Make it server-rendered for PUBLIC_GA_TRACKING_ID
+export async function getServerSideProps() {
+  return { props: {} };
+}
+
 export default Report;


### PR DESCRIPTION
Currently on production, the GA environment variable is not set. Therefore, no traffic to /impact is being captured by Google Analytics at all.

This PR fixes the issue by disabling build-time optimization so that runtime env variables can be picked up.

<img width="1440" alt="截圖 2021-03-07 下午8 08 08" src="https://user-images.githubusercontent.com/108608/110239294-23057100-7f81-11eb-9483-471cda3eeba1.png">
