### PR TITLE
Don't show loading if article is already loaded

### DIFF
--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -271,7 +271,7 @@ function ArticlePage() {
 
   usePushToDataLayer(!!article, { event: 'dataLoaded' });
 
-  if (loading) {
+  if (loading && !article) {
     return (
       <AppLayout>
         <Head>


### PR DESCRIPTION
Currently after up-voting or down-voting a reply, the whole article page will become "Loading...".

It seems that in @apollo/react-hooks v3.1.5 the `loading` state behavior is slightly different from 3.0.

This PR avoids "Loading..." page after an article is already displayed on screen.

![upvote-downvote](https://user-images.githubusercontent.com/108608/168229724-520b5401-f69d-49d7-8cd8-82460e217918.gif)

