### PR TITLE
Add articleTypes URL param without UI

### DIFF
--- a/pages/articles.js
+++ b/pages/articles.js
@@ -102,6 +102,10 @@ function urlQuery2Filter({ userId, ...query } = {}) {
   const selectedReplyTypes = ReplyTypeFilter.getValues(query);
   if (selectedReplyTypes.length) filterObj.replyTypes = selectedReplyTypes;
 
+  // No UI for article types yet, so we read from `query` directly
+  const articleTypes = query.articleTypes ? query.articleTypes.split(',') : [];
+  if (articleTypes.length) filterObj.articleTypes = articleTypes;
+
   // Return filterObj only when it is populated.
   if (!Object.keys(filterObj).length) {
     return undefined;


### PR DESCRIPTION
This PR adds a URL param, `articleTypes`, to rumors-site article list.

- Currently we do not officially launch image support, so the UI of this filter is not implemented yet.
    - Users must **manually specify `articleTypes` in URL**, it is not accessible from UI.
- `articleTypes` should be a comma separated list of `ArticleTypeEnum` (`TEXT`, `IMAGE`, `VIDEO`, `AUDIO`).
- When not given, `articleTypes` is not specified in `ListArticles`.
- If given, `articleTypes` is specified and thus would [override `MEDIA_ARTICLE_SUPPORT` flag in rumors-api](https://github.com/cofacts/rumors-api/blob/8eb18c6202be8735e5d7fe31db4fee5acd7eee06/src/graphql/queries/ListArticles.js#L513-L525).

## Screenshot

### Only images
<img width="698" alt="image" src="https://user-images.githubusercontent.com/108608/186336655-06eccc25-366b-4ef7-84bc-2ba151bad949.png">

### Only text
<img width="701" alt="image" src="https://user-images.githubusercontent.com/108608/186336735-0c53f560-6b84-440f-9633-800b66d20c6b.png">

### Not specified
The result depends on if the API has turned on `MEDIA_ARTICLE_SUPPORT` flag. On staging it is turned on, so it does not limit the article type to just text.
<img width="695" alt="image" src="https://user-images.githubusercontent.com/108608/186336888-e4f02d18-1fb3-49d0-9431-f656d851678b.png">


