### PR TITLE
UX improvements of images in article page

### DIFF
--- a/components/ListPageDisplays/ArticleCard.js
+++ b/components/ListPageDisplays/ArticleCard.js
@@ -88,6 +88,7 @@ const useStyles = makeStyles(theme => ({
   attachment: {
     minWidth: 0, // Don't use intrinsic image width as flex item min-size
     maxHeight: '10em', // Don't let image rows take too much vertical space
+    margin: '0 1em 0 0', // Add right margin that separate attachment and text with a space
   },
 }));
 
@@ -122,6 +123,7 @@ function ArticleCard({ article, highlight = '' }) {
                 <span>{c('Info box').t`reports`}</span>
               </div>
             </div>
+            <Thumbnail article={article} className={classes.attachment} />
             {(text || highlight) && (
               <ExpandableText className={classes.content} lineClamp={3}>
                 {highlight
@@ -129,7 +131,6 @@ function ArticleCard({ article, highlight = '' }) {
                   : text}
               </ExpandableText>
             )}
-            <Thumbnail article={article} className={classes.attachment} />
           </div>
         </ListPageCard>
       </a>

--- a/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
+++ b/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
@@ -83,6 +83,19 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     </span>
                   </div>
                 </div>
+                <Thumbnail
+                  article={
+                    Object {
+                      "articleType": "TEXT",
+                      "createdAt": "2020-01-01T00:00:00Z",
+                      "id": "id1",
+                      "replyCount": 3,
+                      "replyRequestCount": 4,
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+                    }
+                  }
+                  className="makeStyles-attachment"
+                />
                 <ExpandableText
                   className="makeStyles-content"
                   lineClamp={3}
@@ -102,19 +115,6 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     </div>
                   </div>
                 </ExpandableText>
-                <Thumbnail
-                  article={
-                    Object {
-                      "articleType": "TEXT",
-                      "createdAt": "2020-01-01T00:00:00Z",
-                      "id": "id1",
-                      "replyCount": 3,
-                      "replyRequestCount": 4,
-                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
-                    }
-                  }
-                  className="makeStyles-attachment"
-                />
               </div>
             </article>
           </ListPageCard>
@@ -210,6 +210,19 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     </span>
                   </div>
                 </div>
+                <Thumbnail
+                  article={
+                    Object {
+                      "articleType": "TEXT",
+                      "createdAt": "2019-01-01T00:00:00Z",
+                      "id": "id2",
+                      "replyCount": 0,
+                      "replyRequestCount": 999,
+                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eu ex augue. Etiam posuere sagittis iaculis. Vestibulum sollicitudin nec felis a mollis. Phasellus ut est velit. Proin fermentum arcu ornare quam vulputate, vel eleifend velit ultrices. Fusce tincidunt vel urna at luctus.",
+                    }
+                  }
+                  className="makeStyles-attachment"
+                />
                 <ExpandableText
                   className="makeStyles-content"
                   lineClamp={3}
@@ -261,19 +274,6 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     </div>
                   </div>
                 </ExpandableText>
-                <Thumbnail
-                  article={
-                    Object {
-                      "articleType": "TEXT",
-                      "createdAt": "2019-01-01T00:00:00Z",
-                      "id": "id2",
-                      "replyCount": 0,
-                      "replyRequestCount": 999,
-                      "text": "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Mauris eu ex augue. Etiam posuere sagittis iaculis. Vestibulum sollicitudin nec felis a mollis. Phasellus ut est velit. Proin fermentum arcu ornare quam vulputate, vel eleifend velit ultrices. Fusce tincidunt vel urna at luctus.",
-                    }
-                  }
-                  className="makeStyles-attachment"
-                />
               </div>
             </article>
           </ListPageCard>


### PR DESCRIPTION
## Fix #540
- change the order of text and image
- add image right margin

## Snapshots
### Before
![截圖 2023-07-09 下午3 07 08](https://github.com/cofacts/rumors-site/assets/6376572/0d6db8c0-94e8-422f-8240-050499b44754)
### After
![截圖 2023-07-09 下午3 05 38](https://github.com/cofacts/rumors-site/assets/6376572/095d3d67-5670-48da-8b20-654affc341b5)
