### PR TITLE
Fix current user missing in Google Analytics

### DIFF
--- a/components/LandingPage/Header.js
+++ b/components/LandingPage/Header.js
@@ -2,15 +2,15 @@ import React, { useEffect, useState } from 'react';
 import gql from 'graphql-tag';
 import { c, t } from 'ttag';
 import cx from 'clsx';
-import { useQuery, useLazyQuery } from '@apollo/react-hooks';
+import { useQuery } from '@apollo/react-hooks';
 import { useRouter } from 'next/router';
 import { makeStyles, withStyles, useTheme } from '@material-ui/core/styles';
 import useMediaQuery from '@material-ui/core/useMediaQuery';
 import Badge from '@material-ui/core/Badge';
 import { animated, useSpring } from 'react-spring';
 import Link from 'next/link';
-import Avatar from 'components/AppLayout/Widgets/Avatar';
 
+import useCurrentUser from 'lib/useCurrentUser';
 import NavLink from 'components/NavLink';
 import * as Widgets from 'components/AppLayout/Widgets';
 
@@ -31,17 +31,6 @@ const LIST_UNSOLVED_ARTICLES = gql`
       totalCount
     }
   }
-`;
-
-const USER_QUERY = gql`
-  query UserLevelQuery {
-    GetUser {
-      id
-      name
-      ...AvatarData
-    }
-  }
-  ${Avatar.fragments.AvatarData}
 `;
 
 const CustomBadge = withStyles(theme => ({
@@ -167,8 +156,7 @@ const LandingPageHeader = React.memo(({ onLoginModalOpen }) => {
 
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
 
-  const [loadUser, { data: userData }] = useLazyQuery(USER_QUERY);
-  const user = userData?.GetUser;
+  const user = useCurrentUser();
 
   const { data } = useQuery(LIST_UNSOLVED_ARTICLES, {
     ssr: false, // no number needed for SSR
@@ -197,9 +185,6 @@ const LandingPageHeader = React.memo(({ onLoginModalOpen }) => {
       });
     }
   };
-
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  useEffect(() => loadUser(), []);
 
   useEffect(() => {
     handleScroll();


### PR DESCRIPTION
The issue is found in [20220706 meeting](https://g0v.hackmd.io/UopCx5bcRb-gt_3SdVqRdQ#%E5%B0%8F%E8%81%9A%E7%B1%8C%E5%82%99)

Currently on production, if the user is already logged in, starts their session on the landing page, and then goes to other pages, their user ID will not be sent in Google Analytics actions.

This is because
- We push current user to Google Tag Manager in `useCurrentUser`'s `onCompleted` callback 
![image](https://user-images.githubusercontent.com/108608/178239220-cac32f61-efd3-4458-8ee5-cd015a438257.png)
- Before this PR, landing page uses its own way to load user, and thus does not use `useCurrentUser`
- Landing page loads all fields that is required by `useCurrentUser`, so that when user enters other page from landing page, `useCurrentUser` hook will not invoke new GraphQL queries, thus not calling `onCompleted` callback at all.

This PR fixes the issue by using `useCurrentUser` in landing page as well.

## Screenshot
### Before
`CURRENT_USER` is not pushed to `dataLayer` even after the user logs in on landing page
![image](https://user-images.githubusercontent.com/108608/178239130-072393a5-f81b-481e-93a0-d98858a97d2b.png)


### After
Can see that `CURRENT_USER` is pushed to `dataLayer` as expected.
![image](https://user-images.githubusercontent.com/108608/178238832-0a5e6bad-cd64-4e0e-9857-0836ea73032b.png)

