### PR TITLE
[LandingPage] include messages that has been replied

### DIFF
--- a/components/LandingPage/SectionArticles.js
+++ b/components/LandingPage/SectionArticles.js
@@ -13,8 +13,8 @@ import rightImage from './images/article-right.png';
 const LIST_ARTICLES = gql`
   query GetArticlesInLandingPage {
     ListArticles(
-      filter: { replyRequestCount: { GTE: 2 } }
-      orderBy: [{ lastRequestedAt: DESC }]
+      filter: { replyRequestCount: { GTE: 3 } }
+      orderBy: [{ createdAt: DESC }]
       first: 10
     ) {
       edges {

--- a/components/LandingPage/SectionArticles.js
+++ b/components/LandingPage/SectionArticles.js
@@ -11,12 +11,12 @@ import leftImage from './images/article-left.png';
 import rightImage from './images/article-right.png';
 
 const LIST_ARTICLES = gql`
-  query GetArticlesList(
-    $filter: ListArticleFilter
-    $orderBy: [ListArticleOrderBy]
-    $after: String
-  ) {
-    ListArticles(filter: $filter, orderBy: $orderBy, after: $after, first: 10) {
+  query GetArticlesInLandingPage {
+    ListArticles(
+      filter: { replyRequestCount: { GTE: 2 } }
+      orderBy: [{ lastRequestedAt: DESC }]
+      first: 10
+    ) {
       edges {
         node {
           id
@@ -131,20 +131,11 @@ const SectionArticles = () => {
   const classes = useStyles();
   const router = useRouter();
 
-  const listQueryVars = {
-    filter: {
-      replyRequestCount: { GTE: 2 },
-      hasArticleReplyWithMorePositiveFeedback: false,
-    },
-    orderBy: [{ lastRequestedAt: 'DESC' }],
-  };
-
   const {
     loading,
     data: listArticlesData,
     error: listArticlesError,
   } = useQuery(LIST_ARTICLES, {
-    variables: listQueryVars,
     ssr: false, // Fetch on browser is OK
   });
 


### PR DESCRIPTION
## As-is

Currently the landing page only shows messages that has no useful replies yet.
This may give new comer an initial impression that all messages are not getting replied in this website.

![image](https://user-images.githubusercontent.com/108608/118363137-80dbb800-b5c5-11eb-866a-b934180bbd04.png)

## The fix
1. Include messages that is being replied in landing page.
2. List only articles with 3 or more reply requests, so that
    - replied articles are not pushed down so fast
    - it is more likely the message is seen by new site visitors, intriguing them to enter website
3. Sort by `createdAt` instead of `lastRepliedAt` so that replied articles are not pushed down by new requests.

![image](https://user-images.githubusercontent.com/108608/118363184-c304f980-b5c5-11eb-9789-2c085617cc96.png)
