### PR TITLE
Show blocked content only for blocked users

### DIFF
--- a/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
+++ b/components/ArticleReplyFeedbackControl/ReasonsDisplay.js
@@ -5,6 +5,7 @@ import { useQuery } from '@apollo/react-hooks';
 import { withStyles, makeStyles } from '@material-ui/core/styles';
 import { Box, Tab, Tabs, CircularProgress } from '@material-ui/core';
 import { ThumbUpIcon, ThumbDownIcon } from 'components/icons';
+import { useIsUserBlocked } from 'lib/isUserBlocked';
 import Feedback from './Feedback';
 
 const useStyles = makeStyles(() => ({
@@ -38,9 +39,13 @@ const ReasonsDisplayData = gql`
 `;
 
 export const LOAD_FEEDBACKS = gql`
-  query LoadFeadbacksForArticleReply($articleId: String!, $replyId: String!) {
+  query LoadFeadbacksForArticleReply(
+    $articleId: String!
+    $replyId: String!
+    $statuses: [ArticleReplyFeedbackStatusEnum!]
+  ) {
     ListArticleReplyFeedbacks(
-      filter: { articleId: $articleId, replyId: $replyId }
+      filter: { articleId: $articleId, replyId: $replyId, statuses: $statuses }
       first: 100
     ) {
       edges {
@@ -64,11 +69,13 @@ export const LOAD_FEEDBACKS = gql`
 
 function ReasonsDisplay({ articleReply, onSizeChange = () => {} }) {
   const classes = useStyles();
+  const isUserBlocked = useIsUserBlocked();
   const [tab, setTab] = useState(0);
   const { data, loading } = useQuery(LOAD_FEEDBACKS, {
     variables: {
       articleId: articleReply.articleId,
       replyId: articleReply.replyId,
+      statuses: isUserBlocked ? ['NORMAL', 'BLOCKED'] : ['NORMAL'],
     },
     ssr: false,
   });


### PR DESCRIPTION
Depends on API: https://github.com/cofacts/rumors-api/pull/262

This PR implements M3:
- In the new API it will not show blocked content by default
- This PR allows blocked user to see blocked content (reply request, article reply, article category, article reply feedbacks) on article page

## Normal user
Note: there is 1 scammer comment in the image -- we forgot to ban the user previously. Block them here: https://github.com/cofacts/takedowns/pull/35/files?short_path=bcf97d9#diff-bcf97d9ee9386930d59f50144c9d0d8d90dbbeb775a27af646d41729cc055c80
![圖片](https://user-images.githubusercontent.com/108608/147856084-a36276cf-24f9-41a1-8c3a-4296e92b8193.png)

## Blocked user
All blocked contents are shown if and only if the browser is owned by a blocked user.
![圖片](https://user-images.githubusercontent.com/108608/147856110-0dd604b5-bdbd-4928-b291-8046b1b8922b.png)

Ask API to query blocked feedbacks
<img width="1409" alt="圖片" src="https://user-images.githubusercontent.com/108608/147858527-fb328e14-38f2-4e1a-aa8c-b3318f8040d5.png">
