### PR TITLE
Make ellipsis URLs copyable

### DIFF
--- a/lib/__tests__/__snapshots__/text.js.snap
+++ b/lib/__tests__/__snapshots__/text.js.snap
@@ -81,7 +81,14 @@ Array [
   <a
     href="http://www.rumtoast.com/5444/line%E7%BE%A4%E7%B5%84%E8%A1%8C%E5%8B%95%E6%A2%9D%E7%A2%BC%E9%82%80%E8%AB%8B-%E4%B8%80%E5%AE%9A%E8%A6%81%E9%97%9C%E6%8E%89%EF%BC%8C%E4%B8%8D%E7%84%B6%E9%A7%AD%E5%AE%A2%E6%9C%83%E5%85%A5%E4%BE%B5"
   >
-    http:⋯駭客會入侵
+    <React.Fragment>
+      <WithStyles(Component)
+        maxWidth="2.5em"
+      >
+        http://www.rumtoast.com/5444/line群組行動條碼邀請-一定要關掉，不然
+      </WithStyles(Component)>
+      駭客會入侵
+    </React.Fragment>
   </a>,
   "",
 ]

--- a/lib/text.js
+++ b/lib/text.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import { withStyles } from '@material-ui/core/styles';
 import gql from 'graphql-tag';
 
 const BREAK = { $$BREAK: true };
@@ -54,6 +55,20 @@ function traverseForStrings(elem, callback) {
   }
 }
 
+const Cropper = withStyles({
+  cropper: {
+    display: 'inline-block',
+    maxWidth: ({ maxWidth }) => `min(100%, ${maxWidth})`, // 100% ensures this inline-block does not stick out its container
+    overflow: 'hidden',
+    whiteSpace: 'nowrap',
+    textOverflow: 'ellipsis',
+    textDecoration: 'inherit',
+    verticalAlign: 'bottom', // align with the rest of the URLs
+  },
+})(({ children, classes }) => {
+  return <span className={classes.cropper}>{children}</span>;
+});
+
 function shortenUrl(s, maxLength) {
   try {
     s = decodeURIComponent(s);
@@ -61,9 +76,16 @@ function shortenUrl(s, maxLength) {
     // Probably malformed URI components.
     // Do nothing, just use original string
   }
-  return s.length <= maxLength
-    ? s
-    : `${s.slice(0, maxLength / 2)}⋯${s.slice(-maxLength / 2)}`;
+  return s.length <= maxLength ? (
+    s
+  ) : (
+    <>
+      <Cropper maxWidth={`${maxLength / 4}em`}>
+        {s.slice(0, -maxLength / 2)}
+      </Cropper>
+      {s.slice(-maxLength / 2)}
+    </>
+  );
 }
 
 function flatternPureStrings(tokens) {


### PR DESCRIPTION
Currently when we copy links from "References" directly, we often copy the URLs with ellipsis in the middle, thus breaks the links.

This PR adjusted how ellipsis URLs are rendered so that when user selects the text and press "copy", the full URLs are copied instead.

Technically it is replacing `slice` + `...` with rendering the full URL + ellipsis with CSS.

## Can select & copy
Notice that the "..." in the URLs are gone when pasted.
![copy-paste-full-urls](https://user-images.githubusercontent.com/108608/128640745-d3f76a95-a7da-4885-acb9-279c6ec70fb3.gif)


## Works in narrow screens
![url-shrink](https://user-images.githubusercontent.com/108608/128640449-b290451a-3f0e-4b3f-8f0d-0d501f412592.gif)

