### PR TITLE
[Reply] reply detail page should work for DELETED & BLOCKED content

### DIFF
--- a/pages/reply/[id].js
+++ b/pages/reply/[id].js
@@ -66,7 +66,7 @@ const LOAD_REPLY = gql`
       id
       text
       createdAt
-      articleReplies {
+      articleReplies(statuses: [NORMAL, DELETED]) {
         article {
           id
           text
@@ -84,7 +84,7 @@ const LOAD_REPLY = gql`
           node {
             id
             text
-            articleReplies(status: NORMAL) {
+            articleReplies {
               articleId
             }
           }
@@ -100,7 +100,7 @@ const LOAD_REPLY_FOR_USER = gql`
   query LoadReplyPageForUser($id: String!) {
     GetReply(id: $id) {
       id
-      articleReplies {
+      articleReplies(statuses: [NORMAL, DELETED]) {
         ...ArticleReplyForUser
       }
     }
@@ -228,6 +228,29 @@ function ReplyPage() {
       articleReply.createdAt < earliest.createdAt ? articleReply : earliest,
     reply.articleReplies[0]
   );
+
+  // reply.articleReplies can be empty if all article replies are in BLOCKED state.
+  // Return a minimalist reply detail page that cannot be indexed by search engines.
+  //
+  if (!originalArticleReply) {
+    return (
+      <AppLayout>
+        <Head>
+          <title>
+            {ellipsis(reply.text, { wordCount: 100 })} | {t`Cofacts`}
+          </title>
+          <meta name="robots" content="noindex" />
+        </Head>
+        <div className={classes.root}>
+          <Card>
+            <CardHeader>{t`This reply`}</CardHeader>
+            <CardContent>{reply.text}</CardContent>
+          </Card>
+        </div>
+      </AppLayout>
+    );
+  }
+
   const isDeleted = originalArticleReply.status === 'DELETED';
 
   const otherArticleReplies = reply.articleReplies


### PR DESCRIPTION
See analysis in https://github.com/cofacts/rumors-site/issues/468#issuecomment-1005867982 
Fixes #468 .

## Screenshots

### Current
Reply detail page of deleted reply will trigger internal server error:
![圖片](https://user-images.githubusercontent.com/108608/148253307-a2ac8051-0181-4488-bba6-0b2089e941ae.png)

### Fixed
Deleted reply can be properly displayed
![圖片](https://user-images.githubusercontent.com/108608/148253405-d594d69a-8934-4336-9b6a-e9dffdf49539.png)

Blocked reply (spam content) can be displayed in a minimalist fashion for public display, but do not allow web crawler to index
(Simulated by forcefully enter if statement)
![圖片](https://user-images.githubusercontent.com/108608/148253590-b9edbda0-1504-405d-a044-5255c473adb1.png)
