### PR TITLE
Block empty replies

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ By default, the chatbot will be built under `en_US` locale.
 During development, changing `LOCALE` in `.env` allows you to spin up dev server under a specific locale.
 Please set `LOCALE` to one of `en_US`, `zh_TW` or any other language code that exists under `i18n/` directory.
 
+When previewing translated site on local machine, sometimes the translated text does not appear.
+You may need to set `BABEL_DISABLE_CACHE` (example: `BABEL_DISABLE_CACHE=1 npm run dev`) to disable
+babel cache for the new translation to appear correctly.
+
 When building using Docker, `LOCALE` can be provided via build args.
 
 ## Legal

--- a/components/NewReplySection/index.js
+++ b/components/NewReplySection/index.js
@@ -105,8 +105,20 @@ const NewReplySection = withContext(
         const { replyType: type, reference, text } = fields;
         e.preventDefault(); // prevent reload
         if (creatingReply) return;
+
+        const trimmedText = text.trim();
+        if (trimmedText.length === 0) {
+          alert(t`Please provide reply text.`);
+          return;
+        }
+
         createReply({
-          variables: { type, reference, text, articleId: article.id },
+          variables: {
+            type,
+            reference,
+            text: trimmedText,
+            articleId: article.id,
+          },
         });
       },
       [createReply, fields, article.id, creatingReply]

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -146,7 +146,7 @@ msgstr "感謝您的意見。"
 msgid "Your reply has been submitted."
 msgstr "已經送出回應。"
 
-#: components/NewReplySection/index.js:125
+#: components/NewReplySection/index.js:137
 #: lib/apollo.js:47
 msgid "Please login first."
 msgstr "請先登入。"
@@ -2372,6 +2372,10 @@ msgid ""
 msgstr ""
 "2016 年起將 chatbot 導入事實查核領域、並提供 API "
 "介接教學，在此領域激起了典範轉移，專業查核組織開始推出自己的chatbot，也有第三方查詢機器人前來介接 Cofacts 資料。"
+
+#: components/NewReplySection/index.js:111
+msgid "Please provide reply text."
+msgstr "請提供回應文字。"
 
 #: pages/index.js:29
 msgctxt "site title"


### PR DESCRIPTION
Fixes #449 

When reply text is empty or contains nothing but only space / line breaks, block submission.

![block-empty](https://user-images.githubusercontent.com/108608/135214140-df796939-4fae-4e06-82f4-095cc33311d7.gif)
