### PR TITLE
Support attachment variants

### DIFF
--- a/components/ListPageDisplays/ArticleCard.js
+++ b/components/ListPageDisplays/ArticleCard.js
@@ -117,33 +117,31 @@ function ArticleCard({ article, highlight = '' }) {
               {timeAgo => t`First reported ${timeAgo}`}
             </TimeInfo>
           </Infos>
-          <div className={classes.textImageWrapper}>
-            <div className={classes.flex}>
-              <div className={classes.infoBox}>
-                <div>
-                  <h2>{+replyCount}</h2>
-                  <span>{c('Info box').t`replies`}</span>
-                </div>
-                <div>
-                  <h2>{+replyRequestCount}</h2>
-                  <span>{c('Info box').t`reports`}</span>
-                </div>
+          <div className={classes.flex}>
+            <div className={classes.infoBox}>
+              <div>
+                <h2>{+replyCount}</h2>
+                <span>{c('Info box').t`replies`}</span>
               </div>
-              {(text || highlight) && (
-                <ExpandableText className={classes.content} lineClamp={3}>
-                  {highlight
-                    ? highlightSections(highlight, highlightClasses)
-                    : text}
-                </ExpandableText>
-              )}
-              {attachmentUrl && (
-                <img
-                  className={classes.attachmentImage}
-                  src={attachmentUrl}
-                  alt="image"
-                />
-              )}
+              <div>
+                <h2>{+replyRequestCount}</h2>
+                <span>{c('Info box').t`reports`}</span>
+              </div>
             </div>
+            {(text || highlight) && (
+              <ExpandableText className={classes.content} lineClamp={3}>
+                {highlight
+                  ? highlightSections(highlight, highlightClasses)
+                  : text}
+              </ExpandableText>
+            )}
+            {attachmentUrl && (
+              <img
+                className={classes.attachmentImage}
+                src={attachmentUrl}
+                alt="image"
+              />
+            )}
           </div>
         </ListPageCard>
       </a>

--- a/components/ListPageDisplays/ArticleCard.js
+++ b/components/ListPageDisplays/ArticleCard.js
@@ -85,14 +85,8 @@ const useStyles = makeStyles(theme => ({
     color: theme.palette.primary[500],
   },
   attachmentImage: {
-    width: '100%',
-    maxWidth: 336,
-    marginTop: 16,
-  },
-  textImageWrapper: {
-    [theme.breakpoints.up('md')]: {
-      display: 'flex',
-    },
+    minWidth: 0, // Don't use intrinsic image width as flex item min-size
+    maxHeight: '10em', // Don't let image rows take too much vertical space
   },
 }));
 
@@ -142,14 +136,14 @@ function ArticleCard({ article, highlight = '' }) {
                     : text}
                 </ExpandableText>
               )}
+              {attachmentUrl && (
+                <img
+                  className={classes.attachmentImage}
+                  src={attachmentUrl}
+                  alt="image"
+                />
+              )}
             </div>
-            {attachmentUrl && (
-              <img
-                className={classes.attachmentImage}
-                src={attachmentUrl}
-                alt="image"
-              />
-            )}
           </div>
         </ListPageCard>
       </a>
@@ -162,7 +156,7 @@ ArticleCard.fragments = {
     fragment ArticleCard on Article {
       id
       text
-      attachmentUrl
+      attachmentUrl(variant: THUMBNAIL)
       replyCount
       replyRequestCount
       createdAt

--- a/components/ListPageDisplays/ListPageCards.js
+++ b/components/ListPageDisplays/ListPageCards.js
@@ -5,6 +5,10 @@ const useStyles = makeStyles(() => ({
   root: {
     display: 'grid',
     gridRowGap: 12,
+    // Unset min-sizing behavior of all gird items
+    // so that wide contents don't blow up the grid
+    // Ref: https://css-tricks.com/preventing-a-grid-blowout/
+    gridTemplateColumns: 'minmax(0, 1fr)',
   },
 }));
 

--- a/components/ListPageDisplays/ListPageCards.stories.js
+++ b/components/ListPageDisplays/ListPageCards.stories.js
@@ -65,5 +65,14 @@ export const ArticleCards = () => (
         createdAt: '2020-01-01T00:00:00Z',
       }}
     />
+    <ArticleCard
+      article={{
+        id: 'id3',
+        attachmentUrl: 'https://placekitten.com/2000/150',
+        replyCount: 4,
+        replyRequestCount: 6,
+        createdAt: '2020-01-01T00:00:00Z',
+      }}
+    />
   </ListPageCards>
 );

--- a/components/ListPageDisplays/ReplySearchItem.js
+++ b/components/ListPageDisplays/ReplySearchItem.js
@@ -93,8 +93,8 @@ const useStyles = makeStyles(theme => ({
     },
   },
   attachmentImage: {
-    width: '100%',
-    maxWidth: 336,
+    maxWidth: '100%',
+    maxHeight: '8em', // So that image don't take too much space (more than replies)
   },
 }));
 
@@ -229,7 +229,7 @@ ReplySearchItem.fragments = {
         article {
           id
           text
-          attachmentUrl
+          attachmentUrl(variant: THUMBNAIL)
           replyRequestCount
           createdAt
         }

--- a/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
+++ b/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
@@ -60,51 +60,47 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                 </div>
               </Infos>
               <div
-                className="makeStyles-textImageWrapper"
+                className="makeStyles-flex"
               >
                 <div
-                  className="makeStyles-flex"
+                  className="makeStyles-infoBox"
+                >
+                  <div>
+                    <h2>
+                      3
+                    </h2>
+                    <span>
+                      replies
+                    </span>
+                  </div>
+                  <div>
+                    <h2>
+                      4
+                    </h2>
+                    <span>
+                      reports
+                    </span>
+                  </div>
+                </div>
+                <ExpandableText
+                  className="makeStyles-content"
+                  lineClamp={3}
                 >
                   <div
-                    className="makeStyles-infoBox"
-                  >
-                    <div>
-                      <h2>
-                        3
-                      </h2>
-                      <span>
-                        replies
-                      </span>
-                    </div>
-                    <div>
-                      <h2>
-                        4
-                      </h2>
-                      <span>
-                        reports
-                      </span>
-                    </div>
-                  </div>
-                  <ExpandableText
                     className="makeStyles-content"
-                    lineClamp={3}
                   >
                     <div
-                      className="makeStyles-content"
-                    >
-                      <div
-                        className="makeStyles-root"
-                        style={
-                          Object {
-                            "maxHeight": 42,
-                          }
+                      className="makeStyles-root"
+                      style={
+                        Object {
+                          "maxHeight": 42,
                         }
-                      >
-                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-                      </div>
+                      }
+                    >
+                      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
                     </div>
-                  </ExpandableText>
-                </div>
+                  </div>
+                </ExpandableText>
               </div>
             </article>
           </ListPageCard>
@@ -177,45 +173,60 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                 </div>
               </Infos>
               <div
-                className="makeStyles-textImageWrapper"
+                className="makeStyles-flex"
               >
                 <div
-                  className="makeStyles-flex"
+                  className="makeStyles-infoBox"
+                >
+                  <div>
+                    <h2>
+                      0
+                    </h2>
+                    <span>
+                      replies
+                    </span>
+                  </div>
+                  <div>
+                    <h2>
+                      999
+                    </h2>
+                    <span>
+                      reports
+                    </span>
+                  </div>
+                </div>
+                <ExpandableText
+                  className="makeStyles-content"
+                  lineClamp={3}
                 >
                   <div
-                    className="makeStyles-infoBox"
-                  >
-                    <div>
-                      <h2>
-                        0
-                      </h2>
-                      <span>
-                        replies
-                      </span>
-                    </div>
-                    <div>
-                      <h2>
-                        999
-                      </h2>
-                      <span>
-                        reports
-                      </span>
-                    </div>
-                  </div>
-                  <ExpandableText
                     className="makeStyles-content"
-                    lineClamp={3}
                   >
                     <div
-                      className="makeStyles-content"
-                    >
-                      <div
-                        className="makeStyles-root"
-                        style={
-                          Object {
-                            "maxHeight": 42,
-                          }
+                      className="makeStyles-root"
+                      style={
+                        Object {
+                          "maxHeight": 42,
                         }
+                      }
+                    >
+                      <mark
+                        className="makeStyles-highlight"
+                        key="highlight-0"
+                      >
+                        Lorem ipsum
+                      </mark>
+                       dolor sit amet, consectetur adipiscing elit. 
+                      <mark
+                        className="makeStyles-highlight"
+                        key="highlight-1"
+                      >
+                        Mauris eu ex augue
+                      </mark>
+                      . Etiam posuere sagittis iaculis. Vestibulum sollicitudin nec felis a mollis. Phasellus ut est velit. Proin fermentum arcu ornare quam vulputate, vel eleifend velit ultrices. Fusce tincidunt vel urna at luctus.
+                      <section
+                        className="makeStyles-hyperlinks"
+                        key="hyperlink-section-0"
                       >
                         <mark
                           className="makeStyles-highlight"
@@ -223,37 +234,18 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                         >
                           Lorem ipsum
                         </mark>
-                         dolor sit amet, consectetur adipiscing elit. 
+                         dolor sit amet 
                         <mark
                           className="makeStyles-highlight"
                           key="highlight-1"
                         >
                           Mauris eu ex augue
                         </mark>
-                        . Etiam posuere sagittis iaculis. Vestibulum sollicitudin nec felis a mollis. Phasellus ut est velit. Proin fermentum arcu ornare quam vulputate, vel eleifend velit ultrices. Fusce tincidunt vel urna at luctus.
-                        <section
-                          className="makeStyles-hyperlinks"
-                          key="hyperlink-section-0"
-                        >
-                          <mark
-                            className="makeStyles-highlight"
-                            key="highlight-0"
-                          >
-                            Lorem ipsum
-                          </mark>
-                           dolor sit amet 
-                          <mark
-                            className="makeStyles-highlight"
-                            key="highlight-1"
-                          >
-                            Mauris eu ex augue
-                          </mark>
-                          . Etiam posuere sagittis iaculis.
-                        </section>
-                      </div>
+                        . Etiam posuere sagittis iaculis.
+                      </section>
                     </div>
-                  </ExpandableText>
-                </div>
+                  </div>
+                </ExpandableText>
               </div>
             </article>
           </ListPageCard>
@@ -315,36 +307,120 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                 </div>
               </Infos>
               <div
-                className="makeStyles-textImageWrapper"
+                className="makeStyles-flex"
               >
                 <div
-                  className="makeStyles-flex"
+                  className="makeStyles-infoBox"
                 >
-                  <div
-                    className="makeStyles-infoBox"
-                  >
-                    <div>
-                      <h2>
-                        6
-                      </h2>
-                      <span>
-                        replies
-                      </span>
-                    </div>
-                    <div>
-                      <h2>
-                        4
-                      </h2>
-                      <span>
-                        reports
-                      </span>
-                    </div>
+                  <div>
+                    <h2>
+                      6
+                    </h2>
+                    <span>
+                      replies
+                    </span>
+                  </div>
+                  <div>
+                    <h2>
+                      4
+                    </h2>
+                    <span>
+                      reports
+                    </span>
                   </div>
                 </div>
                 <img
                   alt="image"
                   className="makeStyles-attachmentImage"
                   src="https://placekitten.com/512/1000"
+                />
+              </div>
+            </article>
+          </ListPageCard>
+        </a>
+      </Link>
+    </ArticleCard>
+    <ArticleCard
+      article={
+        Object {
+          "attachmentUrl": "https://placekitten.com/2000/150",
+          "createdAt": "2020-01-01T00:00:00Z",
+          "id": "id3",
+          "replyCount": 4,
+          "replyRequestCount": 6,
+        }
+      }
+    >
+      <Link
+        as="/article/id3"
+        href="/article/[id]"
+      >
+        <a
+          className="makeStyles-root"
+          href="/article/id3"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          <ListPageCard>
+            <article
+              className="makeStyles-root"
+            >
+              <Infos>
+                <div
+                  className="makeStyles-root"
+                >
+                  <TimeInfo
+                    key=".0"
+                    time="2020-01-01T00:00:00Z"
+                  >
+                    <Tooltip
+                      title="Jan 1, 2020, 12:00 AM"
+                    >
+                      <time
+                        aria-describedby={null}
+                        className=""
+                        dateTime="2020-01-01T00:00:00.000Z"
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        title="Jan 1, 2020, 12:00 AM"
+                      >
+                        First reported now
+                      </time>
+                    </Tooltip>
+                  </TimeInfo>
+                </div>
+              </Infos>
+              <div
+                className="makeStyles-flex"
+              >
+                <div
+                  className="makeStyles-infoBox"
+                >
+                  <div>
+                    <h2>
+                      4
+                    </h2>
+                    <span>
+                      replies
+                    </span>
+                  </div>
+                  <div>
+                    <h2>
+                      6
+                    </h2>
+                    <span>
+                      reports
+                    </span>
+                  </div>
+                </div>
+                <img
+                  alt="image"
+                  className="makeStyles-attachmentImage"
+                  src="https://placekitten.com/2000/150"
                 />
               </div>
             </article>

--- a/components/NewReplySection/Mobile.js
+++ b/components/NewReplySection/Mobile.js
@@ -69,6 +69,7 @@ const useStyles = makeStyles(theme => ({
       },
     },
   },
+  attachmentImage: { maxWidth: '100%' },
 }));
 
 const CustomSelectInput = withStyles(theme => ({
@@ -176,7 +177,7 @@ export default function Mobile({
           </Tabs>
           <Box display="flex" flexDirection="column" flexGrow={1}>
             {selectedTab === 0 && (
-              <Box p={3.5}>
+              <Box p={2}>
                 {nl2br(
                   linkify(article.text, {
                     props: {
@@ -185,6 +186,11 @@ export default function Mobile({
                   })
                 )}
                 <Hyperlinks hyperlinks={article.hyperlinks} />
+                <img
+                  className={classes.attachmentImage}
+                  src={article.attachmentUrl}
+                  alt="image"
+                />
               </Box>
             )}
             {selectedTab === 1 && (

--- a/components/ProfilePage/RepliedArticleTab.js
+++ b/components/ProfilePage/RepliedArticleTab.js
@@ -44,7 +44,7 @@ const LOAD_REPLIED_ARTICLES = gql`
           replyRequestCount
           createdAt
           text
-          attachmentUrl
+          attachmentUrl(variant: THUMBNAIL)
           articleReplies(status: NORMAL) {
             replyId
             createdAt
@@ -112,8 +112,8 @@ const useStyles = makeStyles(theme => ({
   reply: { marginLeft: 56 },
   replyControl: { marginTop: 16 },
   attachmentImage: {
-    width: '100%',
-    maxWidth: 336,
+    maxWidth: '100%',
+    maxHeight: '8em', // So that image don't take too much space (more than replies)
   },
 }));
 

--- a/components/RelatedReplies.js
+++ b/components/RelatedReplies.js
@@ -51,8 +51,8 @@ const useStyles = makeStyles(theme => ({
     padding: 12,
   },
   attachmentImage: {
-    width: '100%',
-    maxWidth: 120,
+    maxWidth: '100%',
+    maxHeight: '10em', // 10 lines height
   },
 }));
 
@@ -80,7 +80,7 @@ const RelatedArticleReplyData = gql`
     article {
       id
       text
-      attachmentUrl
+      attachmentUrl(variant: THUMBNAIL)
     }
   }
 `;

--- a/components/ReportPage/__snapshots__/ActionButton.stories.storyshot
+++ b/components/ReportPage/__snapshots__/ActionButton.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots ReportPage/ActionButton Default 1`] = `
   }
 >
   <button
-    className="MuiButtonBase-root-300 MuiButton-root-273 MuiButton-outlined-278 makeStyles-button"
+    className="MuiButtonBase-root-299 MuiButton-root-272 MuiButton-outlined-277 makeStyles-button"
     disabled={false}
     onBlur={[Function]}
     onDragLeave={[Function]}
@@ -31,13 +31,13 @@ exports[`Storyshots ReportPage/ActionButton Default 1`] = `
     type="button"
   >
     <span
-      className="MuiButton-label-274"
+      className="MuiButton-label-273"
     >
       Action button text
       <Arrow>
         <svg
           aria-hidden={true}
-          className="MuiSvgIcon-root-301"
+          className="MuiSvgIcon-root-300"
           focusable="false"
           viewBox="0 0 14 27"
         >
@@ -51,7 +51,7 @@ exports[`Storyshots ReportPage/ActionButton Default 1`] = `
       </Arrow>
     </span>
     <span
-      className="MuiTouchRipple-root-310"
+      className="MuiTouchRipple-root-309"
     >
       <TransitionGroup
         childFactory={[Function]}

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -120,7 +120,8 @@ const LOAD_ARTICLE = gql`
     GetArticle(id: $id) {
       id
       text
-      attachmentUrl
+      attachmentUrl(variant: PREVIEW)
+      originalAttachmentUrl: attachmentUrl(variant: ORIGINAL)
       requestedForReply
       replyRequestCount
       replyCount
@@ -180,6 +181,7 @@ const LOAD_ARTICLE_FOR_USER = gql`
   ) {
     GetArticle(id: $id) {
       id # Required, https://github.com/apollographql/apollo-client/issues/2510
+      originalAttachmentUrl: attachmentUrl(variant: ORIGINAL)
       replyRequests(statuses: $replyRequestStatuses) {
         ...ReplyRequestInfoForUser
       }
@@ -310,6 +312,7 @@ function ArticlePage() {
     replyRequestCount,
     text,
     attachmentUrl,
+    originalAttachmentUrl,
     hyperlinks,
     replyCount,
   } = article;
@@ -353,19 +356,26 @@ function ArticlePage() {
               </Infos>
             </header>
             <CardContent>
-              {attachmentUrl && (
-                <a
-                  href={attachmentUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
+              {attachmentUrl &&
+                (!originalAttachmentUrl ? (
                   <img
                     className={classes.attachmentImage}
                     src={attachmentUrl}
                     alt="image"
                   />
-                </a>
-              )}
+                ) : (
+                  <a
+                    href={originalAttachmentUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <img
+                      className={classes.attachmentImage}
+                      src={attachmentUrl}
+                      alt="image"
+                    />
+                  </a>
+                ))}
               {text &&
                 nl2br(
                   linkify(text, {

--- a/pages/replies.js
+++ b/pages/replies.js
@@ -44,7 +44,7 @@ const LIST_ARTICLES = gql`
           replyRequestCount
           createdAt
           text
-          attachmentUrl
+          attachmentUrl(variant: THUMBNAIL)
           articleReplies(status: NORMAL) {
             reply {
               id
@@ -179,8 +179,8 @@ const useStyles = makeStyles(theme => ({
     },
   },
   attachmentImage: {
-    width: '100%',
-    maxWidth: 336,
+    maxWidth: '100%',
+    maxHeight: '8em', // So that image don't take too much space (more than replies)
   },
 }));
 

--- a/pages/reply/[id].js
+++ b/pages/reply/[id].js
@@ -74,7 +74,7 @@ const LOAD_REPLY = gql`
         article {
           id
           text
-          attachmentUrl
+          attachmentUrl(variant: PREVIEW)
           replyCount
         }
         createdAt

--- a/pages/search.js
+++ b/pages/search.js
@@ -42,7 +42,6 @@ const LIST_ARTICLES = gql`
           replyRequestCount
           createdAt
           text
-          attachmentUrl
           ...ArticleCard
         }
         highlight {


### PR DESCRIPTION
Extends #490 on task #483 . Must merge after API PR https://github.com/cofacts/rumors-api/pull/288 is deployed.

This PR:
- Uses "thumbnail" variant for list
- Uses "preview" variant for detail page
- Constraints image height so that image articles does not take too much vertical space in lists
- In article detail, add link to original file for logged in users

Deployed to staging.

## Screenshots

### Article list, desktop
<img width="980" alt="image" src="https://user-images.githubusercontent.com/108608/177980978-f3cb15c5-8c6e-4528-844c-18eb23d0b26d.png">

### Article list, mobile
<img width="499" alt="image" src="https://user-images.githubusercontent.com/108608/177981067-33c3a3c1-d2a2-40c3-af99-2f53c9b96a02.png">

### Reply list, desktop
<img width="978" alt="image" src="https://user-images.githubusercontent.com/108608/177981168-12361d87-6dd3-4e6d-89ff-db7ab37b6e06.png">

### Reply list, mobile
<img width="475" alt="image" src="https://user-images.githubusercontent.com/108608/177981140-12a78fd0-22d9-49c0-86a1-cac41685f9c1.png">

### Profile page, desktop
<img width="1244" alt="image" src="https://user-images.githubusercontent.com/108608/177982049-390b7ded-0676-4cfb-9f24-a6203ae4b141.png">

### Profile page, mobile
<img width="507" alt="image" src="https://user-images.githubusercontent.com/108608/177982098-3052b3c2-0382-48cc-bd36-97921e65ffec.png">

### Article detail, desktop
Note that only when user logs in, clicking the image in article detail would bring user to the original file 
<img width="1014" alt="image" src="https://user-images.githubusercontent.com/108608/177980481-d692c7a5-d70b-489f-b3bf-7bd3886c56aa.png">

### Article detail, mobile
<img width="547" alt="image" src="https://user-images.githubusercontent.com/108608/177980885-aee96402-7d1c-45ab-91d9-62e3dd1125e2.png">

### Create reply message tab, mobile
<img width="350" alt="image" src="https://user-images.githubusercontent.com/108608/177982871-391a80bf-275c-4d53-9244-5afe84f22fe3.png">

### Related reply, desktop
<img width="907" alt="image" src="https://user-images.githubusercontent.com/108608/177983052-72022652-7ca5-4a9f-8fde-f732b46eb5dd.png">

### Related reply, mobile
<img width="353" alt="image" src="https://user-images.githubusercontent.com/108608/177982979-dcbf3c17-a150-42da-b849-4033681472cd.png">

### Storybook
<img width="996" alt="image" src="https://user-images.githubusercontent.com/108608/177981957-725db20f-e6cd-4917-8980-fc236edc9e1f.png">
