### PR TITLE
[AppLayout][LandingPage] change forum links to tutorial

### DIFF
--- a/components/AppLayout/AppFooter.js
+++ b/components/AppLayout/AppFooter.js
@@ -106,6 +106,9 @@ function AppFooter() {
             <CustomLink href="/hoax-for-you">
               {c('App layout').t`For You`}
             </CustomLink>
+            <CustomLink href="/tutorial">
+              {c('App layout').t`Tutorial`}
+            </CustomLink>
           </div>
           <div className={classes.column}>
             <h3>{t`About`}</h3>

--- a/components/AppLayout/AppHeader.js
+++ b/components/AppLayout/AppHeader.js
@@ -30,7 +30,6 @@ import Avatar from './Widgets/Avatar';
 import LevelProgressBar from './Widgets/LevelProgressBar';
 
 import { NAVBAR_HEIGHT, TABS_HEIGHT } from 'constants/size';
-import { EDITOR_FACEBOOK_GROUP } from 'constants/urls';
 import desktopLogo from './images/logo-desktop.svg';
 import mobileLogo from './images/logo-mobile.svg';
 

--- a/components/AppLayout/AppHeader.js
+++ b/components/AppLayout/AppHeader.js
@@ -173,11 +173,10 @@ const Links = ({ classes, unsolvedCount }) => (
     <Box
       display={['none', 'none', 'inline']}
       component={NavLink}
-      external
-      href={EDITOR_FACEBOOK_GROUP}
+      href="/tutorial"
       className={classes.tab}
     >
-      {c('App layout').t`Forum`}
+      {c('App layout').t`Tutorial`}
     </Box>
   </>
 );

--- a/components/AppLayout/AppSidebar.js
+++ b/components/AppLayout/AppSidebar.js
@@ -129,9 +129,7 @@ function AppSidebar({ open, toggle, user, onLoginModalOpen, onLogout }) {
       <Divider classes={{ root: classes.divider }} />
       <List className={classes.list}>
         <ListItem classes={{ root: classes.listItem }} button>
-          <NavLink external href={EDITOR_FACEBOOK_GROUP}>
-            {t`Forum`}
-          </NavLink>
+          <NavLink href="/tutorial">{t`Tutorial`}</NavLink>
         </ListItem>
         <ListItem classes={{ root: classes.listItem }} button>
           <NavLink external href={PROJECT_HACKFOLDR}>

--- a/components/AppLayout/AppSidebar.js
+++ b/components/AppLayout/AppSidebar.js
@@ -14,12 +14,7 @@ import {
 } from '@material-ui/core';
 import Avatar from './Widgets/Avatar';
 import LevelProgressBar from './Widgets/LevelProgressBar';
-import {
-  EDITOR_FACEBOOK_GROUP,
-  PROJECT_HACKFOLDR,
-  CONTACT_EMAIL,
-  LINE_URL,
-} from 'constants/urls';
+import { PROJECT_HACKFOLDR, CONTACT_EMAIL, LINE_URL } from 'constants/urls';
 import NavLink from 'components/NavLink';
 import Ribbon from 'components/Ribbon';
 import ProfileLink from 'components/ProfileLink';

--- a/components/LandingPage/Header.js
+++ b/components/LandingPage/Header.js
@@ -237,12 +237,7 @@ const LandingPageHeader = React.memo(({ onLoginModalOpen }) => {
               {c('App layout').t`For You`}
             </CustomBadge>
           </NavLink>
-          <NavLink
-            className={classes.item}
-            href="/tutorial"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
+          <NavLink className={classes.item} href="/tutorial?tab=check-rumors">
             {c('App layout').t`Tutorial`}
           </NavLink>
           {user?.name ? (

--- a/components/LandingPage/Header.js
+++ b/components/LandingPage/Header.js
@@ -15,7 +15,6 @@ import NavLink from 'components/NavLink';
 import * as Widgets from 'components/AppLayout/Widgets';
 
 import { NAVBAR_HEIGHT } from 'constants/size';
-import { EDITOR_FACEBOOK_GROUP } from 'constants/urls';
 
 import desktopBlackLogo from './images/logo-desktop-black.svg';
 import mobileBlackLogo from './images/logo-mobile-black.svg';
@@ -238,14 +237,14 @@ const LandingPageHeader = React.memo(({ onLoginModalOpen }) => {
               {c('App layout').t`For You`}
             </CustomBadge>
           </NavLink>
-          <a
+          <NavLink
             className={classes.item}
-            href={EDITOR_FACEBOOK_GROUP}
+            href="/tutorial"
             target="_blank"
             rel="noopener noreferrer"
           >
-            {c('App layout').t`Forum`}
-          </a>
+            {c('App layout').t`Tutorial`}
+          </NavLink>
           {user?.name ? (
             <Widgets.Avatar
               user={user}


### PR DESCRIPTION
Discussion: https://g0v.hackmd.io/@mrorz/cofacts-meeting-notes/%2F-G9Md9IyQauRoalIXJgenQ 

This PR replaces the original "Forum" link in app header & app sidebar to tutorial.

- Landing page: "Forum" link changed to "Tutorial" and point to how-to-check-rumors tutorial (`/tutorial?tab=check-rumors`)
- Inside application: "Forum link" in app header & sidebar changed to "Tutorial" pointing to fact-checking tutorial.
- Add tutorial link to footer. (`/tutorial`)

## Landing page
<img width="973" alt="圖片" src="https://user-images.githubusercontent.com/108608/145668429-86a822fb-0c76-4847-a66d-245e295be807.png">

## Inside application

### Desktop header
<img width="793" alt="圖片" src="https://user-images.githubusercontent.com/108608/145668292-16afcbd7-8c28-405a-82f7-e8301e15f720.png">

### Mobile sidebar
<img width="838" alt="圖片" src="https://user-images.githubusercontent.com/108608/145668306-d9789406-e961-4823-8d68-b61345305706.png">

### Footer
<img width="1196" alt="圖片" src="https://user-images.githubusercontent.com/108608/145668347-57910c8a-e4c6-4d2d-8222-da855c1f222e.png">
