### PR TITLE
Support audio and video

### DIFF
--- a/components/ListPageDisplays/ArticleCard.js
+++ b/components/ListPageDisplays/ArticleCard.js
@@ -129,7 +129,7 @@ function ArticleCard({ article, highlight = '' }) {
                   : text}
               </ExpandableText>
             )}
-            <Thumbnail article={article} />
+            <Thumbnail article={article} className={classes.attachment} />
           </div>
         </ListPageCard>
       </a>

--- a/components/ListPageDisplays/ArticleCard.js
+++ b/components/ListPageDisplays/ArticleCard.js
@@ -4,6 +4,7 @@ import { c, t } from 'ttag';
 import { makeStyles } from '@material-ui/core/styles';
 import Infos, { TimeInfo } from 'components/Infos';
 import ExpandableText from 'components/ExpandableText';
+import Thumbnail from 'components/Thumbnail';
 import ListPageCard from './ListPageCard';
 import { highlightSections } from 'lib/text';
 import { useHighlightStyles } from './utils';
@@ -97,15 +98,7 @@ const useStyles = makeStyles(theme => ({
  * @param {Highlights?} props.highlight - If given, display search snippet instead of reply text
  */
 function ArticleCard({ article, highlight = '' }) {
-  const {
-    id,
-    text,
-    articleType,
-    attachmentUrl,
-    replyCount,
-    replyRequestCount,
-    createdAt,
-  } = article;
+  const { id, text, replyCount, replyRequestCount, createdAt } = article;
   const classes = useStyles();
   const highlightClasses = useHighlightStyles();
 
@@ -136,36 +129,7 @@ function ArticleCard({ article, highlight = '' }) {
                   : text}
               </ExpandableText>
             )}
-            {(() => {
-              switch (articleType) {
-                case 'TEXT':
-                  return null;
-                case 'IMAGE':
-                  return (
-                    <img
-                      className={classes.attachment}
-                      src={attachmentUrl}
-                      alt="image"
-                    />
-                  );
-                case 'VIDEO':
-                  return attachmentUrl ? (
-                    <video
-                      className={classes.attachment}
-                      src={attachmentUrl}
-                      controls
-                    />
-                  ) : (
-                    t`A video` + ` (${t`Preview not supported yet`})`
-                  );
-                case 'AUDIO':
-                  return attachmentUrl ? (
-                    <audio src={attachmentUrl} controls />
-                  ) : (
-                    t`An audio` + ` (${t`Preview not supported yet`})`
-                  );
-              }
-            })()}
+            <Thumbnail article={article} />
           </div>
         </ListPageCard>
       </a>
@@ -178,12 +142,12 @@ ArticleCard.fragments = {
     fragment ArticleCard on Article {
       id
       text
-      articleType
-      attachmentUrl(variant: THUMBNAIL)
       replyCount
       replyRequestCount
       createdAt
+      ...ThumbnailArticleData
     }
+    ${Thumbnail.fragments.ThumbnailArticleData}
   `,
   Highlight: highlightSections.fragments.HighlightFields,
 };

--- a/components/ListPageDisplays/ArticleCard.js
+++ b/components/ListPageDisplays/ArticleCard.js
@@ -84,7 +84,7 @@ const useStyles = makeStyles(theme => ({
   highlight: {
     color: theme.palette.primary[500],
   },
-  attachmentImage: {
+  attachment: {
     minWidth: 0, // Don't use intrinsic image width as flex item min-size
     maxHeight: '10em', // Don't let image rows take too much vertical space
   },
@@ -100,6 +100,7 @@ function ArticleCard({ article, highlight = '' }) {
   const {
     id,
     text,
+    articleType,
     attachmentUrl,
     replyCount,
     replyRequestCount,
@@ -135,13 +136,36 @@ function ArticleCard({ article, highlight = '' }) {
                   : text}
               </ExpandableText>
             )}
-            {attachmentUrl && (
-              <img
-                className={classes.attachmentImage}
-                src={attachmentUrl}
-                alt="image"
-              />
-            )}
+            {(() => {
+              switch (articleType) {
+                case 'TEXT':
+                  return null;
+                case 'IMAGE':
+                  return (
+                    <img
+                      className={classes.attachment}
+                      src={attachmentUrl}
+                      alt="image"
+                    />
+                  );
+                case 'VIDEO':
+                  return attachmentUrl ? (
+                    <video
+                      className={classes.attachment}
+                      src={attachmentUrl}
+                      controls
+                    />
+                  ) : (
+                    t`A video` + ` (${t`Preview not supported yet`})`
+                  );
+                case 'AUDIO':
+                  return attachmentUrl ? (
+                    <audio src={attachmentUrl} controls />
+                  ) : (
+                    t`An audio` + ` (${t`Preview not supported yet`})`
+                  );
+              }
+            })()}
           </div>
         </ListPageCard>
       </a>
@@ -154,6 +178,7 @@ ArticleCard.fragments = {
     fragment ArticleCard on Article {
       id
       text
+      articleType
       attachmentUrl(variant: THUMBNAIL)
       replyCount
       replyRequestCount

--- a/components/ListPageDisplays/ListPageCards.stories.js
+++ b/components/ListPageDisplays/ListPageCards.stories.js
@@ -61,7 +61,7 @@ export const ArticleCards = () => (
     <ArticleCard
       article={{
         id: 'id3',
-        attachmentUrl: 'https://placekitten.com/512/1000',
+        thumbnailUrl: 'https://placekitten.com/512/1000',
         replyCount: 6,
         replyRequestCount: 4,
         createdAt: '2020-01-01T00:00:00Z',
@@ -71,7 +71,7 @@ export const ArticleCards = () => (
     <ArticleCard
       article={{
         id: 'id3',
-        attachmentUrl: 'https://placekitten.com/2000/150',
+        thumbnailUrl: 'https://placekitten.com/2000/150',
         replyCount: 4,
         replyRequestCount: 6,
         createdAt: '2020-01-01T00:00:00Z',
@@ -81,7 +81,7 @@ export const ArticleCards = () => (
     <ArticleCard
       article={{
         id: 'id4',
-        attachmentUrl: null,
+        thumbnailUrl: null,
         replyCount: 0,
         replyRequestCount: 0,
         createdAt: '2020-01-01T00:00:00Z',
@@ -91,7 +91,7 @@ export const ArticleCards = () => (
     <ArticleCard
       article={{
         id: 'id5',
-        attachmentUrl:
+        thumbnailUrl:
           'https://drive.google.com/uc?id=1SQ9lc1-ghzw-SL6Dyb_UMN6hAPBAckvK&confirm=t',
         replyCount: 0,
         replyRequestCount: 0,
@@ -102,7 +102,7 @@ export const ArticleCards = () => (
     <ArticleCard
       article={{
         id: 'id6',
-        attachmentUrl:
+        thumbnailUrl:
           'https://drive.google.com/uc?id=1DczThMYTmGV3GvDCAU2EPnhsBwVcoFQi&confirm=t',
         replyCount: 0,
         replyRequestCount: 0,
@@ -113,7 +113,7 @@ export const ArticleCards = () => (
     <ArticleCard
       article={{
         id: 'id6',
-        attachmentUrl:
+        thumbnailUrl:
           'https://drive.google.com/uc?id=1D-K8hVcOw7UNbu80uJkAYMJd1HilAFOp&confirm=t',
         replyCount: 0,
         replyRequestCount: 0,

--- a/components/ListPageDisplays/ListPageCards.stories.js
+++ b/components/ListPageDisplays/ListPageCards.stories.js
@@ -33,6 +33,7 @@ export const ArticleCards = () => (
         replyCount: 3,
         replyRequestCount: 4,
         createdAt: '2020-01-01T00:00:00Z',
+        articleType: 'TEXT',
       }}
     />
     <ArticleCard
@@ -43,6 +44,7 @@ export const ArticleCards = () => (
         replyCount: 0,
         replyRequestCount: 999,
         createdAt: '2019-01-01T00:00:00Z',
+        articleType: 'TEXT',
       }}
       highlight={{
         text:
@@ -63,6 +65,7 @@ export const ArticleCards = () => (
         replyCount: 6,
         replyRequestCount: 4,
         createdAt: '2020-01-01T00:00:00Z',
+        articleType: 'IMAGE',
       }}
     />
     <ArticleCard
@@ -72,6 +75,50 @@ export const ArticleCards = () => (
         replyCount: 4,
         replyRequestCount: 6,
         createdAt: '2020-01-01T00:00:00Z',
+        articleType: 'IMAGE',
+      }}
+    />
+    <ArticleCard
+      article={{
+        id: 'id4',
+        attachmentUrl: null,
+        replyCount: 0,
+        replyRequestCount: 0,
+        createdAt: '2020-01-01T00:00:00Z',
+        articleType: 'VIDEO',
+      }}
+    />
+    <ArticleCard
+      article={{
+        id: 'id5',
+        attachmentUrl:
+          'https://drive.google.com/uc?id=1SQ9lc1-ghzw-SL6Dyb_UMN6hAPBAckvK&confirm=t',
+        replyCount: 0,
+        replyRequestCount: 0,
+        createdAt: '2020-01-01T00:00:00Z',
+        articleType: 'VIDEO',
+      }}
+    />
+    <ArticleCard
+      article={{
+        id: 'id6',
+        attachmentUrl:
+          'https://drive.google.com/uc?id=1DczThMYTmGV3GvDCAU2EPnhsBwVcoFQi&confirm=t',
+        replyCount: 0,
+        replyRequestCount: 0,
+        createdAt: '2020-01-01T00:00:00Z',
+        articleType: 'VIDEO',
+      }}
+    />
+    <ArticleCard
+      article={{
+        id: 'id6',
+        attachmentUrl:
+          'https://drive.google.com/uc?id=1D-K8hVcOw7UNbu80uJkAYMJd1HilAFOp&confirm=t',
+        replyCount: 0,
+        replyRequestCount: 0,
+        createdAt: '2020-01-01T00:00:00Z',
+        articleType: 'AUDIO',
       }}
     />
   </ListPageCards>

--- a/components/ListPageDisplays/ReplySearchItem.js
+++ b/components/ListPageDisplays/ReplySearchItem.js
@@ -13,6 +13,7 @@ import {
 import ExpandableText from 'components/ExpandableText';
 import Infos from 'components/Infos';
 import TimeInfo from 'components/Infos/TimeInfo';
+import Thumbnail from 'components/Thumbnail';
 import ReplyItem from './ReplyItem';
 import { nl2br } from 'lib/text';
 import VisibilityIcon from '@material-ui/icons/Visibility';
@@ -92,10 +93,6 @@ const useStyles = makeStyles(theme => ({
       marginBottom: 0,
     },
   },
-  attachmentImage: {
-    maxWidth: '100%',
-    maxHeight: '8em', // So that image don't take too much space (more than replies)
-  },
 }));
 
 function RepliedArticleInfo({ article }) {
@@ -146,13 +143,7 @@ export default function ReplySearchItem({
       <Box p={{ xs: 2, md: 4.5 }}>
         <RepliedArticleInfo article={articleReply.article} />
         <div className={classes.flex}>
-          {articleReply.article.attachmentUrl && (
-            <img
-              className={classes.attachmentImage}
-              src={articleReply.article.attachmentUrl}
-              alt="image"
-            />
-          )}
+          <Thumbnail article={articleReply.article} />
           {articleReply.article.text && (
             <ExpandableText className={classes.content} lineClamp={3}>
               {nl2br(articleReply.article.text)}
@@ -196,13 +187,7 @@ export default function ReplySearchItem({
                   >
                     <div className={classes.otherArticleItem}>
                       <RepliedArticleInfo article={article} />
-                      {article.attachmentUrl && (
-                        <img
-                          className={classes.attachmentImage}
-                          src={article.attachmentUrl}
-                          alt="image"
-                        />
-                      )}
+                      <Thumbnail article={article} />
                       {article.text && (
                         <ExpandableText lineClamp={3}>
                           {article.text}
@@ -229,9 +214,9 @@ ReplySearchItem.fragments = {
         article {
           id
           text
-          attachmentUrl(variant: THUMBNAIL)
           replyRequestCount
           createdAt
+          ...ThumbnailArticleData
         }
         ...ReplyItemArticleReplyData
       }
@@ -239,6 +224,7 @@ ReplySearchItem.fragments = {
     }
     ${ReplyItem.fragments.ReplyItem}
     ${ReplyItem.fragments.ReplyItemArticleReplyData}
+    ${Thumbnail.fragments.ThumbnailArticleData}
   `,
   Highlight: ReplyItem.fragments.Highlight,
 };

--- a/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
+++ b/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
@@ -113,6 +113,7 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                       "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
                     }
                   }
+                  className="makeStyles-attachment"
                 />
               </div>
             </article>
@@ -271,6 +272,7 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                       "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eu ex augue. Etiam posuere sagittis iaculis. Vestibulum sollicitudin nec felis a mollis. Phasellus ut est velit. Proin fermentum arcu ornare quam vulputate, vel eleifend velit ultrices. Fusce tincidunt vel urna at luctus.",
                     }
                   }
+                  className="makeStyles-attachment"
                 />
               </div>
             </article>
@@ -367,10 +369,11 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                       "thumbnailUrl": "https://placekitten.com/512/1000",
                     }
                   }
+                  className="makeStyles-attachment"
                 >
                   <img
                     alt=""
-                    className="makeStyles-thumbnail"
+                    className="makeStyles-thumbnail makeStyles-attachment"
                     src="https://placekitten.com/512/1000"
                   />
                 </Thumbnail>
@@ -469,10 +472,11 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                       "thumbnailUrl": "https://placekitten.com/2000/150",
                     }
                   }
+                  className="makeStyles-attachment"
                 >
                   <img
                     alt=""
-                    className="makeStyles-thumbnail"
+                    className="makeStyles-thumbnail makeStyles-attachment"
                     src="https://placekitten.com/2000/150"
                   />
                 </Thumbnail>
@@ -571,6 +575,7 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                       "thumbnailUrl": null,
                     }
                   }
+                  className="makeStyles-attachment"
                 >
                   A video (Preview not supported yet)
                 </Thumbnail>
@@ -669,10 +674,11 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                       "thumbnailUrl": "https://drive.google.com/uc?id=1SQ9lc1-ghzw-SL6Dyb_UMN6hAPBAckvK&confirm=t",
                     }
                   }
+                  className="makeStyles-attachment"
                 >
                   <video
                     autoPlay={true}
-                    className="makeStyles-thumbnail"
+                    className="makeStyles-thumbnail makeStyles-attachment"
                     loop={true}
                     muted={true}
                     src="https://drive.google.com/uc?id=1SQ9lc1-ghzw-SL6Dyb_UMN6hAPBAckvK&confirm=t"
@@ -773,10 +779,11 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                       "thumbnailUrl": "https://drive.google.com/uc?id=1DczThMYTmGV3GvDCAU2EPnhsBwVcoFQi&confirm=t",
                     }
                   }
+                  className="makeStyles-attachment"
                 >
                   <video
                     autoPlay={true}
-                    className="makeStyles-thumbnail"
+                    className="makeStyles-thumbnail makeStyles-attachment"
                     loop={true}
                     muted={true}
                     src="https://drive.google.com/uc?id=1DczThMYTmGV3GvDCAU2EPnhsBwVcoFQi&confirm=t"
@@ -877,6 +884,7 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                       "thumbnailUrl": "https://drive.google.com/uc?id=1D-K8hVcOw7UNbu80uJkAYMJd1HilAFOp&confirm=t",
                     }
                   }
+                  className="makeStyles-attachment"
                 >
                   <audio
                     controls={true}

--- a/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
+++ b/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
@@ -102,6 +102,18 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     </div>
                   </div>
                 </ExpandableText>
+                <Thumbnail
+                  article={
+                    Object {
+                      "articleType": "TEXT",
+                      "createdAt": "2020-01-01T00:00:00Z",
+                      "id": "id1",
+                      "replyCount": 3,
+                      "replyRequestCount": 4,
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                    }
+                  }
+                />
               </div>
             </article>
           </ListPageCard>
@@ -248,6 +260,18 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     </div>
                   </div>
                 </ExpandableText>
+                <Thumbnail
+                  article={
+                    Object {
+                      "articleType": "TEXT",
+                      "createdAt": "2019-01-01T00:00:00Z",
+                      "id": "id2",
+                      "replyCount": 0,
+                      "replyRequestCount": 999,
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eu ex augue. Etiam posuere sagittis iaculis. Vestibulum sollicitudin nec felis a mollis. Phasellus ut est velit. Proin fermentum arcu ornare quam vulputate, vel eleifend velit ultrices. Fusce tincidunt vel urna at luctus.",
+                    }
+                  }
+                />
               </div>
             </article>
           </ListPageCard>
@@ -258,11 +282,11 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
       article={
         Object {
           "articleType": "IMAGE",
-          "attachmentUrl": "https://placekitten.com/512/1000",
           "createdAt": "2020-01-01T00:00:00Z",
           "id": "id3",
           "replyCount": 6,
           "replyRequestCount": 4,
+          "thumbnailUrl": "https://placekitten.com/512/1000",
         }
       }
     >
@@ -332,11 +356,24 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     </span>
                   </div>
                 </div>
-                <img
-                  alt="image"
-                  className="makeStyles-attachment"
-                  src="https://placekitten.com/512/1000"
-                />
+                <Thumbnail
+                  article={
+                    Object {
+                      "articleType": "IMAGE",
+                      "createdAt": "2020-01-01T00:00:00Z",
+                      "id": "id3",
+                      "replyCount": 6,
+                      "replyRequestCount": 4,
+                      "thumbnailUrl": "https://placekitten.com/512/1000",
+                    }
+                  }
+                >
+                  <img
+                    alt=""
+                    className="makeStyles-thumbnail"
+                    src="https://placekitten.com/512/1000"
+                  />
+                </Thumbnail>
               </div>
             </article>
           </ListPageCard>
@@ -347,11 +384,11 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
       article={
         Object {
           "articleType": "IMAGE",
-          "attachmentUrl": "https://placekitten.com/2000/150",
           "createdAt": "2020-01-01T00:00:00Z",
           "id": "id3",
           "replyCount": 4,
           "replyRequestCount": 6,
+          "thumbnailUrl": "https://placekitten.com/2000/150",
         }
       }
     >
@@ -421,11 +458,24 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     </span>
                   </div>
                 </div>
-                <img
-                  alt="image"
-                  className="makeStyles-attachment"
-                  src="https://placekitten.com/2000/150"
-                />
+                <Thumbnail
+                  article={
+                    Object {
+                      "articleType": "IMAGE",
+                      "createdAt": "2020-01-01T00:00:00Z",
+                      "id": "id3",
+                      "replyCount": 4,
+                      "replyRequestCount": 6,
+                      "thumbnailUrl": "https://placekitten.com/2000/150",
+                    }
+                  }
+                >
+                  <img
+                    alt=""
+                    className="makeStyles-thumbnail"
+                    src="https://placekitten.com/2000/150"
+                  />
+                </Thumbnail>
               </div>
             </article>
           </ListPageCard>
@@ -436,11 +486,11 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
       article={
         Object {
           "articleType": "VIDEO",
-          "attachmentUrl": null,
           "createdAt": "2020-01-01T00:00:00Z",
           "id": "id4",
           "replyCount": 0,
           "replyRequestCount": 0,
+          "thumbnailUrl": null,
         }
       }
     >
@@ -510,7 +560,20 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     </span>
                   </div>
                 </div>
-                A video (Preview not supported yet)
+                <Thumbnail
+                  article={
+                    Object {
+                      "articleType": "VIDEO",
+                      "createdAt": "2020-01-01T00:00:00Z",
+                      "id": "id4",
+                      "replyCount": 0,
+                      "replyRequestCount": 0,
+                      "thumbnailUrl": null,
+                    }
+                  }
+                >
+                  A video (Preview not supported yet)
+                </Thumbnail>
               </div>
             </article>
           </ListPageCard>
@@ -521,11 +584,11 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
       article={
         Object {
           "articleType": "VIDEO",
-          "attachmentUrl": "https://drive.google.com/uc?id=1SQ9lc1-ghzw-SL6Dyb_UMN6hAPBAckvK&confirm=t",
           "createdAt": "2020-01-01T00:00:00Z",
           "id": "id5",
           "replyCount": 0,
           "replyRequestCount": 0,
+          "thumbnailUrl": "https://drive.google.com/uc?id=1SQ9lc1-ghzw-SL6Dyb_UMN6hAPBAckvK&confirm=t",
         }
       }
     >
@@ -595,11 +658,26 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     </span>
                   </div>
                 </div>
-                <video
-                  className="makeStyles-attachment"
-                  controls={true}
-                  src="https://drive.google.com/uc?id=1SQ9lc1-ghzw-SL6Dyb_UMN6hAPBAckvK&confirm=t"
-                />
+                <Thumbnail
+                  article={
+                    Object {
+                      "articleType": "VIDEO",
+                      "createdAt": "2020-01-01T00:00:00Z",
+                      "id": "id5",
+                      "replyCount": 0,
+                      "replyRequestCount": 0,
+                      "thumbnailUrl": "https://drive.google.com/uc?id=1SQ9lc1-ghzw-SL6Dyb_UMN6hAPBAckvK&confirm=t",
+                    }
+                  }
+                >
+                  <video
+                    autoPlay={true}
+                    className="makeStyles-thumbnail"
+                    loop={true}
+                    muted={true}
+                    src="https://drive.google.com/uc?id=1SQ9lc1-ghzw-SL6Dyb_UMN6hAPBAckvK&confirm=t"
+                  />
+                </Thumbnail>
               </div>
             </article>
           </ListPageCard>
@@ -610,11 +688,11 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
       article={
         Object {
           "articleType": "VIDEO",
-          "attachmentUrl": "https://drive.google.com/uc?id=1DczThMYTmGV3GvDCAU2EPnhsBwVcoFQi&confirm=t",
           "createdAt": "2020-01-01T00:00:00Z",
           "id": "id6",
           "replyCount": 0,
           "replyRequestCount": 0,
+          "thumbnailUrl": "https://drive.google.com/uc?id=1DczThMYTmGV3GvDCAU2EPnhsBwVcoFQi&confirm=t",
         }
       }
     >
@@ -684,11 +762,26 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     </span>
                   </div>
                 </div>
-                <video
-                  className="makeStyles-attachment"
-                  controls={true}
-                  src="https://drive.google.com/uc?id=1DczThMYTmGV3GvDCAU2EPnhsBwVcoFQi&confirm=t"
-                />
+                <Thumbnail
+                  article={
+                    Object {
+                      "articleType": "VIDEO",
+                      "createdAt": "2020-01-01T00:00:00Z",
+                      "id": "id6",
+                      "replyCount": 0,
+                      "replyRequestCount": 0,
+                      "thumbnailUrl": "https://drive.google.com/uc?id=1DczThMYTmGV3GvDCAU2EPnhsBwVcoFQi&confirm=t",
+                    }
+                  }
+                >
+                  <video
+                    autoPlay={true}
+                    className="makeStyles-thumbnail"
+                    loop={true}
+                    muted={true}
+                    src="https://drive.google.com/uc?id=1DczThMYTmGV3GvDCAU2EPnhsBwVcoFQi&confirm=t"
+                  />
+                </Thumbnail>
               </div>
             </article>
           </ListPageCard>
@@ -699,11 +792,11 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
       article={
         Object {
           "articleType": "AUDIO",
-          "attachmentUrl": "https://drive.google.com/uc?id=1D-K8hVcOw7UNbu80uJkAYMJd1HilAFOp&confirm=t",
           "createdAt": "2020-01-01T00:00:00Z",
           "id": "id6",
           "replyCount": 0,
           "replyRequestCount": 0,
+          "thumbnailUrl": "https://drive.google.com/uc?id=1D-K8hVcOw7UNbu80uJkAYMJd1HilAFOp&confirm=t",
         }
       }
     >
@@ -773,10 +866,23 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     </span>
                   </div>
                 </div>
-                <audio
-                  controls={true}
-                  src="https://drive.google.com/uc?id=1D-K8hVcOw7UNbu80uJkAYMJd1HilAFOp&confirm=t"
-                />
+                <Thumbnail
+                  article={
+                    Object {
+                      "articleType": "AUDIO",
+                      "createdAt": "2020-01-01T00:00:00Z",
+                      "id": "id6",
+                      "replyCount": 0,
+                      "replyRequestCount": 0,
+                      "thumbnailUrl": "https://drive.google.com/uc?id=1D-K8hVcOw7UNbu80uJkAYMJd1HilAFOp&confirm=t",
+                    }
+                  }
+                >
+                  <audio
+                    controls={true}
+                    src="https://drive.google.com/uc?id=1D-K8hVcOw7UNbu80uJkAYMJd1HilAFOp&confirm=t"
+                  />
+                </Thumbnail>
               </div>
             </article>
           </ListPageCard>

--- a/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
+++ b/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
@@ -8,6 +8,7 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
     <ArticleCard
       article={
         Object {
+          "articleType": "TEXT",
           "createdAt": "2020-01-01T00:00:00Z",
           "id": "id1",
           "replyCount": 3,
@@ -110,6 +111,7 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
     <ArticleCard
       article={
         Object {
+          "articleType": "TEXT",
           "createdAt": "2019-01-01T00:00:00Z",
           "id": "id2",
           "replyCount": 0,
@@ -255,6 +257,7 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
     <ArticleCard
       article={
         Object {
+          "articleType": "IMAGE",
           "attachmentUrl": "https://placekitten.com/512/1000",
           "createdAt": "2020-01-01T00:00:00Z",
           "id": "id3",
@@ -331,7 +334,7 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                 </div>
                 <img
                   alt="image"
-                  className="makeStyles-attachmentImage"
+                  className="makeStyles-attachment"
                   src="https://placekitten.com/512/1000"
                 />
               </div>
@@ -343,6 +346,7 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
     <ArticleCard
       article={
         Object {
+          "articleType": "IMAGE",
           "attachmentUrl": "https://placekitten.com/2000/150",
           "createdAt": "2020-01-01T00:00:00Z",
           "id": "id3",
@@ -419,8 +423,359 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                 </div>
                 <img
                   alt="image"
-                  className="makeStyles-attachmentImage"
+                  className="makeStyles-attachment"
                   src="https://placekitten.com/2000/150"
+                />
+              </div>
+            </article>
+          </ListPageCard>
+        </a>
+      </Link>
+    </ArticleCard>
+    <ArticleCard
+      article={
+        Object {
+          "articleType": "VIDEO",
+          "attachmentUrl": null,
+          "createdAt": "2020-01-01T00:00:00Z",
+          "id": "id4",
+          "replyCount": 0,
+          "replyRequestCount": 0,
+        }
+      }
+    >
+      <Link
+        as="/article/id4"
+        href="/article/[id]"
+      >
+        <a
+          className="makeStyles-root"
+          href="/article/id4"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          <ListPageCard>
+            <article
+              className="makeStyles-root"
+            >
+              <Infos>
+                <div
+                  className="makeStyles-root"
+                >
+                  <TimeInfo
+                    key=".0"
+                    time="2020-01-01T00:00:00Z"
+                  >
+                    <Tooltip
+                      title="Jan 1, 2020, 12:00 AM"
+                    >
+                      <time
+                        aria-describedby={null}
+                        className=""
+                        dateTime="2020-01-01T00:00:00.000Z"
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        title="Jan 1, 2020, 12:00 AM"
+                      >
+                        First reported now
+                      </time>
+                    </Tooltip>
+                  </TimeInfo>
+                </div>
+              </Infos>
+              <div
+                className="makeStyles-flex"
+              >
+                <div
+                  className="makeStyles-infoBox"
+                >
+                  <div>
+                    <h2>
+                      0
+                    </h2>
+                    <span>
+                      replies
+                    </span>
+                  </div>
+                  <div>
+                    <h2>
+                      0
+                    </h2>
+                    <span>
+                      reports
+                    </span>
+                  </div>
+                </div>
+                A video (Preview not supported yet)
+              </div>
+            </article>
+          </ListPageCard>
+        </a>
+      </Link>
+    </ArticleCard>
+    <ArticleCard
+      article={
+        Object {
+          "articleType": "VIDEO",
+          "attachmentUrl": "https://drive.google.com/uc?id=1SQ9lc1-ghzw-SL6Dyb_UMN6hAPBAckvK&confirm=t",
+          "createdAt": "2020-01-01T00:00:00Z",
+          "id": "id5",
+          "replyCount": 0,
+          "replyRequestCount": 0,
+        }
+      }
+    >
+      <Link
+        as="/article/id5"
+        href="/article/[id]"
+      >
+        <a
+          className="makeStyles-root"
+          href="/article/id5"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          <ListPageCard>
+            <article
+              className="makeStyles-root"
+            >
+              <Infos>
+                <div
+                  className="makeStyles-root"
+                >
+                  <TimeInfo
+                    key=".0"
+                    time="2020-01-01T00:00:00Z"
+                  >
+                    <Tooltip
+                      title="Jan 1, 2020, 12:00 AM"
+                    >
+                      <time
+                        aria-describedby={null}
+                        className=""
+                        dateTime="2020-01-01T00:00:00.000Z"
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        title="Jan 1, 2020, 12:00 AM"
+                      >
+                        First reported now
+                      </time>
+                    </Tooltip>
+                  </TimeInfo>
+                </div>
+              </Infos>
+              <div
+                className="makeStyles-flex"
+              >
+                <div
+                  className="makeStyles-infoBox"
+                >
+                  <div>
+                    <h2>
+                      0
+                    </h2>
+                    <span>
+                      replies
+                    </span>
+                  </div>
+                  <div>
+                    <h2>
+                      0
+                    </h2>
+                    <span>
+                      reports
+                    </span>
+                  </div>
+                </div>
+                <video
+                  className="makeStyles-attachment"
+                  controls={true}
+                  src="https://drive.google.com/uc?id=1SQ9lc1-ghzw-SL6Dyb_UMN6hAPBAckvK&confirm=t"
+                />
+              </div>
+            </article>
+          </ListPageCard>
+        </a>
+      </Link>
+    </ArticleCard>
+    <ArticleCard
+      article={
+        Object {
+          "articleType": "VIDEO",
+          "attachmentUrl": "https://drive.google.com/uc?id=1DczThMYTmGV3GvDCAU2EPnhsBwVcoFQi&confirm=t",
+          "createdAt": "2020-01-01T00:00:00Z",
+          "id": "id6",
+          "replyCount": 0,
+          "replyRequestCount": 0,
+        }
+      }
+    >
+      <Link
+        as="/article/id6"
+        href="/article/[id]"
+      >
+        <a
+          className="makeStyles-root"
+          href="/article/id6"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          <ListPageCard>
+            <article
+              className="makeStyles-root"
+            >
+              <Infos>
+                <div
+                  className="makeStyles-root"
+                >
+                  <TimeInfo
+                    key=".0"
+                    time="2020-01-01T00:00:00Z"
+                  >
+                    <Tooltip
+                      title="Jan 1, 2020, 12:00 AM"
+                    >
+                      <time
+                        aria-describedby={null}
+                        className=""
+                        dateTime="2020-01-01T00:00:00.000Z"
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        title="Jan 1, 2020, 12:00 AM"
+                      >
+                        First reported now
+                      </time>
+                    </Tooltip>
+                  </TimeInfo>
+                </div>
+              </Infos>
+              <div
+                className="makeStyles-flex"
+              >
+                <div
+                  className="makeStyles-infoBox"
+                >
+                  <div>
+                    <h2>
+                      0
+                    </h2>
+                    <span>
+                      replies
+                    </span>
+                  </div>
+                  <div>
+                    <h2>
+                      0
+                    </h2>
+                    <span>
+                      reports
+                    </span>
+                  </div>
+                </div>
+                <video
+                  className="makeStyles-attachment"
+                  controls={true}
+                  src="https://drive.google.com/uc?id=1DczThMYTmGV3GvDCAU2EPnhsBwVcoFQi&confirm=t"
+                />
+              </div>
+            </article>
+          </ListPageCard>
+        </a>
+      </Link>
+    </ArticleCard>
+    <ArticleCard
+      article={
+        Object {
+          "articleType": "AUDIO",
+          "attachmentUrl": "https://drive.google.com/uc?id=1D-K8hVcOw7UNbu80uJkAYMJd1HilAFOp&confirm=t",
+          "createdAt": "2020-01-01T00:00:00Z",
+          "id": "id6",
+          "replyCount": 0,
+          "replyRequestCount": 0,
+        }
+      }
+    >
+      <Link
+        as="/article/id6"
+        href="/article/[id]"
+      >
+        <a
+          className="makeStyles-root"
+          href="/article/id6"
+          onClick={[Function]}
+          onMouseEnter={[Function]}
+        >
+          <ListPageCard>
+            <article
+              className="makeStyles-root"
+            >
+              <Infos>
+                <div
+                  className="makeStyles-root"
+                >
+                  <TimeInfo
+                    key=".0"
+                    time="2020-01-01T00:00:00Z"
+                  >
+                    <Tooltip
+                      title="Jan 1, 2020, 12:00 AM"
+                    >
+                      <time
+                        aria-describedby={null}
+                        className=""
+                        dateTime="2020-01-01T00:00:00.000Z"
+                        onBlur={[Function]}
+                        onFocus={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseOver={[Function]}
+                        onTouchEnd={[Function]}
+                        onTouchStart={[Function]}
+                        title="Jan 1, 2020, 12:00 AM"
+                      >
+                        First reported now
+                      </time>
+                    </Tooltip>
+                  </TimeInfo>
+                </div>
+              </Infos>
+              <div
+                className="makeStyles-flex"
+              >
+                <div
+                  className="makeStyles-infoBox"
+                >
+                  <div>
+                    <h2>
+                      0
+                    </h2>
+                    <span>
+                      replies
+                    </span>
+                  </div>
+                  <div>
+                    <h2>
+                      0
+                    </h2>
+                    <span>
+                      reports
+                    </span>
+                  </div>
+                </div>
+                <audio
+                  controls={true}
+                  src="https://drive.google.com/uc?id=1D-K8hVcOw7UNbu80uJkAYMJd1HilAFOp&confirm=t"
                 />
               </div>
             </article>

--- a/components/NewReplySection/Mobile.js
+++ b/components/NewReplySection/Mobile.js
@@ -69,7 +69,7 @@ const useStyles = makeStyles(theme => ({
       },
     },
   },
-  attachmentImage: { maxWidth: '100%' },
+  attachment: { maxWidth: '100%' },
 }));
 
 const CustomSelectInput = withStyles(theme => ({
@@ -178,6 +178,31 @@ export default function Mobile({
           <Box display="flex" flexDirection="column" flexGrow={1}>
             {selectedTab === 0 && (
               <Box p={2}>
+                {(() => {
+                  switch (article.articleType) {
+                    case 'IMAGE':
+                      return (
+                        <img
+                          className={classes.attachment}
+                          src={article.attachmentUrl}
+                          alt="image"
+                        />
+                      );
+                    case 'VIDEO':
+                      return (
+                        <video
+                          className={classes.attachment}
+                          src={article.originalAttachmentUrl}
+                          controls
+                        />
+                      );
+                    case 'AUDIO':
+                      return (
+                        <audio src={article.originalAttachmentUrl} controls />
+                      );
+                  }
+                })()}
+
                 {nl2br(
                   linkify(article.text, {
                     props: {
@@ -186,11 +211,6 @@ export default function Mobile({
                   })
                 )}
                 <Hyperlinks hyperlinks={article.hyperlinks} />
-                <img
-                  className={classes.attachmentImage}
-                  src={article.attachmentUrl}
-                  alt="image"
-                />
               </Box>
             )}
             {selectedTab === 1 && (

--- a/components/ProfilePage/RepliedArticleTab.js
+++ b/components/ProfilePage/RepliedArticleTab.js
@@ -21,6 +21,7 @@ import ArticleReplyFeedbackControl from 'components/ArticleReplyFeedbackControl'
 import ArticleReplySummary from 'components/ArticleReplySummary';
 import Avatar from 'components/AppLayout/Widgets/Avatar';
 import ReplyInfo from 'components/ReplyInfo';
+import Thumbnail from 'components/Thumbnail';
 
 import { nl2br, linkify } from 'lib/text';
 
@@ -116,10 +117,6 @@ const useStyles = makeStyles(theme => ({
   },
   reply: { marginLeft: 56 },
   replyControl: { marginTop: 16 },
-  attachmentImage: {
-    maxWidth: '100%',
-    maxHeight: '8em', // So that image don't take too much space (more than replies)
-  },
 }));
 
 function ArticleReply({ articleReply }) {
@@ -272,13 +269,7 @@ function RepliedArticleTab({ userId }) {
                   {timeAgo => t`First reported ${timeAgo}`}
                 </TimeInfo>
               </Infos>
-              {article.attachmentUrl && (
-                <img
-                  className={classes.attachmentImage}
-                  src={article.attachmentUrl}
-                  alt="image"
-                />
-              )}
+              <Thumbnail article={article} />
               {article.text && (
                 <ExpandableText lineClamp={3}>{article.text}</ExpandableText>
               )}

--- a/components/ProfilePage/RepliedArticleTab.js
+++ b/components/ProfilePage/RepliedArticleTab.js
@@ -49,7 +49,7 @@ const LOAD_REPLIED_ARTICLES = gql`
           replyRequestCount
           createdAt
           text
-          attachmentUrl(variant: THUMBNAIL)
+          ...ThumbnailArticleData
           articleReplies(status: NORMAL) {
             replyId
             createdAt
@@ -75,6 +75,7 @@ const LOAD_REPLIED_ARTICLES = gql`
   ${ReplyInfo.fragments.replyInfo}
   ${Avatar.fragments.AvatarData}
   ${ArticleReplySummary.fragments.ArticleReplySummaryData}
+  ${Thumbnail.fragments.ThumbnailArticleData}
 `;
 
 const LOAD_REPLIED_ARTICLES_STAT = gql`

--- a/components/RelatedReplies.js
+++ b/components/RelatedReplies.js
@@ -9,6 +9,7 @@ import ExpandableText from './ExpandableText';
 import { linkify, nl2br } from 'lib/text';
 import Link from 'next/link';
 import PlainList from 'components/PlainList';
+import Thumbnail from 'components/Thumbnail';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -50,7 +51,7 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
     padding: 12,
   },
-  attachmentImage: {
+  attachment: {
     maxWidth: '100%',
     maxHeight: '10em', // 10 lines height
   },
@@ -80,9 +81,10 @@ const RelatedArticleReplyData = gql`
     article {
       id
       text
-      attachmentUrl(variant: THUMBNAIL)
+      ...ThumbnailArticleData
     }
   }
+  ${Thumbnail.fragments.ThumbnailArticleData}
 `;
 
 /**
@@ -115,13 +117,7 @@ function RelatedReplyItem({ article, reply, onConnect, disabled, actionText }) {
         <section>
           <h3 className={classes.title}>{t`Related article`}</h3>
           <blockquote className={classes.blockquote}>
-            {article.attachmentUrl && (
-              <img
-                className={classes.attachmentImage}
-                src={article.attachmentUrl}
-                alt="image"
-              />
-            )}
+            <Thumbnail article={article} className={classes.attachment} />
             {article.text && (
               <ExpandableText wordCount={40}>
                 {/*

--- a/components/ReportPage/__snapshots__/ActionButton.stories.storyshot
+++ b/components/ReportPage/__snapshots__/ActionButton.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots ReportPage/ActionButton Default 1`] = `
   }
 >
   <button
-    className="MuiButtonBase-root-301 MuiButton-root-274 MuiButton-outlined-279 makeStyles-button"
+    className="MuiButtonBase-root-302 MuiButton-root-275 MuiButton-outlined-280 makeStyles-button"
     disabled={false}
     onBlur={[Function]}
     onDragLeave={[Function]}
@@ -31,13 +31,13 @@ exports[`Storyshots ReportPage/ActionButton Default 1`] = `
     type="button"
   >
     <span
-      className="MuiButton-label-275"
+      className="MuiButton-label-276"
     >
       Action button text
       <Arrow>
         <svg
           aria-hidden={true}
-          className="MuiSvgIcon-root-302"
+          className="MuiSvgIcon-root-303"
           focusable="false"
           viewBox="0 0 14 27"
         >
@@ -51,7 +51,7 @@ exports[`Storyshots ReportPage/ActionButton Default 1`] = `
       </Arrow>
     </span>
     <span
-      className="MuiTouchRipple-root-311"
+      className="MuiTouchRipple-root-312"
     >
       <TransitionGroup
         childFactory={[Function]}

--- a/components/SideSection.js
+++ b/components/SideSection.js
@@ -122,13 +122,3 @@ export const SideSectionText = withStyles(() => ({
     </article>
   );
 });
-
-export const SideSectionImage = withStyles(() => ({
-  asideImage: {
-    maxWidth: '100%',
-    maxHeight: '100px',
-    verticalAlign: 'bottom',
-  },
-}))(({ classes, className, ...props }) => {
-  return <img className={cx(classes.asideImage, className)} {...props} />;
-});

--- a/components/SideSection.stories.js
+++ b/components/SideSection.stories.js
@@ -6,7 +6,6 @@ import {
   SideSectionLinks,
   SideSectionLink,
   SideSectionText,
-  SideSectionImage,
 } from './SideSection';
 
 export default {
@@ -36,12 +35,6 @@ export const SideSectionStructure = () => (
             3 Side section 3 Side section 3 Side section 3 Side section 3 Side
             section 3 Side section 3 Side section 3 Side section 3{' '}
           </SideSectionText>
-        </SideSectionLink>
-        <SideSectionLink>
-          <SideSectionImage src="https://placekitten.com/300/200" />
-        </SideSectionLink>
-        <SideSectionLink>
-          <SideSectionImage src="https://placekitten.com/200/500" />
         </SideSectionLink>
       </SideSectionLinks>
     </SideSection>

--- a/components/Thumbnail.js
+++ b/components/Thumbnail.js
@@ -21,9 +21,9 @@ function Thumbnail({ article, className }) {
   const classes = useStyles();
   const thumbnailCls = cx(classes.thumbnail, className);
 
-  switch (article.articleTypei) {
+  switch (article.articleType) {
     case 'IMAGE': {
-      const altText = ellipsis(article.text, { wordCount: 40 });
+      const altText = ellipsis(article.text ?? '', { wordCount: 40 });
       return (
         <img
           className={thumbnailCls}
@@ -36,7 +36,13 @@ function Thumbnail({ article, className }) {
       return !article.thumbnailUrl ? (
         t`A video` + ` (${t`Preview not supported yet`})`
       ) : (
-        <video className={thumbnailCls} src={article.thumbnailUrl} controls />
+        <video
+          className={thumbnailCls}
+          src={article.thumbnailUrl}
+          autoPlay
+          loop
+          muted
+        />
       );
     case 'AUDIO':
       return !article.thumbnailUrl ? (

--- a/components/Thumbnail.js
+++ b/components/Thumbnail.js
@@ -1,0 +1,62 @@
+import gql from 'graphql-tag';
+import { t } from 'ttag';
+import { makeStyles } from '@material-ui/core/styles';
+import cx from 'clsx';
+
+import { ellipsis } from 'lib/text';
+
+const useStyles = makeStyles(() => ({
+  thumbnail: {
+    maxWidth: '100%',
+    maxHeight: '8em', // So that image don't take too much space (more than replies)
+  },
+}));
+
+/**
+ *
+ * @param {ThumbnailArticleData} props.article
+ * @param {string} props.className - for replaced elements like image and video
+ */
+function Thumbnail({ article, className }) {
+  const classes = useStyles();
+  const thumbnailCls = cx(classes.thumbnail, className);
+
+  switch (article.articleTypei) {
+    case 'IMAGE': {
+      const altText = ellipsis(article.text, { wordCount: 40 });
+      return (
+        <img
+          className={thumbnailCls}
+          src={article.thumbnailUrl}
+          alt={altText}
+        />
+      );
+    }
+    case 'VIDEO':
+      return !article.thumbnailUrl ? (
+        t`A video` + ` (${t`Preview not supported yet`})`
+      ) : (
+        <video className={thumbnailCls} src={article.thumbnailUrl} controls />
+      );
+    case 'AUDIO':
+      return !article.thumbnailUrl ? (
+        t`An audio` + ` (${t`Preview not supported yet`})`
+      ) : (
+        <audio src={article.thumbnailUrl} controls />
+      );
+  }
+
+  return null;
+}
+
+Thumbnail.fragments = {
+  ThumbnailArticleData: gql`
+    fragment ThumbnailArticleData on Article {
+      articleType
+      text
+      thumbnailUrl: attachmentUrl(variant: THUMBNAIL)
+    }
+  `,
+};
+
+export default Thumbnail;

--- a/components/__snapshots__/SideSection.stories.storyshot
+++ b/components/__snapshots__/SideSection.stories.storyshot
@@ -60,34 +60,6 @@ exports[`Storyshots SideSection Side Section Structure 1`] = `
               </Component>
             </a>
           </Component>
-          <Component>
-            <a
-              className="Component-asideItem"
-            >
-              <Component
-                src="https://placekitten.com/300/200"
-              >
-                <img
-                  className="Component-asideImage"
-                  src="https://placekitten.com/300/200"
-                />
-              </Component>
-            </a>
-          </Component>
-          <Component>
-            <a
-              className="Component-asideItem"
-            >
-              <Component
-                src="https://placekitten.com/200/500"
-              >
-                <img
-                  className="Component-asideImage"
-                  src="https://placekitten.com/200/500"
-                />
-              </Component>
-            </a>
-          </Component>
         </div>
       </Component>
     </aside>

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -30,7 +30,6 @@ import {
   SideSectionLinks,
   SideSectionLink,
   SideSectionText,
-  SideSectionImage,
 } from 'components/SideSection';
 import Hyperlinks from 'components/Hyperlinks';
 import CurrentReplies from 'components/CurrentReplies';
@@ -41,6 +40,7 @@ import ArticleInfo from 'components/ArticleInfo';
 import ArticleCategories from 'components/ArticleCategories';
 import TrendPlot from 'components/TrendPlot';
 import Infos, { TimeInfo } from 'components/Infos';
+import Thumbnail from 'components/Thumbnail';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -109,6 +109,11 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
     maxWidth: 600,
   },
+  asideAttachment: {
+    maxWidth: '100%',
+    maxHeight: '100px',
+    verticalAlign: 'bottom',
+  },
 }));
 
 const LOAD_ARTICLE = gql`
@@ -148,11 +153,11 @@ const LOAD_ARTICLE = gql`
             id
             text
             articleType
-            attachmentUrl(variant: THUMBNAIL)
             articleCategories {
               categoryId
             }
             ...ArticleInfo
+            ...ThumbnailArticleData
           }
         }
       }
@@ -179,6 +184,7 @@ const LOAD_ARTICLE = gql`
   ${ArticleCategories.fragments.ArticleCategoryData}
   ${ArticleCategories.fragments.AddCategoryDialogData}
   ${ArticleInfo.fragments.articleInfo}
+  ${Thumbnail.fragments.ThumbnailArticleData}
 `;
 
 const LOAD_ARTICLE_FOR_USER = gql`
@@ -521,8 +527,11 @@ function ArticlePage() {
                   passHref
                 >
                   <SideSectionLink>
-                    {node.articleType === 'IMAGE' ? (
-                      <SideSectionImage src={node.attachmentUrl} />
+                    {node.articleType !== 'TEXT' ? (
+                      <Thumbnail
+                        article={node}
+                        className={classes.asideAttachment}
+                      />
                     ) : (
                       <SideSectionText>{node.text}</SideSectionText>
                     )}

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -105,7 +105,7 @@ const useStyles = makeStyles(theme => ({
     width: '100%',
     borderRadius: theme.shape.borderRadius,
   },
-  attachmentImage: {
+  attachment: {
     width: '100%',
     maxWidth: 600,
   },
@@ -121,6 +121,7 @@ const LOAD_ARTICLE = gql`
     GetArticle(id: $id) {
       id
       text
+      articleType
       attachmentUrl(variant: PREVIEW)
       originalAttachmentUrl: attachmentUrl(variant: ORIGINAL)
       requestedForReply
@@ -319,6 +320,7 @@ function ArticlePage() {
   const {
     replyRequestCount,
     text,
+    articleType,
     attachmentUrl,
     originalAttachmentUrl,
     hyperlinks,
@@ -364,26 +366,46 @@ function ArticlePage() {
               </Infos>
             </header>
             <CardContent>
-              {attachmentUrl &&
-                (!originalAttachmentUrl ? (
-                  <img
-                    className={classes.attachmentImage}
-                    src={attachmentUrl}
-                    alt="image"
-                  />
-                ) : (
-                  <a
-                    href={originalAttachmentUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    <img
-                      className={classes.attachmentImage}
-                      src={attachmentUrl}
-                      alt="image"
-                    />
-                  </a>
-                ))}
+              {(() => {
+                switch (articleType) {
+                  case 'IMAGE':
+                    return !originalAttachmentUrl ? (
+                      <img
+                        className={classes.attachment}
+                        src={attachmentUrl}
+                        alt="image"
+                      />
+                    ) : (
+                      <a
+                        href={originalAttachmentUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <img
+                          className={classes.attachment}
+                          src={attachmentUrl}
+                          alt="image"
+                        />
+                      </a>
+                    );
+                  case 'VIDEO':
+                    return !originalAttachmentUrl ? (
+                      t`Log in to view video content`
+                    ) : (
+                      <video
+                        className={classes.attachment}
+                        src={originalAttachmentUrl}
+                        controls
+                      />
+                    );
+                  case 'AUDIO':
+                    return !originalAttachmentUrl ? (
+                      t`Log in to view audio content`
+                    ) : (
+                      <audio src={originalAttachmentUrl} controls />
+                    );
+                }
+              })()}
               {text &&
                 nl2br(
                   linkify(text, {

--- a/pages/replies.js
+++ b/pages/replies.js
@@ -29,6 +29,7 @@ import {
 } from 'components/ListPageControls';
 import FeedDisplay from 'components/Subscribe/FeedDisplay';
 import AppLayout from 'components/AppLayout';
+import Thumbnail from 'components/Thumbnail';
 import withData from 'lib/apollo';
 
 const LIST_ARTICLES = gql`
@@ -44,7 +45,7 @@ const LIST_ARTICLES = gql`
           replyRequestCount
           createdAt
           text
-          attachmentUrl(variant: THUMBNAIL)
+          ...ThumbnailArticleData
           articleReplies(status: NORMAL) {
             reply {
               id
@@ -59,6 +60,7 @@ const LIST_ARTICLES = gql`
   }
   ${ReplyItem.fragments.ReplyItem}
   ${ReplyItem.fragments.ReplyItemArticleReplyData}
+  ${Thumbnail.fragments.ThumbnailArticleData}
 `;
 
 const LIST_STAT = gql`
@@ -178,10 +180,6 @@ const useStyles = makeStyles(theme => ({
       marginBottom: 12,
     },
   },
-  attachmentImage: {
-    maxWidth: '100%',
-    maxHeight: '8em', // So that image don't take too much space (more than replies)
-  },
 }));
 
 function ReplyListPage() {
@@ -260,13 +258,7 @@ function ReplyListPage() {
                     {timeAgo => t`First reported ${timeAgo}`}
                   </TimeInfo>
                 </Infos>
-                {article.attachmentUrl && (
-                  <img
-                    className={classes.attachmentImage}
-                    src={article.attachmentUrl}
-                    alt="image"
-                  />
-                )}
+                <Thumbnail article={article} />
                 {article.text && (
                   <ExpandableText lineClamp={2}>{article.text}</ExpandableText>
                 )}

--- a/pages/reply/[id].js
+++ b/pages/reply/[id].js
@@ -17,6 +17,7 @@ import getTermsString from 'lib/terms';
 import ExpandableText from 'components/ExpandableText';
 import AppLayout from 'components/AppLayout';
 import ArticleReply from 'components/ArticleReply';
+import Thumbnail from 'components/Thumbnail';
 import { Card, CardHeader, CardContent } from 'components/Card';
 import { ProfileTooltip } from 'components/ProfileLink';
 import Infos, { TimeInfo } from 'components/Infos';
@@ -58,10 +59,6 @@ const useStyles = makeStyles(theme => ({
   infos: {
     marginTop: 12,
   },
-  attachmentImage: {
-    width: '100%',
-    maxWidth: 600,
-  },
 }));
 
 const LOAD_REPLY = gql`
@@ -74,8 +71,8 @@ const LOAD_REPLY = gql`
         article {
           id
           text
-          attachmentUrl(variant: PREVIEW)
           replyCount
+          ...ThumbnailArticleData
         }
         createdAt
         status
@@ -99,6 +96,7 @@ const LOAD_REPLY = gql`
   }
   ${ArticleReply.fragments.ArticleReplyData}
   ${ProfileTooltip.fragments.ProfileTooltipUserData}
+  ${Thumbnail.fragments.ThumbnailArticleData}
 `;
 
 const LOAD_REPLY_FOR_USER = gql`
@@ -254,13 +252,7 @@ function ReplyPage() {
                 as={`/article/${originalArticleReply.article.id}`}
               >
                 <a className={classes.articleLink}>
-                  {originalArticleReply.article.attachmentUrl && (
-                    <img
-                      className={classes.attachmentImage}
-                      src={originalArticleReply.article.attachmentUrl}
-                      alt="image"
-                    />
-                  )}
+                  <Thumbnail article={originalArticleReply.article} />
                   {originalArticleReply.article.text && (
                     <ExpandableText lineClamp={5}>
                       {nl2br(originalArticleReply.article.text)}
@@ -285,13 +277,7 @@ function ReplyPage() {
                 <CardContent key={ar.article.id}>
                   <Link href="/article/[id]" as={`/article/${ar.article.id}`}>
                     <a className={classes.articleLink}>
-                      {ar.article.attachmentUrl && (
-                        <img
-                          className={classes.attachmentImage}
-                          src={ar.article.attachmentUrl}
-                          alt="image"
-                        />
-                      )}
+                      <Thumbnail article={ar.article} />
                       {ar.article.text && (
                         <ExpandableText>
                           {nl2br(ar.article.text)}


### PR DESCRIPTION
- Implements `Thumbnail` for thumbnail in list pages    
    - "list pages" includes related articles, article list, reply list, reply search, and the search result of similar replies in reply editor. 
      - It replaces `SideSectionImage` in `SideSection`, but is way more versatile than `SideSectionImage`
    - It is designed to use thumbnail images only
      - As we did not implement "thumbnail" variant for video and audio, "Preview not supported yet" will be shown.
      - Note that the thumbnail may load if an logged in user get data via AJAX
          - This is expected before we properly implement thumbnail generation.
          - The thumbnail will show for logged in user getting data from AJAX is due to the `attachmentUrl` resolution logic -- it will resolve to `ORIGINAL`
          - When the data is retrieved via server-side rendering, there is no log-in session available, thus the `attachmentUrl(variant: THUMBNAIL)` will always resolve to `null`, as videos and audios does not have thumbnail variant and is resolved to `ORIGINAL`.
    - It has no interaction (no hyperlinks, no controls)
    - Its graphql fragment renames `attachmentUrl(variant: THUMBNAIL)` to `thumbnailUrl` to avoid conflicting with other fields
- For other places that requires bigger image / video, ad-hoc switch-case is used instead
    - These occurrences include the rumor section in article detail, and rumor tab in mobile reply editor
    - They have different styles and has interactions, thus do not use `Thumbnail`

## Article list
### Storybook
No `attachmentUrl`, horizontal video, vertical video, audio
<img width="460" alt="image" src="https://user-images.githubusercontent.com/108608/194748198-953c2323-5fc2-48d4-8529-2d022653d8cf.png">

### Actual article list
<img width="1004" alt="image" src="https://user-images.githubusercontent.com/108608/194589920-c8109b6f-d7b2-42db-895e-8968709424db.png">

## Article detail

### Rumor section
Logged in:
<img width="972" alt="image" src="https://user-images.githubusercontent.com/108608/194678786-df1cf275-766d-432e-b32e-4426900d6415.png">

Not logged in:
<img width="1036" alt="image" src="https://user-images.githubusercontent.com/108608/194678798-cf14d09d-0ed9-47c9-a51a-c63768fde165.png">
(API only allows logged in website users to access original file, whose bandwidth would cost is a lot)

### Mobile reply editor 
<img width="522" alt="image" src="https://user-images.githubusercontent.com/108608/194731424-73671148-3b6d-43eb-b74b-cb29462f89a7.png">

### Reply search
<img width="577" alt="image" src="https://user-images.githubusercontent.com/108608/194746868-32037f09-1553-4536-a325-7061951acd57.png">

## Reply detail
<img width="688" alt="image" src="https://user-images.githubusercontent.com/108608/194744099-d3f9bcc2-8a2a-418e-a4e0-1621e546e561.png">

## Profile page
<img width="1099" alt="image" src="https://user-images.githubusercontent.com/108608/194746252-6a8ae75b-2ad6-49ac-b74f-34a2ef419c9f.png">

