### PR TITLE
[ProfilePage] fix slug infinite redirect

### DIFF
--- a/components/ProfilePage/EditProfileDialog.js
+++ b/components/ProfilePage/EditProfileDialog.js
@@ -49,7 +49,7 @@ function EditProfileDialog({ user, onClose = () => {} }) {
   };
 
   const profileURL = `${location.origin}/user/${
-    slug ? encodeURIComponent(slug) : `[${t`Username`}]`
+    slug ? encodeURI(slug) : `[${t`Username`}]`
   }`;
 
   return (

--- a/components/ProfilePage/ProfilePage.js
+++ b/components/ProfilePage/ProfilePage.js
@@ -84,8 +84,9 @@ function ProfilePage({ id, slug }) {
   const router = useRouter();
   const latestSlug = data?.GetUser?.slug; // slug may update after user edits
   useEffect(() => {
-    const targetPath = `/user/${latestSlug}`;
-    if (latestSlug && window.location.pathname !== targetPath) {
+    if (!latestSlug) return;
+    const targetPath = `/user/${encodeURI(latestSlug)}`;
+    if (window.location.pathname !== targetPath) {
       router.replace(targetPath);
     }
   }, [latestSlug, router]);


### PR DESCRIPTION
Currently slugs with characters will trigger infinite page reload.

This PR modifies the reload detection mechanism so that it handles URL encoded paths correctly.
