### PR TITLE
Improve filter, sort and count in profile page.

### DIFF
--- a/components/ProfilePage/ProfilePage.js
+++ b/components/ProfilePage/ProfilePage.js
@@ -162,12 +162,7 @@ function ProfilePage({ id, slug }) {
               router.push({ query: { tab } });
             }}
           >
-            <Tab
-              value="replies"
-              label={`${t`Replied messages`} ${
-                contributionData?.repliedArticles?.totalCount
-              }`}
-            />
+            <Tab value="replies" label={t`Replied messages`} />
           </Tabs>
           {contentElem}
         </Card>

--- a/components/ProfilePage/RepliedArticleTab.js
+++ b/components/ProfilePage/RepliedArticleTab.js
@@ -13,7 +13,7 @@ import {
   SortInput,
   LoadMore,
 } from 'components/ListPageControls';
-import { CardContent } from 'components/Card';
+import { CardHeader, CardContent } from 'components/Card';
 import Infos from 'components/Infos';
 import TimeInfo from 'components/Infos/TimeInfo';
 import ExpandableText from 'components/ExpandableText';
@@ -78,6 +78,7 @@ const LOAD_REPLIED_ARTICLES_STAT = gql`
     $orderBy: [ListArticleOrderBy]
   ) {
     ListArticles(filter: $filter, orderBy: $orderBy) {
+      totalCount
       ...LoadMoreConnectionForStats
     }
   }
@@ -223,6 +224,7 @@ function RepliedArticleTab({ userId }) {
   // List data
   const articleEdges = listArticlesData?.ListArticles?.edges || [];
   const statsData = listStatData?.ListArticles || {};
+  const totalCount = statsData?.totalCount;
 
   if (!userId) {
     return null;
@@ -238,14 +240,21 @@ function RepliedArticleTab({ userId }) {
         <ReplyTypeFilter />
         <CategoryFilter />
       </Filters>
-      {loading && !articleEdges.length ? (
+      {loading && !totalCount ? (
         <CardContent>{t`Loading...`}</CardContent>
       ) : listArticlesError ? (
         <CardContent>{listArticlesError.toString()}</CardContent>
-      ) : articleEdges.length === 0 ? (
+      ) : totalCount === 0 ? (
         <CardContent>{t`No replied messages.`}</CardContent>
       ) : (
         <>
+          <CardHeader>
+            {ngettext(
+              msgid`${totalCount} message matching criteria`,
+              `${totalCount} messages matching criteria`,
+              totalCount
+            )}
+          </CardHeader>
           {articleEdges.map(({ node: article }) => (
             <CardContent key={article.id}>
               <Infos className={classes.infos}>

--- a/components/ProfilePage/RepliedArticleTab.js
+++ b/components/ProfilePage/RepliedArticleTab.js
@@ -29,7 +29,7 @@ const REPLIES_ORDER = [
     value: 'lastMatchingArticleReplyCreatedAt',
     label: t`Most recently replied`,
   },
-  { value: 'lastRepliedAt', label: t`Most recently replied by any users` },
+  { value: 'lastRepliedAt', label: t`Most recently replied by any user` },
   { value: 'lastRequestedAt', label: t`Most recently asked` },
   { value: 'replyRequestCount', label: t`Most asked` },
 ];


### PR DESCRIPTION
Fixes #492 

- Add message count of filtered messages
- Time filter and type filter should act on the users' article-reply, rather than any article replies in article.
- Add a sort option that sorts by matching (user's) article reply. 

# Screenshots
Left: this PR; Right: staging, before this PR.

## Search count & filter

- The updated time filter will properly apply the logic on the user's article reply, rather than applying on any reply of the article.
- Count of searched result is displayed below the filter.

![image](https://user-images.githubusercontent.com/108608/178222915-f3869595-8d83-4b73-8182-663108b1da08.png)

## Article reply type update

The updated type filter will properly apply the logic on the user's article reply, rather than applying on any reply of the article.
![image](https://user-images.githubusercontent.com/108608/178223554-146f6f5b-a928-4322-b56b-6433b734e911.png)

## New sort options

- Most recently applied: default. Sort by the profile page users article replies that matches the search criteria.
- Most recently applied by any user: The original sorting method before this PR.  Sort by any article reply in the matching article.
![image](https://user-images.githubusercontent.com/108608/178223803-94de74ce-3651-4004-b3c0-dd620186f618.png)
