### PR TITLE
Block spammer articles

### DIFF
--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -127,8 +127,9 @@ function getErrorText(error) {
 
 /**
  * @param {object} props.hyperlink
+ * @param {string} props.rel - rel prop for the hyperlink (other than noopener and noreferrer)
  */
-function Hyperlink({ hyperlink }) {
+function Hyperlink({ hyperlink, rel = '' }) {
   const { title, topImageUrl, error, url } = hyperlink;
   const summary = (hyperlink.summary || '').slice(0, 200);
 
@@ -146,7 +147,7 @@ function Hyperlink({ hyperlink }) {
       </div>
       <span className={classes.url}>
         <HyperlinkIcon />
-        <a href={url} target="_blank" rel="noopener noreferrer">
+        <a href={url} target="_blank" rel={`noopener noreferrer ${rel}`}>
           {url}
         </a>
       </span>
@@ -173,8 +174,9 @@ function PollingHyperlink({ pollingType, pollingId }) {
  * @param {object[] | null} props.hyperlinks
  * @param {'articles'|'replies'?} props.pollingType - poll article or reply for hyperlinks when it's not loaded (null)
  * @param {string?} props.pollingId - polling article or reply id for hyperlinks when it's not loaded (null)
+ * @param {string?} props.rel - rel prop for the hyperlink (other than noopener and noreferrer)
  */
-function Hyperlinks({ hyperlinks, pollingType, pollingId }) {
+function Hyperlinks({ hyperlinks, pollingType, pollingId, rel }) {
   if (!((pollingId && pollingType) || (!pollingId && !pollingType))) {
     throw new Error('pollingType and pollingId must be specified together');
   }
@@ -191,7 +193,7 @@ function Hyperlinks({ hyperlinks, pollingType, pollingId }) {
       mb={1}
     >
       {(hyperlinks || []).map((hyperlink, idx) => (
-        <Hyperlink key={idx} hyperlink={hyperlink} />
+        <Hyperlink key={idx} hyperlink={hyperlink} rel={rel} />
       ))}
       {!hyperlinks && pollingId && (
         <PollingHyperlink pollingId={pollingId} pollingType={pollingType} />

--- a/components/__snapshots__/Hyperlinks.stories.storyshot
+++ b/components/__snapshots__/Hyperlinks.stories.storyshot
@@ -78,7 +78,7 @@ exports[`Storyshots Hyperlinks All Variants 1`] = `
             </HyperlinkIcon>
             <a
               href="https://cofacts.org"
-              rel="noopener noreferrer"
+              rel="noopener noreferrer "
               target="_blank"
             >
               https://cofacts.org
@@ -135,7 +135,7 @@ exports[`Storyshots Hyperlinks All Variants 1`] = `
             </HyperlinkIcon>
             <a
               href="https://cofacts.org"
-              rel="noopener noreferrer"
+              rel="noopener noreferrer "
               target="_blank"
             >
               https://cofacts.org
@@ -186,7 +186,7 @@ exports[`Storyshots Hyperlinks All Variants 1`] = `
             </HyperlinkIcon>
             <a
               href="https://not-found.org"
-              rel="noopener noreferrer"
+              rel="noopener noreferrer "
               target="_blank"
             >
               https://not-found.org

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -133,6 +133,7 @@ const LOAD_ARTICLE = gql`
       replyRequestCount
       replyCount
       createdAt
+      status
       references {
         type
       }
@@ -353,6 +354,8 @@ function ArticlePage() {
         <title>
           {ellipsis(article.text, { wordCount: 100 })} | {t`Cofacts`}
         </title>
+        {/* Don't let search engines index blocked spam */ article.status ===
+          'BLOCKED' && <meta name="robots" content="noindex, nofollow" />}
       </Head>
       <div className={classes.root}>
         <div className={classes.main}>

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -375,56 +375,62 @@ function ArticlePage() {
               </Infos>
             </header>
             <CardContent>
-              {(() => {
-                switch (articleType) {
-                  case 'IMAGE':
-                    return !originalAttachmentUrl ? (
-                      <img
-                        className={classes.attachment}
-                        src={attachmentUrl}
-                        alt="image"
-                      />
-                    ) : (
-                      <a
-                        href={originalAttachmentUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        <img
-                          className={classes.attachment}
-                          src={attachmentUrl}
-                          alt="image"
-                        />
-                      </a>
-                    );
-                  case 'VIDEO':
-                    return !originalAttachmentUrl ? (
-                      t`Log in to view video content`
-                    ) : (
-                      <video
-                        className={classes.attachment}
-                        src={originalAttachmentUrl}
-                        controls
-                      />
-                    );
-                  case 'AUDIO':
-                    return !originalAttachmentUrl ? (
-                      t`Log in to view audio content`
-                    ) : (
-                      <audio src={originalAttachmentUrl} controls />
-                    );
-                }
-              })()}
-              {text &&
-                nl2br(
-                  linkify(text, {
-                    props: {
-                      target: '_blank',
-                      rel: 'ugc nofollow',
-                    },
-                  })
-                )}
-              <Hyperlinks hyperlinks={hyperlinks} rel="ugc nofollow" />
+              {article.status === 'BLOCKED' && !currentUser ? (
+                t`Log in to view content`
+              ) : (
+                <>
+                  {(() => {
+                    switch (articleType) {
+                      case 'IMAGE':
+                        return !originalAttachmentUrl ? (
+                          <img
+                            className={classes.attachment}
+                            src={attachmentUrl}
+                            alt="image"
+                          />
+                        ) : (
+                          <a
+                            href={originalAttachmentUrl}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            <img
+                              className={classes.attachment}
+                              src={attachmentUrl}
+                              alt="image"
+                            />
+                          </a>
+                        );
+                      case 'VIDEO':
+                        return !originalAttachmentUrl ? (
+                          t`Log in to view video content`
+                        ) : (
+                          <video
+                            className={classes.attachment}
+                            src={originalAttachmentUrl}
+                            controls
+                          />
+                        );
+                      case 'AUDIO':
+                        return !originalAttachmentUrl ? (
+                          t`Log in to view audio content`
+                        ) : (
+                          <audio src={originalAttachmentUrl} controls />
+                        );
+                    }
+                  })()}
+                  {text &&
+                    nl2br(
+                      linkify(text, {
+                        props: {
+                          target: '_blank',
+                          rel: 'ugc nofollow',
+                        },
+                      })
+                    )}
+                  <Hyperlinks hyperlinks={hyperlinks} rel="ugc nofollow" />
+                </>
+              )}
               <Box my={[1.5, 2]}>
                 <ArticleCategories
                   articleId={article.id}

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -420,10 +420,11 @@ function ArticlePage() {
                   linkify(text, {
                     props: {
                       target: '_blank',
+                      rel: 'ugc nofollow',
                     },
                   })
                 )}
-              <Hyperlinks hyperlinks={hyperlinks} />
+              <Hyperlinks hyperlinks={hyperlinks} rel="ugc nofollow" />
               <Box my={[1.5, 2]}>
                 <ArticleCategories
                   articleId={article.id}


### PR DESCRIPTION
This PR implements block SEO spam M3 in the design doc https://g0v.hackmd.io/XBJS-KEtScWyVCuQ9P_iNQ?both#M3-Hide-blocked-article-for-non-logged-in-users

- [feat(article): add meta tag that blocks search engine for blocked articles](https://github.com/cofacts/rumors-site/commit/429ade7b0f2402274813936e8c3ad88ccd8b7a63) 
- [feat(article): add ugc rel for all article's hyperlinks](https://github.com/cofacts/rumors-site/commit/0b1b9d7d1ba9fbff9909c829714374c41a08eeaf)
-  [feat(article): hide blocked article for anonymous users](https://github.com/cofacts/rumors-site/commit/ac6ac02d109d16d9bab33fbefe8935d84bba8694)

## Viewing blocked article before logging in
Note that the robot meta tag is added
<img width="1283" alt="image" src="https://user-images.githubusercontent.com/108608/214286647-f6181fef-44bc-4e81-8276-f8b4264876cf.png">

## Viewing blocked article after logging in
<img width="798" alt="image" src="https://user-images.githubusercontent.com/108608/214286841-ce55eeea-b6ff-4f3e-b29b-6eab61a357ac.png">
