### PR TITLE
feat(article): don't show reply requests with <=0 score for users not logged in yet

### DIFF
--- a/components/ReplyRequestReason/ReplyRequestReason.js
+++ b/components/ReplyRequestReason/ReplyRequestReason.js
@@ -11,6 +11,7 @@ import ActionMenu, {
   ReportAbuseMenuItem,
   useCanReportAbuse,
 } from 'components/ActionMenu';
+import useCurrentUser from 'lib/useCurrentUser';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -62,6 +63,7 @@ const ReplyRequestInfo = gql`
     negativeFeedbackCount
 
     user {
+      id
       name
       ...AvatarData
     }
@@ -92,6 +94,7 @@ function ReplyRequestReason({ replyRequest, articleId }) {
     user,
   } = replyRequest;
 
+  const currentUser = useCurrentUser();
   const canReportAbuse = useCanReportAbuse(user.id);
   const [voteReason, { loading }] = useMutation(UPDATE_VOTE);
   const handleVote = vote => {
@@ -101,6 +104,8 @@ function ReplyRequestReason({ replyRequest, articleId }) {
   const classes = useStyles();
 
   if (!replyRequestReason) return null;
+
+  const isOwnReplyRequest = user && currentUser && user.id === currentUser.id;
 
   return (
     <div className={classes.root}>
@@ -118,7 +123,7 @@ function ReplyRequestReason({ replyRequest, articleId }) {
               className={classes.vote}
               type="button"
               onClick={() => handleVote(UPVOTE)}
-              disabled={loading}
+              disabled={loading || isOwnReplyRequest}
             >
               <ThumbUpIcon className={classes.thumbIcon} />
               {positiveFeedbackCount}
@@ -130,7 +135,7 @@ function ReplyRequestReason({ replyRequest, articleId }) {
               className={classes.vote}
               type="button"
               onClick={() => handleVote(DOWNVOTE)}
-              disabled={loading}
+              disabled={loading || isOwnReplyRequest}
             >
               <ThumbDownIcon className={classes.thumbIcon} />
               {negativeFeedbackCount}

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -199,6 +199,8 @@ const LOAD_ARTICLE_FOR_USER = gql`
       id # Required, https://github.com/apollographql/apollo-client/issues/2510
       originalAttachmentUrl: attachmentUrl(variant: ORIGINAL)
       replyRequests(statuses: $replyRequestStatuses) {
+        positiveFeedbackCount
+        negativeFeedbackCount
         ...ReplyRequestInfoForUser
       }
       articleReplies(statuses: $articleReplyStatuses) {
@@ -345,7 +347,11 @@ function ArticlePage() {
   );
 
   const replyRequestsWithComments = (article.replyRequests || []).filter(
-    ({ reason }) => reason
+    ({ reason, positiveFeedbackCount, negativeFeedbackCount }) =>
+      reason &&
+      reason.trim().length > 0 &&
+      // For users not logged in yet, only show reply requests with positive feedbacks
+      (currentUser ? true : positiveFeedbackCount - negativeFeedbackCount > 0)
   );
 
   return (


### PR DESCRIPTION
As title.
Fixes #522 

## Not logged in
<img width="950" alt="image" src="https://user-images.githubusercontent.com/108608/214288846-90a7ebf1-f3ab-4272-a6d1-6c878aab79c4.png">

## Logged in
<img width="952" alt="image" src="https://user-images.githubusercontent.com/108608/214288895-643ce36e-b461-48af-b2e8-0185429cd770.png">

## Disable own reply request
<img width="789" alt="image" src="https://user-images.githubusercontent.com/108608/214290776-146ad3a2-e12e-49df-b3e8-05c27bf7f330.png">

