### PR TITLE
Support showing similar images in side section

### DIFF
--- a/components/SideSection.js
+++ b/components/SideSection.js
@@ -122,3 +122,13 @@ export const SideSectionText = withStyles(() => ({
     </article>
   );
 });
+
+export const SideSectionImage = withStyles(() => ({
+  asideImage: {
+    maxWidth: '100%',
+    maxHeight: '100px',
+    verticalAlign: 'bottom',
+  },
+}))(({ classes, className, ...props }) => {
+  return <img className={cx(classes.asideImage, className)} {...props} />;
+});

--- a/components/SideSection.stories.js
+++ b/components/SideSection.stories.js
@@ -6,6 +6,7 @@ import {
   SideSectionLinks,
   SideSectionLink,
   SideSectionText,
+  SideSectionImage,
 } from './SideSection';
 
 export default {
@@ -35,6 +36,12 @@ export const SideSectionStructure = () => (
             3 Side section 3 Side section 3 Side section 3 Side section 3 Side
             section 3 Side section 3 Side section 3 Side section 3{' '}
           </SideSectionText>
+        </SideSectionLink>
+        <SideSectionLink>
+          <SideSectionImage src="https://placekitten.com/300/200" />
+        </SideSectionLink>
+        <SideSectionLink>
+          <SideSectionImage src="https://placekitten.com/200/500" />
         </SideSectionLink>
       </SideSectionLinks>
     </SideSection>

--- a/components/__snapshots__/SideSection.stories.storyshot
+++ b/components/__snapshots__/SideSection.stories.storyshot
@@ -60,6 +60,34 @@ exports[`Storyshots SideSection Side Section Structure 1`] = `
               </Component>
             </a>
           </Component>
+          <Component>
+            <a
+              className="Component-asideItem"
+            >
+              <Component
+                src="https://placekitten.com/300/200"
+              >
+                <img
+                  className="Component-asideImage"
+                  src="https://placekitten.com/300/200"
+                />
+              </Component>
+            </a>
+          </Component>
+          <Component>
+            <a
+              className="Component-asideItem"
+            >
+              <Component
+                src="https://placekitten.com/200/500"
+              >
+                <img
+                  className="Component-asideImage"
+                  src="https://placekitten.com/200/500"
+                />
+              </Component>
+            </a>
+          </Component>
         </div>
       </Component>
     </aside>

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -30,6 +30,7 @@ import {
   SideSectionLinks,
   SideSectionLink,
   SideSectionText,
+  SideSectionImage,
 } from 'components/SideSection';
 import Hyperlinks from 'components/Hyperlinks';
 import CurrentReplies from 'components/CurrentReplies';
@@ -145,6 +146,8 @@ const LOAD_ARTICLE = gql`
           node {
             id
             text
+            articleType
+            attachmentUrl(variant: THUMBNAIL)
             articleCategories {
               categoryId
             }
@@ -496,7 +499,11 @@ function ArticlePage() {
                   passHref
                 >
                   <SideSectionLink>
-                    <SideSectionText>{node.text}</SideSectionText>
+                    {node.articleType === 'IMAGE' ? (
+                      <SideSectionImage src={node.attachmentUrl} />
+                    ) : (
+                      <SideSectionText>{node.text}</SideSectionText>
+                    )}
                     <ArticleInfo className={classes.asideInfo} article={node} />
                   </SideSectionLink>
                 </Link>


### PR DESCRIPTION
Support image articles be displayed in the similar article section in article detail page.

Depends on API https://github.com/cofacts/rumors-api/pull/291

## Storybook
Mobile
![image](https://user-images.githubusercontent.com/108608/187089547-c315e151-9659-4629-b12f-7e3072ad91f7.png)

Desktop
![image](https://user-images.githubusercontent.com/108608/187089552-1614b89c-2425-4b4f-a1ff-63d1cc73608d.png)

## Real example
Mobile
![image](https://user-images.githubusercontent.com/108608/187089493-baac15b3-a4fe-467d-ad3e-9fce860a9d9c.png)

Desktop
![image](https://user-images.githubusercontent.com/108608/187089466-29347cc9-0ecc-4b81-a73a-c63f98e722ac.png)
