### PR TITLE
Fix downvote dialog by proper null handling

### DIFF
--- a/components/ArticleCategories/DownVoteDialog.js
+++ b/components/ArticleCategories/DownVoteDialog.js
@@ -48,7 +48,7 @@ function DownVoteDialog({
   });
 
   const downVoteFeedbacks = (
-    data.GetArticle?.articleCategories.find(ac => ac.categoryId === categoryId)
+    data?.GetArticle?.articleCategories.find(ac => ac.categoryId === categoryId)
       ?.feedbacks ?? []
   ).filter(({ vote, comment }) => vote === 'DOWNVOTE' && comment);
 


### PR DESCRIPTION
Fixes #486. Root cause please see https://github.com/cofacts/rumors-site/issues/486#issuecomment-1125673951 .

I roughly checked other return value of `useQuery()`; other access of `data` prop are all properly guarded by `?.`.

<img width="949" alt="圖片" src="https://user-images.githubusercontent.com/108608/168223209-bc464ec1-7532-4b9a-a4fe-bf17fd921593.png">
