### PR TITLE
[Trivial] Update URL constants

### DIFF
--- a/components/ReportPage/EcosystemModal.js
+++ b/components/ReportPage/EcosystemModal.js
@@ -88,10 +88,10 @@ const ECOSYSTEM_CONTENTS = [
     links: [
       { href: 'https://github.com/cofacts', label: t`Cofacts open dataset` },
       {
-        href: 'https://cofacts.org/analytics',
+        href: 'https://cofacts.tw/analytics',
         label: t`Cofacts usage analytics`,
       },
-      { href: 'https://api.cofacts.org', label: t`Cofacts API` },
+      { href: 'https://api.cofacts.tw', label: t`Cofacts API` },
     ],
   },
 ];

--- a/components/ReportPage/SectionSponsor.js
+++ b/components/ReportPage/SectionSponsor.js
@@ -194,11 +194,11 @@ function SectionSponsor() {
   const [urlToShare, setUrlToShare] = useState('');
 
   useEffect(() => {
-    const url = `https://cofacts.tw${location.pathname}`;
-
     // Set URL to share on client, when location is available.
     // Will re-render this component to update the URL.
     //
+    // Get rid of extra things like fbclid when sharing
+    const url = `${location.origin}${location.pathname}`;
     setUrlToShare(
       `${FACEBOOK_SHARE_URL_PREFIX}&href=${encodeURIComponent(url)}`
     );

--- a/components/ReportPage/SectionSponsor.js
+++ b/components/ReportPage/SectionSponsor.js
@@ -194,7 +194,7 @@ function SectionSponsor() {
   const [urlToShare, setUrlToShare] = useState('');
 
   useEffect(() => {
-    const url = `https://dev.cofacts.org${location.pathname}`;
+    const url = `https://cofacts.tw${location.pathname}`;
 
     // Set URL to share on client, when location is available.
     // Will re-render this component to update the URL.

--- a/constants/urls.js
+++ b/constants/urls.js
@@ -1,6 +1,6 @@
 export const USER_REFERENCE =
   'http://beta.hackfoldr.org/cofacts/https%253A%252F%252Fhackmd.io%252Fs%252FBJPLbAKwb';
-export const PROJECT_HACKFOLDR = 'https://cofacts.org/hack';
+export const PROJECT_HACKFOLDR = 'https://cofacts.tw/hack';
 export const EDITOR_REFERENCE =
   'http://beta.hackfoldr.org/cofacts/https%253A%252F%252Fhackmd.io%252Fs%252FSJPAscuP-';
 export const EDITOR_FACEBOOK_GROUP =


### PR DESCRIPTION
Since we are using cofacts.tw as primary URL, we should change the legacy URLs in the codebase to cofacts.tw.

