### PR TITLE
Fix iOS video fullscreen problem

### DIFF
--- a/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
+++ b/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
@@ -681,6 +681,7 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     className="makeStyles-thumbnail makeStyles-attachment"
                     loop={true}
                     muted={true}
+                    playsInline={true}
                     src="https://drive.google.com/uc?id=1SQ9lc1-ghzw-SL6Dyb_UMN6hAPBAckvK&confirm=t"
                   />
                 </Thumbnail>
@@ -786,6 +787,7 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     className="makeStyles-thumbnail makeStyles-attachment"
                     loop={true}
                     muted={true}
+                    playsInline={true}
                     src="https://drive.google.com/uc?id=1DczThMYTmGV3GvDCAU2EPnhsBwVcoFQi&confirm=t"
                   />
                 </Thumbnail>

--- a/components/Thumbnail.js
+++ b/components/Thumbnail.js
@@ -40,6 +40,7 @@ function Thumbnail({ article, className }) {
           className={thumbnailCls}
           src={article.thumbnailUrl}
           autoPlay
+          playsinline
           loop
           muted
         />

--- a/components/Thumbnail.js
+++ b/components/Thumbnail.js
@@ -40,7 +40,7 @@ function Thumbnail({ article, className }) {
           className={thumbnailCls}
           src={article.thumbnailUrl}
           autoPlay
-          playsinline
+          playsInline
           loop
           muted
         />


### PR DESCRIPTION
Fixes #511 

From doc:
> Without the `playsinline` attribute, videos must be in full-screen mode for playback on iPhone.
https://developer.apple.com/documentation/webkit/delivering_video_content_for_safari#3030250

This PR adds `playsinline` (camelCase in React) so that iOS don't automatically fullscreen the videos.
The branch has been deployed to https://dev.cofacts.tw for iOS users to test.

https://user-images.githubusercontent.com/108608/201179204-ebcb126e-7781-46c3-bf45-b170c5fd8318.mov

