### PR TITLE
Don't throw error when article does not have ID

### DIFF
--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -470,7 +470,7 @@ function ArticlePage() {
             <CreateReplyRequestForm
               requestedForReply={article.requestedForReply}
               articleId={article.id}
-              articleUserId={article.user.id}
+              articleUserId={article.user?.id || 'N/A'}
               onNewReplyButtonClick={() => {
                 setShowForm(true);
                 // use setTimeout to make sure the form has shown


### PR DESCRIPTION
`articleUserId` is just used in reporting user, should not block page from rendering.

Fixes #531 

Before: https://cofacts.tw/article/5673777689453-rumor
After: https://dev.cofacts.tw/article/5673777689453-rumor

