### PR TITLE
Revise time representation

### DIFF
--- a/components/Infos/TimeInfo.js
+++ b/components/Infos/TimeInfo.js
@@ -1,3 +1,4 @@
+import { t } from 'ttag';
 import Tooltip from 'components/Tooltip';
 import isValid from 'date-fns/isValid';
 import { useEffect, useState } from 'react';
@@ -14,10 +15,8 @@ function formatDateAbsolute(date, { forceYear = false } = {}) {
   let options = {
     day: 'numeric',
     month: 'short',
-    hour: 'numeric',
-    minute: 'numeric',
   };
-  if (now.getFullYear() != date.getFullYear() || forceYear) {
+  if (now.getFullYear() !== date.getFullYear() || forceYear) {
     options.year = 'numeric';
   }
 
@@ -25,18 +24,23 @@ function formatDateAbsolute(date, { forceYear = false } = {}) {
   return dtf.format(date);
 }
 
+const rtf = new Intl.RelativeTimeFormat(locale, {
+  style: 'narrow',
+  numeric: 'auto',
+});
+
 /**
  * Formats date as a relative time (e.g. X days ago).
  * Works best if date is in the past.
  */
 function formatDateRelative(date) {
-  const rtf = new Intl.RelativeTimeFormat(locale, { style: 'narrow' });
   const now = new Date();
-  const minsAgo = (now - date) / 1000 / 60;
+  const secsAgo = (now - date) / 1000;
+  const minsAgo = secsAgo / 60;
   const hoursAgo = minsAgo / 60;
 
   if (minsAgo < 1) {
-    return 'less than a minute ago';
+    return rtf.format(-Math.round(secsAgo), 'seconds');
   }
   // "60 min. ago" and "1 hr. ago" mean the same thing, so if 59.5 <= minsAgo < 90 we display "1 hr. ago".
   if (minsAgo < 59.5) {
@@ -52,9 +56,9 @@ function formatDateRelative(date) {
 /**
  * Formats the date as a relative time if within 23.5 hours, otherwise formats as an absolute time.
  */
-function formatDate(date) {
+export function formatDate(date) {
   const hoursAgo = (new Date() - date) / 1000 / 60 / 60;
-  if (hoursAgo < 23.5) {
+  if (hoursAgo < 48) {
     return formatDateRelative(date);
   } else {
     return formatDateAbsolute(date);

--- a/components/Infos/TimeInfo.js
+++ b/components/Infos/TimeInfo.js
@@ -9,7 +9,10 @@ const locale = (process.env.LOCALE || 'en_US').replace('_', '-');
  * Formats date as an absolute time, using local timezone.
  * Year will be omitted unless different from current year or forceYear = true.
  */
-function formatDateAbsolute(date, { forceYear = false } = {}) {
+function formatDateAbsolute(
+  date,
+  { forceYear = false, forceTime = false } = {}
+) {
   const now = new Date();
 
   let options = {
@@ -18,6 +21,10 @@ function formatDateAbsolute(date, { forceYear = false } = {}) {
   };
   if (now.getFullYear() !== date.getFullYear() || forceYear) {
     options.year = 'numeric';
+  }
+  if (forceTime) {
+    options.hour = 'numeric';
+    options.minute = 'numeric';
   }
 
   const dtf = new Intl.DateTimeFormat(locale, options);
@@ -96,7 +103,9 @@ function TimeInfo({ time, children = t => t }) {
   }
 
   return (
-    <Tooltip title={formatDateAbsolute(date, { forceYear: true })}>
+    <Tooltip
+      title={formatDateAbsolute(date, { forceYear: true, forceTime: true })}
+    >
       <time dateTime={date.toISOString()}>{children(timeAgoStr)}</time>
     </Tooltip>
   );

--- a/components/Infos/TimeInfo.js
+++ b/components/Infos/TimeInfo.js
@@ -61,7 +61,7 @@ function formatDateRelative(date) {
 }
 
 /**
- * Formats the date as a relative time if within 23.5 hours, otherwise formats as an absolute time.
+ * Formats the date as a relative time if it's near, otherwise formats as an absolute time.
  */
 export function formatDate(date) {
   const hoursAgo = (new Date() - date) / 1000 / 60 / 60;

--- a/components/Infos/TimeInfo.js
+++ b/components/Infos/TimeInfo.js
@@ -1,4 +1,4 @@
-import { t } from 'ttag';
+import differenceInCalendarDays from 'date-fns/differenceInCalendarDays';
 import Tooltip from 'components/Tooltip';
 import isValid from 'date-fns/isValid';
 import { useEffect, useState } from 'react';
@@ -50,7 +50,7 @@ function formatDateRelative(date) {
   if (hoursAgo < 23.5) {
     return rtf.format(-Math.round(hoursAgo), 'hours');
   }
-  return rtf.format(-Math.round(hoursAgo / 24), 'days');
+  return rtf.format(differenceInCalendarDays(date, now), 'days');
 }
 
 /**

--- a/components/Infos/__snapshots__/Infos.stories.storyshot
+++ b/components/Infos/__snapshots__/Infos.stories.storyshot
@@ -181,7 +181,7 @@ exports[`Storyshots Infos With Time Info 1`] = `
           onTouchStart={[Function]}
           title="Jun 4, 1989, 12:00 AM"
         >
-          Jun 4, 1989, 12:00 AM
+          Jun 4, 1989
         </time>
       </Tooltip>
     </TimeInfo>
@@ -205,7 +205,7 @@ exports[`Storyshots Infos With Time Info 1`] = `
           onTouchStart={[Function]}
           title="Jun 4, 1989, 12:00 AM"
         >
-          Jun 4, 1989, 12:00 AM
+          Jun 4, 1989
         </time>
       </Tooltip>
     </TimeInfo>
@@ -229,7 +229,7 @@ exports[`Storyshots Infos With Time Info 1`] = `
           onTouchStart={[Function]}
           title="Jun 4, 1989, 12:00 AM"
         >
-          Created Jun 4, 1989, 12:00 AM
+          Created Jun 4, 1989
         </time>
       </Tooltip>
     </TimeInfo>

--- a/components/Infos/__tests__/TimeInfo.js
+++ b/components/Infos/__tests__/TimeInfo.js
@@ -1,8 +1,8 @@
-import MockDate from "mockdate";
-import { formatDate } from "../TimeInfo";
+import MockDate from 'mockdate';
+import { formatDate } from '../TimeInfo';
 
-it("formatDate formats date", () => {
-  MockDate.set("2020-01-01");
+it('formatDate formats date', () => {
+  MockDate.set('2020-01-01T12:00:00Z');
   const now = new Date();
 
   expect(formatDate(now)).toMatchInlineSnapshot(`"now"`);
@@ -22,23 +22,33 @@ it("formatDate formats date", () => {
     formatDate(new Date(now - 1.5 * 60 * 60 * 1000))
   ).toMatchInlineSnapshot(`"2 hr. ago"`);
 
+  // 0.5 days and 1 seconds ago
+  expect(formatDate(new Date('2019-12-31T23:59:59Z'))).toMatchInlineSnapshot(
+    `"12 hr. ago"`
+  );
+
   // 1 day ago
-  expect(formatDate(new Date("2019-12-31"))).toMatchInlineSnapshot(
+  expect(formatDate(new Date('2019-12-31T12:00:00Z'))).toMatchInlineSnapshot(
     `"yesterday"`
   );
 
-  // 1.5 days ago (rounds up)
-  expect(
-    formatDate(new Date(now - 1.5 * 24 * 60 * 60 * 1000))
-  ).toMatchInlineSnapshot(`"2 days ago"`);
+  // 1.5 days ago, still in "yesterday"
+  expect(formatDate(new Date('2019-12-31T00:00:00Z'))).toMatchInlineSnapshot(
+    `"yesterday"`
+  );
 
-  // 2 days ago, uses absolute time
-  expect(formatDate(new Date("2019-12-30"))).toMatchInlineSnapshot(
+  // 1.5 days and 1 second ago, but it's the day before yesterday
+  expect(formatDate(new Date('2019-12-30T23:59:59Z'))).toMatchInlineSnapshot(
+    `"2 days ago"`
+  );
+
+  // exactly 2 days ago
+  expect(formatDate(new Date('2019-12-30T12:00:00Z'))).toMatchInlineSnapshot(
     `"Dec 30, 2019"`
   );
 
   // Many months ago
-  expect(formatDate(new Date("2019-06-30"))).toMatchInlineSnapshot(
+  expect(formatDate(new Date('2019-06-30'))).toMatchInlineSnapshot(
     `"Jun 30, 2019"`
   );
 

--- a/components/Infos/__tests__/TimeInfo.js
+++ b/components/Infos/__tests__/TimeInfo.js
@@ -1,0 +1,46 @@
+import MockDate from "mockdate";
+import { formatDate } from "../TimeInfo";
+
+it("formatDate formats date", () => {
+  MockDate.set("2020-01-01");
+  const now = new Date();
+
+  expect(formatDate(now)).toMatchInlineSnapshot(`"now"`);
+
+  // 5 sec ago
+  expect(formatDate(new Date(now - 5000))).toMatchInlineSnapshot(
+    `"5 sec. ago"`
+  );
+
+  // 1.5 min ago (rounds up)
+  expect(formatDate(new Date(now - 90000))).toMatchInlineSnapshot(
+    `"2 min. ago"`
+  );
+
+  // 1.5 hours ago (rounds up)
+  expect(
+    formatDate(new Date(now - 1.5 * 60 * 60 * 1000))
+  ).toMatchInlineSnapshot(`"2 hr. ago"`);
+
+  // 1 day ago
+  expect(formatDate(new Date("2019-12-31"))).toMatchInlineSnapshot(
+    `"yesterday"`
+  );
+
+  // 1.5 days ago (rounds up)
+  expect(
+    formatDate(new Date(now - 1.5 * 24 * 60 * 60 * 1000))
+  ).toMatchInlineSnapshot(`"2 days ago"`);
+
+  // 2 days ago, uses absolute time
+  expect(formatDate(new Date("2019-12-30"))).toMatchInlineSnapshot(
+    `"Dec 30, 2019"`
+  );
+
+  // Many months ago
+  expect(formatDate(new Date("2019-06-30"))).toMatchInlineSnapshot(
+    `"Jun 30, 2019"`
+  );
+
+  MockDate.reset();
+});

--- a/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
+++ b/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
@@ -53,7 +53,7 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                         onTouchStart={[Function]}
                         title="Jan 1, 2020, 12:00 AM"
                       >
-                        First reported less than a minute ago
+                        First reported now
                       </time>
                     </Tooltip>
                   </TimeInfo>
@@ -156,7 +156,7 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                         onTouchStart={[Function]}
                         title="Jan 1, 2019, 12:00 AM"
                       >
-                        First reported Jan 1, 2019, 12:00 AM
+                        First reported Jan 1, 2019
                       </time>
                     </Tooltip>
                   </TimeInfo>

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -16,8 +16,6 @@ import { nl2br, linkify, ellipsis } from 'lib/text';
 import { usePushToDataLayer } from 'lib/gtm';
 import getTermsString from 'lib/terms';
 
-import { format, formatDistanceToNow } from 'lib/dateWithLocale';
-import isValid from 'date-fns/isValid';
 import { LINE_URL } from 'constants/urls';
 
 import AddIcon from '@material-ui/icons/AddCircleOutline';
@@ -40,6 +38,7 @@ import NewReplySection from 'components/NewReplySection';
 import ArticleInfo from 'components/ArticleInfo';
 import ArticleCategories from 'components/ArticleCategories';
 import TrendPlot from 'components/TrendPlot';
+import Infos, { TimeInfo } from 'components/Infos';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -66,14 +65,6 @@ const useStyles = makeStyles(theme => ({
     [theme.breakpoints.up('md')]: {
       fontSize: 14,
       padding: '10px 28px',
-    },
-  },
-  firstReported: {
-    fontSize: 12,
-    lineHeight: '20px',
-    color: theme.palette.secondary[200],
-    [theme.breakpoints.up('md')]: {
-      fontSize: 14,
     },
   },
   main: {
@@ -288,12 +279,6 @@ function ArticlePage() {
   const { replyRequestCount, text, hyperlinks, replyCount } = article;
   const similarArticles = article?.similarArticles?.edges || [];
 
-  const createdAt = article.createdAt
-    ? new Date(article.createdAt)
-    : new Date();
-
-  const timeAgo = formatDistanceToNow(createdAt);
-
   const replyRequestsWithComments = (article.replyRequests || []).filter(
     ({ reason }) => reason
   );
@@ -316,15 +301,11 @@ function ArticlePage() {
                   replyRequestCount
                 )}
               </Ribbon>
-
-              {isValid(createdAt) && (
-                <span
-                  className={classes.firstReported}
-                  title={format(createdAt)}
-                >
-                  {t`First reported ${timeAgo}`}
-                </span>
-              )}
+              <Infos>
+                <TimeInfo time={article.createdAt}>
+                  {timeAgo => t`First reported ${timeAgo}`}
+                </TimeInfo>
+              </Infos>
             </header>
             <CardContent>
               {nl2br(


### PR DESCRIPTION
Thanks to @kerrickstaley we are now having relative dates!

This is a revision of the relative time display so that the behavior is more similar to Facebook timeline.

- Apply `TimeInfo` for "First reported" display on top right corner in article detail page
- Remove time from absolute time display outside of tooltip
    - Align with Facebook timeline
- Relative date cut-off time changes to 48 hours
    - Allows "yesterday" to appear
    - Also allows literal "days ago"
- Calculate calendar days for relative date
    - Calendar days should be more intuitive for users
- Replace "less than a minute ago" with seconds so that we don't need to translate lol
- Adds unit test for `formatDate()`
    - Please check if the snapshot makes sense / is intuitive for users @bil4444 

## Screenshots

### First-reported
![image](https://user-images.githubusercontent.com/108608/112267847-066f7580-8cb1-11eb-8a61-7c02e9d57088.png)
![image](https://user-images.githubusercontent.com/108608/112268101-69610c80-8cb1-11eb-996f-13637b5eac85.png)


### Relative time
![image](https://user-images.githubusercontent.com/108608/112267975-39196e00-8cb1-11eb-95c3-45f969b787e8.png)
![image](https://user-images.githubusercontent.com/108608/112268111-6ebe5700-8cb1-11eb-90cb-3d4859a04da7.png)
