### PR TITLE
Handle SSG case

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -122,14 +122,16 @@ MyDocument.getInitialProps = async ctx => {
     const sheets = new ServerStyleSheets();
     const originalRenderPage = ctx.renderPage;
 
+    // ctx.req will be undefined on static page build
+    const serverSideCookie = ctx.req?.headers?.cookie
+      ? cookie.parse(ctx.req.headers.cookie)
+      : {};
+
     ctx.renderPage = () =>
       originalRenderPage({
         enhanceApp: App => props =>
           sheets.collect(
-            <App
-              {...props}
-              serverSideCookie={cookie.parse(ctx.req.headers.cookie)}
-            />
+            <App {...props} serverSideCookie={serverSideCookie} />
           ),
       });
 


### PR DESCRIPTION
[Previous image build](https://github.com/cofacts/rumors-site/actions/runs/1529029608) fails due to the server-side cookie logic introduced in #457 .

This PR fixes the build by properly handle SSG case, which will have undefined ctx.req.