### PR TITLE
Collaborative editing history

### DIFF
--- a/components/Collaborate/CollabEditor.js
+++ b/components/Collaborate/CollabEditor.js
@@ -1,5 +1,3 @@
-/* eslint-env browser */
-
 import * as Y from 'yjs';
 import { HocuspocusProvider } from '@hocuspocus/provider';
 import {
@@ -13,17 +11,16 @@ import { t } from 'ttag';
 import { nl2br, linkify } from 'lib/text';
 import { Button, Typography } from '@material-ui/core';
 import { TranscribePenIcon } from 'components/icons';
-import { EditorState } from 'prosemirror-state';
-import { EditorView } from 'prosemirror-view';
+import { useProseMirror, ProseMirror } from 'use-prosemirror';
 import { schema } from './Schema';
 import { exampleSetup } from 'prosemirror-example-setup';
 import { keymap } from 'prosemirror-keymap';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
 import useCurrentUser from 'lib/useCurrentUser';
-import cx from 'clsx';
 import PlaceholderPlugin from './Placeholder';
 import getConfig from 'next/config';
+import CollabHistory from './CollabHistory';
 
 const {
   publicRuntimeConfig: { PUBLIC_COLLAB_SERVER_URL },
@@ -84,25 +81,84 @@ const colors = [
 
 const color = colors[Math.floor(Math.random() * colors.length)];
 
+const Editor = ({ provider, currentUser, className, innerRef, onUnmount }) => {
+  useEffect(() => {
+    // console.log('editor mount');
+    return () => {
+      onUnmount();
+    };
+  }, [onUnmount]);
+
+  const ydoc = provider.document;
+  const permanentUserData = new Y.PermanentUserData(ydoc);
+  permanentUserData.setUserMapping(
+    ydoc,
+    ydoc.clientID,
+    JSON.stringify({
+      id: currentUser.id,
+      name: currentUser.name,
+    })
+  );
+
+  const yXmlFragment = ydoc.get('prosemirror', Y.XmlFragment);
+
+  const [state, setState] = useProseMirror({
+    schema,
+    plugins: [
+      ySyncPlugin(yXmlFragment, { permanentUserData }),
+      yCursorPlugin(provider.awareness),
+      yUndoPlugin(),
+      keymap({
+        'Mod-z': undo,
+        'Mod-y': redo,
+        'Mod-Shift-z': redo,
+      }),
+      PlaceholderPlugin(t`Input transcript`),
+    ].concat(exampleSetup({ schema, menuBar: false })),
+  });
+
+  return (
+    <ProseMirror
+      ref={innerRef}
+      state={state}
+      onChange={setState}
+      className={className}
+    />
+  );
+};
+
+/**
+ * @param {Article} props.article
+ */
 const CollabEditor = ({ article }) => {
   const editor = useRef(null);
-  const [editorView, setEditorView] = useState(null);
+  const [showEditor, setShowEditor] = useState(null);
+  const [isSynced, setIsSynced] = useState(false);
   const currentUser = useCurrentUser();
+
+  // onTranscribe setup provider for both Editor and CollabHistory to use.
+  // And, to avoid duplicated connection, provider will be destroyed(close connection) when Editor unmounted.
+  const [provider, setProvider] = useState(null);
+
   const onTranscribe = () => {
     if (!currentUser) {
       return alert(t`Please login first.`);
     }
-    const ydoc = new Y.Doc();
-    const permanentUserData = new Y.PermanentUserData(ydoc);
-    permanentUserData.setUserMapping(ydoc, ydoc.clientID, currentUser.name);
-    // set gc to false to keep doc (delete)history
-    ydoc.gc = false;
 
+    setShowEditor(true);
+
+    if (provider) return;
+    setIsSynced(false);
     const provider = new HocuspocusProvider({
       url: PUBLIC_COLLAB_SERVER_URL,
       name: article.id,
       broadcast: false,
-      document: ydoc,
+      document: new Y.Doc({ gc: false }), // set gc to false to keep doc (delete)history
+      onSynced: () => {
+        // https://github.com/ueberdosis/hocuspocus/blob/main/docs/provider/events.md
+        // console.log('onSynced');
+        setIsSynced(true);
+      },
       // onAwarenessChange: ({ states }) => {
       //   console.log('provider', states);
       // },
@@ -111,33 +167,15 @@ const CollabEditor = ({ article }) => {
       name: currentUser.name,
       color,
     });
-    const yXmlFragment = ydoc.get('prosemirror', Y.XmlFragment);
-
-    if (editorView) editorView.destroy();
-    setEditorView(
-      new EditorView(editor.current, {
-        state: EditorState.create({
-          schema,
-          plugins: [
-            ySyncPlugin(yXmlFragment, { permanentUserData }),
-            yCursorPlugin(provider.awareness),
-            yUndoPlugin(),
-            keymap({
-              'Mod-z': undo,
-              'Mod-y': redo,
-              'Mod-Shift-z': redo,
-            }),
-            PlaceholderPlugin(t`Input transcript`),
-          ].concat(exampleSetup({ schema, menuBar: false })),
-        }),
-      })
-    );
+    setProvider(provider);
   };
 
   const onDone = () => {
-    if (editorView) {
+    // get EditorView: https://github.com/ponymessenger/use-prosemirror#prosemirror-
+    const prosemirrorEditorView = editor.current?.view;
+    if (prosemirrorEditorView) {
       let text = '';
-      editorView.state.doc.content.forEach(node => {
+      prosemirrorEditorView.state.doc.content.forEach(node => {
         // console.log(node.textContent);
         // console.log(node.type.name);
         if (node.textContent) {
@@ -148,9 +186,8 @@ const CollabEditor = ({ article }) => {
 
       // TODO: listen textChanged event?
       article.text = text;
-      editorView.destroy();
     }
-    setEditorView(null);
+    setShowEditor(false);
   };
 
   const classes = useStyles();
@@ -167,7 +204,7 @@ const CollabEditor = ({ article }) => {
             >
               {t`No transcripts yet`}
             </Typography>
-            {!editorView ? (
+            {!showEditor ? (
               <>
                 <Button
                   color="primary"
@@ -191,22 +228,22 @@ const CollabEditor = ({ article }) => {
             >
               {t`Transcript`}
             </Typography>
-            {!editorView ? (
-              <>
-                <Button
-                  variant="outlined"
-                  className={classes.editButton}
-                  onClick={onTranscribe}
-                >
-                  <TranscribePenIcon className={classes.newReplyFabIcon} />
-                  {t`Edit`}
-                </Button>
-              </>
-            ) : null}
+            {!showEditor ? (
+              <Button
+                variant="outlined"
+                className={classes.editButton}
+                onClick={onTranscribe}
+              >
+                <TranscribePenIcon className={classes.newReplyFabIcon} />
+                {t`Edit`}
+              </Button>
+            ) : (
+              isSynced && <CollabHistory ydoc={provider.document} />
+            )}
           </>
         )}
       </div>
-      {!editorView ? (
+      {!showEditor ? (
         <>
           {article.text &&
             nl2br(
@@ -219,11 +256,19 @@ const CollabEditor = ({ article }) => {
             )}
         </>
       ) : null}
-      <div
-        ref={editor}
-        className={cx(classes.prosemirrorEditor, !editorView && 'hide')}
-      />
-      {!editorView ? null : (
+      {showEditor && isSynced && (
+        <Editor
+          provider={provider}
+          innerRef={editor}
+          className={classes.prosemirrorEditor}
+          currentUser={currentUser}
+          onUnmount={() => {
+            // console.log('destroy provider');
+            provider.destroy();
+          }}
+        />
+      )}
+      {!showEditor ? null : (
         <>
           <div className={classes.transcriptFooter}>
             <Button

--- a/components/Collaborate/CollabEditor.js
+++ b/components/Collaborate/CollabEditor.js
@@ -21,8 +21,6 @@ import useCurrentUser from 'lib/useCurrentUser';
 import PlaceholderPlugin from './Placeholder';
 import getConfig from 'next/config';
 import CollabHistory from './CollabHistory';
-import gql from 'graphql-tag';
-import { useQuery } from '@apollo/react-hooks';
 
 const {
   publicRuntimeConfig: { PUBLIC_COLLAB_SERVER_URL },
@@ -83,17 +81,6 @@ const colors = [
 
 const color = colors[Math.floor(Math.random() * colors.length)];
 
-const YDOC_VERSIONS_QUERY = gql`
-  query GetYdocVersions($id: String!) {
-    GetYdoc(id: $id) {
-      versions {
-        createdAt
-        snapshot
-      }
-    }
-  }
-`;
-
 const Editor = ({ provider, currentUser, className, innerRef, onUnmount }) => {
   useEffect(() => {
     // console.log('editor mount');
@@ -152,14 +139,6 @@ const CollabEditor = ({ article }) => {
   // onTranscribe setup provider for both Editor and CollabHistory to use.
   // And, to avoid duplicated connection, provider will be destroyed(close connection) when Editor unmounted.
   const [provider, setProvider] = useState(null);
-  const { loading, data: getYdocData, refetch } = useQuery(
-    YDOC_VERSIONS_QUERY,
-    {
-      variables: { id: article.id },
-      ssr: false, // No need to fetch on server
-    }
-  );
-  const versionList = getYdocData?.GetYdoc?.versions || [];
 
   const onTranscribe = () => {
     if (!currentUser) {
@@ -208,10 +187,6 @@ const CollabEditor = ({ article }) => {
       // TODO: listen textChanged event?
       article.text = text;
     }
-
-    // refetch to get latest versionList
-    refetch({ id: article.id });
-
     setShowEditor(false);
   };
 
@@ -263,12 +238,8 @@ const CollabEditor = ({ article }) => {
                 {t`Edit`}
               </Button>
             ) : (
-              isSynced &&
-              !loading && (
-                <CollabHistory
-                  ydoc={provider.document}
-                  versionList={versionList}
-                />
+              isSynced && (
+                <CollabHistory ydoc={provider.document} docName={article.id} />
               )
             )}
           </>

--- a/components/Collaborate/CollabEditor.js
+++ b/components/Collaborate/CollabEditor.js
@@ -15,8 +15,7 @@ import { Button, Typography } from '@material-ui/core';
 import { TranscribePenIcon } from 'components/icons';
 import { EditorState } from 'prosemirror-state';
 import { EditorView } from 'prosemirror-view';
-import { schema } from 'prosemirror-schema-basic';
-import { DOMParser } from 'prosemirror-model';
+import { schema } from './Schema';
 import { exampleSetup } from 'prosemirror-example-setup';
 import { keymap } from 'prosemirror-keymap';
 import { useState, useRef } from 'react';
@@ -96,6 +95,7 @@ const CollabEditor = ({ article }) => {
     const ydoc = new Y.Doc();
     const permanentUserData = new Y.PermanentUserData(ydoc);
     permanentUserData.setUserMapping(ydoc, ydoc.clientID, currentUser.name);
+    // set gc to false to keep doc (delete)history
     ydoc.gc = false;
 
     const provider = new HocuspocusProvider({
@@ -118,7 +118,6 @@ const CollabEditor = ({ article }) => {
       new EditorView(editor.current, {
         state: EditorState.create({
           schema,
-          doc: DOMParser.fromSchema(schema).parse(editor.current),
           plugins: [
             ySyncPlugin(yXmlFragment, { permanentUserData }),
             yCursorPlugin(provider.awareness),

--- a/components/Collaborate/CollabHistory.js
+++ b/components/Collaborate/CollabHistory.js
@@ -173,7 +173,7 @@ const CustomModalContent = forwardRef(function CustomModalContent(
           )}
         </Box>
         <Box className={classes.modalMain}>
-          <Typography variant="h6">{t`Difference between version ${versionTitle} and it's previous version`}</Typography>
+          <Typography variant="h6">{t`Difference between version ${versionTitle} and its previous version`}</Typography>
           <ProseMirror
             ref={editor}
             state={state}

--- a/components/Collaborate/CollabHistory.js
+++ b/components/Collaborate/CollabHistory.js
@@ -1,0 +1,215 @@
+import { t } from 'ttag';
+import * as Y from 'yjs';
+import { ySyncPlugin, ySyncPluginKey } from 'y-prosemirror';
+import { useProseMirror, ProseMirror } from 'use-prosemirror';
+import { schema } from './Schema';
+import { exampleSetup } from 'prosemirror-example-setup';
+import { useState, useRef, useEffect, forwardRef, useCallback } from 'react';
+import { Button, Modal, Box, Typography } from '@material-ui/core';
+import { ToggleButtonGroup, ToggleButton } from '@material-ui/lab';
+import { makeStyles } from '@material-ui/core/styles';
+import CloseIcon from '@material-ui/icons/Close';
+
+const useStyles = makeStyles(theme => ({
+  prosemirrorEditor: {
+    borderRadius: 8,
+    border: `1px solid ${theme.palette.secondary[200]}`,
+    marginBottom: 16,
+    flexGrow: 1,
+  },
+  modal: {
+    display: 'flex',
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%)',
+    width: '80vh',
+    height: '80vh',
+    backgroundColor: 'white',
+    border: `1px solid ${theme.palette.secondary[200]}`,
+    borderRadius: 10,
+    padding: 20,
+  },
+  modalSideBar: {
+    display: 'flex',
+    flexDirection: 'column',
+    width: 200,
+    padding: 4,
+  },
+  modalMain: {
+    display: 'flex',
+    flexDirection: 'column',
+    flexGrow: 1,
+    padding: 4,
+  },
+  modalClose: {
+    position: 'absolute',
+    right: 12,
+    top: 10,
+    color: theme.palette.secondary[100],
+  },
+}));
+
+const renderVersion = (editorview, version, prevVersion) => {
+  const transaction = editorview.state.tr.setMeta(ySyncPluginKey, {
+    snapshot: Y.decodeSnapshot(version.snapshot),
+    prevSnapshot:
+      prevVersion == null
+        ? Y.emptySnapshot
+        : Y.decodeSnapshot(prevVersion.snapshot),
+  });
+  editorview.dispatch(transaction);
+};
+
+// const unrenderVersion = editorview => {
+//   const binding = ySyncPluginKey.getState(editorview.state).binding;
+//   if (binding != null) {
+//     binding.unrenderSnapshot();
+//   }
+// };
+
+/**
+ * Should render `Versions` after `editorLoaded`,
+ * `Versions` will default render latest version
+ * @param {EditorView} editorView
+ * @param {Y.Doc} ydoc
+ * @param {(version: Y.Snapshot, index: number) => void} onSelect - called when version selected
+ */
+const Versions = ({ editorView, ydoc, onSelect }) => {
+  const versions = ydoc.getArray('versions');
+  const defaultVIdx = versions.length - 1;
+  const [selectedVersion, setSelectedVersion] = useState(null);
+
+  useEffect(() => {
+    // default select latest version
+    selectAndRender(defaultVIdx);
+  }, [defaultVIdx, selectAndRender]);
+
+  const selectAndRender = useCallback(
+    reverseIdx => {
+      setSelectedVersion(reverseIdx);
+      const version = versions.get(reverseIdx);
+      const prevVersion = reverseIdx > 0 ? versions.get(reverseIdx - 1) : null;
+      onSelect(version, reverseIdx);
+      renderVersion(editorView, version, prevVersion);
+    },
+    [versions, onSelect, editorView]
+  );
+
+  const toggleChanged = (event, reverseIdx) => {
+    // avoid deselect toggle
+    if (reverseIdx === null) return;
+    selectAndRender(reverseIdx);
+  };
+
+  return (
+    <>
+      <Typography variant="h6">{t`Versions`}</Typography>
+      {versions.length > 0 ? (
+        <ToggleButtonGroup
+          orientation="vertical"
+          value={selectedVersion}
+          exclusive
+          onChange={toggleChanged}
+          style={{ overflow: 'auto' }}
+        >
+          {versions.map((v, i) => {
+            // list version in reverse order
+            const reverseIdx = versions.length - 1 - i;
+            const version = versions.get(reverseIdx);
+
+            return (
+              <ToggleButton key={reverseIdx} value={reverseIdx}>
+                {new Date(version.date).toLocaleString()}
+              </ToggleButton>
+            );
+          })}
+        </ToggleButtonGroup>
+      ) : (
+        <div>No snapshots..</div>
+      )}
+    </>
+  );
+};
+
+const CustomModalContent = forwardRef(function CustomModalContent(
+  { ydoc, onClose },
+  ref
+) {
+  const editor = useRef(ref);
+  const classes = useStyles();
+  const [versionTitle, setVersionTitle] = useState('');
+  const [editorLoaded, setEditorLoaded] = useState(false);
+
+  const permanentUserData = new Y.PermanentUserData(ydoc);
+  const yXmlFragment = ydoc.get('prosemirror', Y.XmlFragment);
+  const onFirstRender = () => {
+    setEditorLoaded(true);
+  };
+
+  const [state, setState] = useProseMirror({
+    schema,
+    plugins: [
+      ySyncPlugin(yXmlFragment, {
+        permanentUserData,
+        onFirstRender,
+      }),
+    ].concat(exampleSetup({ schema, menuBar: false })),
+  });
+
+  return (
+    <>
+      <Box className={classes.modal}>
+        <Box className={classes.modalSideBar}>
+          {/* show Versions after editorLoaded to ensure default snapshot rendered correctly */}
+          {editorLoaded && (
+            <Versions
+              editorView={editor.current.view}
+              ydoc={ydoc}
+              onSelect={version =>
+                setVersionTitle(new Date(version.date).toLocaleString())
+              }
+            />
+          )}
+        </Box>
+        <Box className={classes.modalMain}>
+          <Typography variant="h6">{t`Difference between version ${versionTitle} and it's previous version`}</Typography>
+          <ProseMirror
+            ref={editor}
+            state={state}
+            onChange={setState}
+            className={classes.prosemirrorEditor}
+          />
+        </Box>
+        <CloseIcon className={classes.modalClose} onClick={onClose} />
+      </Box>
+    </>
+  );
+});
+
+const CollabHistory = ({ ydoc }) => {
+  const [open, setOpen] = useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  const classes = useStyles();
+
+  return (
+    <>
+      <div className="CollabEditor">
+        <Button
+          variant="outlined"
+          className={classes.editButton}
+          onClick={handleOpen}
+        >
+          {t`History`}
+        </Button>
+        <Modal open={open} onClose={handleClose}>
+          <CustomModalContent ydoc={ydoc} onClose={handleClose} />
+        </Modal>
+      </div>
+    </>
+  );
+};
+
+export default CollabHistory;

--- a/components/Collaborate/CollabHistory.js
+++ b/components/Collaborate/CollabHistory.js
@@ -16,6 +16,7 @@ const useStyles = makeStyles(theme => ({
     border: `1px solid ${theme.palette.secondary[200]}`,
     marginBottom: 16,
     flexGrow: 1,
+    overflow: 'auto',
   },
   modal: {
     display: 'flex',
@@ -31,6 +32,7 @@ const useStyles = makeStyles(theme => ({
     padding: 20,
   },
   modalSideBar: {
+    flex: 'none',
     display: 'flex',
     flexDirection: 'column',
     width: 200,

--- a/components/Collaborate/Prosemirror.css
+++ b/components/Collaborate/Prosemirror.css
@@ -195,3 +195,78 @@ this is a rough fix for the first cursor position when the first paragraph is em
   padding-right: 2px;
   white-space: nowrap;
 }
+
+#y-version {
+  position: relative;
+}
+
+.version-modal[hidden] {
+  display: none;
+}
+
+.version-modal:not([hidden]) {
+  position: absolute;
+  top: 30px;
+  right: 0;
+  width: 300px;
+  min-height: 300px;
+  height: fit-content;
+  z-index: 20;
+  background-color: white;
+  border: 1px solid #ccc;
+  border-radius: 11px;
+  border-top-right-radius: 0;
+  box-shadow: 0 3px 7px rgba(0, 0, 0, 0.3);
+}
+
+.version-modal > button {
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.version-list {
+  line-height: 30px;
+  padding: 0 8px;
+  cursor: pointer;
+}
+
+.version-list:hover {
+  background-color: #eee;
+}
+
+[ychange_type] {
+  position: relative;
+}
+.ychange-hover {
+  display: none;
+}
+*:hover > .ychange-hover {
+  display: inline;
+  position: absolute;
+  width: max-content;
+  top: -14px;
+  left: 0;
+  font-size: 12px;
+  padding: 0 2px;
+  border-radius: 3px 3px 0 0;
+  color: #fdfdfe;
+  user-select: none;
+  word-break: normal;
+}
+
+ychange[ychange_type='removed'], p[ychange_type='removed'] {
+  text-decoration: line-through;
+}
+/*
+p[ychange_type='removed'] > span > br {
+  display: none;
+}
+*/
+*:not(ychange)[ychange_type='removed'] {
+  background-color: #ff5a56;
+  color: inherit !important;
+}
+img[ychange_type='removed'] {
+  padding: 2px;
+}

--- a/components/Collaborate/Schema.js
+++ b/components/Collaborate/Schema.js
@@ -1,0 +1,311 @@
+// Ref: https://github.com/yjs/yjs-demos/blob/main/prosemirror-versions/schema.js
+//
+import { Schema } from 'prosemirror-model';
+
+const brDOM = ['br'];
+
+const calcYChangeStyle = ychange => {
+  switch (ychange.type) {
+    case 'removed':
+      return `color:${ychange.color.dark}`;
+    case 'added':
+      return `background-color:${ychange.color.light}`;
+    case null:
+      return '';
+  }
+};
+
+const calcYchangeDomAttrs = (attrs, domAttrs = {}) => {
+  domAttrs = Object.assign({}, domAttrs);
+  if (attrs.ychange !== null) {
+    domAttrs.ychange_user = attrs.ychange.user;
+    domAttrs.ychange_type = attrs.ychange.type;
+    domAttrs.ychange_color = attrs.ychange.color.light;
+    domAttrs.style = calcYChangeStyle(attrs.ychange);
+  }
+  return domAttrs;
+};
+
+/**
+ * @param {any} ychange
+ * @param {Array<any>}
+ */
+const hoverWrapper = (ychange, els) =>
+  ychange === null
+    ? els
+    : [
+        [
+          'span',
+          {
+            class: 'ychange-hover',
+            style: `background-color:${ychange.color.dark}`,
+          },
+          ychange.user || 'Unknown',
+        ],
+        ['span', ...els],
+      ];
+
+// :: Object
+// [Specs](#model.NodeSpec) for the nodes defined in this schema.
+export const nodes = {
+  // :: NodeSpec The top level document node.
+  doc: {
+    content: 'block+',
+  },
+
+  // :: NodeSpec A plain paragraph textblock. Represented in the DOM
+  // as a `<p>` element.
+  paragraph: {
+    attrs: { ychange: { default: null } },
+    content: 'inline*',
+    group: 'block',
+    parseDOM: [{ tag: 'p' }],
+    toDOM(node) {
+      // only render changes if no child nodes
+      const renderChanges = node.content.size === 0;
+      const attrs = renderChanges
+        ? calcYchangeDomAttrs(node.attrs)
+        : node.attrs;
+      const defChildren = [0];
+      const children = renderChanges
+        ? hoverWrapper(node.attrs.ychange, defChildren)
+        : defChildren;
+      return ['p', attrs, ...children];
+    },
+  },
+
+  // :: NodeSpec A blockquote (`<blockquote>`) wrapping one or more blocks.
+  blockquote: {
+    attrs: { ychange: { default: null } },
+    content: 'block+',
+    group: 'block',
+    defining: true,
+    parseDOM: [{ tag: 'blockquote' }],
+    toDOM(node) {
+      return [
+        'blockquote',
+        calcYchangeDomAttrs(node.attrs),
+        ...hoverWrapper(node.attrs.ychange, [0]),
+      ];
+    },
+  },
+
+  // :: NodeSpec A horizontal rule (`<hr>`).
+  horizontal_rule: {
+    attrs: { ychange: { default: null } },
+    group: 'block',
+    parseDOM: [{ tag: 'hr' }],
+    toDOM(node) {
+      return [
+        'hr',
+        calcYchangeDomAttrs(node.attrs),
+        ...hoverWrapper(node.attrs.ychange, []),
+      ];
+    },
+  },
+
+  // :: NodeSpec A heading textblock, with a `level` attribute that
+  // should hold the number 1 to 6. Parsed and serialized as `<h1>` to
+  // `<h6>` elements.
+  heading: {
+    attrs: {
+      level: { default: 1 },
+      ychange: { default: null },
+    },
+    content: 'inline*',
+    group: 'block',
+    defining: true,
+    parseDOM: [
+      { tag: 'h1', attrs: { level: 1 } },
+      { tag: 'h2', attrs: { level: 2 } },
+      { tag: 'h3', attrs: { level: 3 } },
+      { tag: 'h4', attrs: { level: 4 } },
+      { tag: 'h5', attrs: { level: 5 } },
+      { tag: 'h6', attrs: { level: 6 } },
+    ],
+    toDOM(node) {
+      return [
+        'h' + node.attrs.level,
+        calcYchangeDomAttrs(node.attrs),
+        ...hoverWrapper(node.attrs.ychange, [0]),
+      ];
+    },
+  },
+
+  // :: NodeSpec A code listing. Disallows marks or non-text inline
+  // nodes by default. Represented as a `<pre>` element with a
+  // `<code>` element inside of it.
+  code_block: {
+    attrs: { ychange: { default: null } },
+    content: 'text*',
+    marks: '',
+    group: 'block',
+    code: true,
+    defining: true,
+    parseDOM: [{ tag: 'pre', preserveWhitespace: 'full' }],
+    toDOM(node) {
+      return [
+        'pre',
+        calcYchangeDomAttrs(node.attrs),
+        ...hoverWrapper(node.attrs.ychange, [['code', 0]]),
+      ];
+    },
+  },
+
+  // :: NodeSpec The text node.
+  text: {
+    group: 'inline',
+  },
+
+  // :: NodeSpec An inline image (`<img>`) node. Supports `src`,
+  // `alt`, and `href` attributes. The latter two default to the empty
+  // string.
+  image: {
+    inline: true,
+    attrs: {
+      ychange: { default: null },
+      src: {},
+      alt: { default: null },
+      title: { default: null },
+    },
+    group: 'inline',
+    draggable: true,
+    parseDOM: [
+      {
+        tag: 'img[src]',
+        getAttrs(dom) {
+          return {
+            src: dom.getAttribute('src'),
+            title: dom.getAttribute('title'),
+            alt: dom.getAttribute('alt'),
+          };
+        },
+      },
+    ],
+    toDOM(node) {
+      const domAttrs = {
+        src: node.attrs.src,
+        title: node.attrs.title,
+        alt: node.attrs.alt,
+      };
+      return [
+        'img',
+        calcYchangeDomAttrs(node.attrs, domAttrs),
+        ...hoverWrapper(node.attrs.ychange, []),
+      ];
+    },
+  },
+
+  // :: NodeSpec A hard line break, represented in the DOM as `<br>`.
+  hard_break: {
+    inline: true,
+    group: 'inline',
+    selectable: false,
+    parseDOM: [{ tag: 'br' }],
+    toDOM() {
+      return brDOM;
+    },
+  },
+};
+
+const emDOM = ['em', 0];
+const strongDOM = ['strong', 0];
+const codeDOM = ['code', 0];
+
+// :: Object [Specs](#model.MarkSpec) for the marks in the schema.
+export const marks = {
+  // :: MarkSpec A link. Has `href` and `title` attributes. `title`
+  // defaults to the empty string. Rendered and parsed as an `<a>`
+  // element.
+  link: {
+    attrs: {
+      href: {},
+      title: { default: null },
+    },
+    inclusive: false,
+    parseDOM: [
+      {
+        tag: 'a[href]',
+        getAttrs(dom) {
+          return {
+            href: dom.getAttribute('href'),
+            title: dom.getAttribute('title'),
+          };
+        },
+      },
+    ],
+    toDOM(node) {
+      return ['a', node.attrs, 0];
+    },
+  },
+
+  // :: MarkSpec An emphasis mark. Rendered as an `<em>` element.
+  // Has parse rules that also match `<i>` and `font-style: italic`.
+  em: {
+    parseDOM: [{ tag: 'i' }, { tag: 'em' }, { style: 'font-style=italic' }],
+    toDOM() {
+      return emDOM;
+    },
+  },
+
+  // :: MarkSpec A strong mark. Rendered as `<strong>`, parse rules
+  // also match `<b>` and `font-weight: bold`.
+  strong: {
+    parseDOM: [
+      { tag: 'strong' },
+      // This works around a Google Docs misbehavior where
+      // pasted content will be inexplicably wrapped in `<b>`
+      // tags with a font-weight normal.
+      {
+        tag: 'b',
+        getAttrs: node => node.style.fontWeight !== 'normal' && null,
+      },
+      {
+        style: 'font-weight',
+        getAttrs: value => /^(bold(er)?|[5-9]\d{2,})$/.test(value) && null,
+      },
+    ],
+    toDOM() {
+      return strongDOM;
+    },
+  },
+
+  // :: MarkSpec Code font mark. Represented as a `<code>` element.
+  code: {
+    parseDOM: [{ tag: 'code' }],
+    toDOM() {
+      return codeDOM;
+    },
+  },
+  ychange: {
+    attrs: {
+      user: { default: null },
+      type: { default: null },
+      color: { default: null },
+    },
+    inclusive: false,
+    parseDOM: [{ tag: 'ychange' }],
+    toDOM(node) {
+      return [
+        'ychange',
+        {
+          ychange_user: node.attrs.user,
+          ychange_type: node.attrs.type,
+          style: calcYChangeStyle(node.attrs),
+          ychange_color: node.attrs.color.light,
+        },
+        ...hoverWrapper(node.attrs, [0]),
+      ];
+    },
+  },
+};
+
+// :: Schema
+// This schema rougly corresponds to the document schema used by
+// [CommonMark](http://commonmark.org/), minus the list elements,
+// which are defined in the [`prosemirror-schema-list`](#schema-list)
+// module.
+//
+// To reuse elements from this schema, extend or read from its
+// `spec.nodes` and `spec.marks` [properties](#model.Schema.spec).
+export const schema = new Schema({ nodes, marks });

--- a/components/Collaborate/Schema.js
+++ b/components/Collaborate/Schema.js
@@ -30,20 +30,33 @@ const calcYchangeDomAttrs = (attrs, domAttrs = {}) => {
  * @param {any} ychange
  * @param {Array<any>}
  */
-const hoverWrapper = (ychange, els) =>
-  ychange === null
-    ? els
-    : [
-        [
-          'span',
-          {
-            class: 'ychange-hover',
-            style: `background-color:${ychange.color.dark}`,
-          },
-          ychange.user || 'Unknown',
-        ],
-        ['span', ...els],
-      ];
+const hoverWrapper = (ychange, els) => {
+  if (ychange === null) {
+    return els;
+  } else {
+    let name = '';
+    try {
+      name = ychange.user ? JSON.parse(ychange.user).name : 'Unknown';
+    } catch (e) {
+      // JSON.parse error
+      // console.error(e);
+    } finally {
+      name = name || ychange.user;
+    }
+
+    return [
+      [
+        'span',
+        {
+          class: 'ychange-hover',
+          style: `background-color:${ychange.color.dark}`,
+        },
+        name,
+      ],
+      ['span', ...els],
+    ];
+  }
+};
 
 // :: Object
 // [Specs](#model.NodeSpec) for the nodes defined in this schema.

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -2538,7 +2538,20 @@ msgstr "逐字稿"
 msgid "Done"
 msgstr "完成"
 
-#: pages/index.js:29
+#: components\Collaborate\CollabHistory.js:109
+msgid "Versions"
+msgstr "版本"
+
+#: components\Collaborate\CollabHistory.js:178
+#, javascript-format
+msgid "Difference between version ${ versionTitle } and it's previous version"
+msgstr "版本 ${ versionTitle } 與上一個版本的差異"
+
+#: components\Collaborate\CollabHistory.js:207
+msgid "History"
+msgstr "歷史紀錄"
+
+#: pages\index.js:29
 msgctxt "site title"
 msgid "Cofacts"
 msgstr "Cofacts 真的假的"

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -2544,7 +2544,7 @@ msgstr "版本"
 
 #: components\Collaborate\CollabHistory.js:178
 #, javascript-format
-msgid "Difference between version ${ versionTitle } and it's previous version"
+msgid "Difference between version ${ versionTitle } and its previous version"
 msgstr "版本 ${ versionTitle } 與上一個版本的差異"
 
 #: components\Collaborate\CollabHistory.js:207

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -2551,6 +2551,10 @@ msgstr "版本 ${ versionTitle } 與上一個版本的差異"
 msgid "History"
 msgstr "歷史紀錄"
 
+#: components\Collaborate\CollabHistory.js:211
+msgid "No histories..."
+msgstr "尚無歷史紀錄"
+
 #: pages\index.js:29
 msgctxt "site title"
 msgid "Cofacts"

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "react-virtualized-auto-sizer": "^1.0.2",
         "rollbar": "^2.14.4",
         "ttag": "^1.7.22",
+        "use-prosemirror": "^1.3.0",
         "y-prosemirror": "^1.2.1",
         "yjs": "^13.5.29"
       },
@@ -32050,6 +32051,18 @@
         }
       }
     },
+    "node_modules/use-prosemirror": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-prosemirror/-/use-prosemirror-1.3.0.tgz",
+      "integrity": "sha512-49s+g3hRGcTue8bClAgOOPz/TE7flKzrfXJXW8MdycnDe3NFqEr4S0TS8i70shvqW+vdte6NlaArqYNyQqmF4g==",
+      "peerDependencies": {
+        "prosemirror-model": "^1.11.0",
+        "prosemirror-state": "^1.3.3",
+        "prosemirror-view": "^1.15.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/use-subscription": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/use-subscription/-/use-subscription-1.4.1.tgz",
@@ -58589,6 +58602,12 @@
       "requires": {
         "use-isomorphic-layout-effect": "^1.1.1"
       }
+    },
+    "use-prosemirror": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/use-prosemirror/-/use-prosemirror-1.3.0.tgz",
+      "integrity": "sha512-49s+g3hRGcTue8bClAgOOPz/TE7flKzrfXJXW8MdycnDe3NFqEr4S0TS8i70shvqW+vdte6NlaArqYNyQqmF4g==",
+      "requires": {}
     },
     "use-subscription": {
       "version": "1.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@hocuspocus/provider": "^2.0.3",
         "@material-ui/core": "^4.9.7",
         "@material-ui/icons": "^4.9.1",
+        "@material-ui/lab": "^4.0.0-alpha.61",
         "accepts": "^1.3.7",
         "apollo-boost": "^0.4.4",
         "apollo-link": "^1.2.13",
@@ -4801,6 +4802,33 @@
       },
       "peerDependencies": {
         "@material-ui/core": "^4.0.0",
+        "@types/react": "^16.8.6 || ^17.0.0",
+        "react": "^16.8.0 || ^17.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@material-ui/lab": {
+      "version": "4.0.0-alpha.61",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.61.tgz",
+      "integrity": "sha512-rSzm+XKiNUjKegj8bzt5+pygZeckNLOr+IjykH8sYdVk7dE9y2ZuUSofiMV2bJk3qU+JHwexmw+q0RyNZB9ugg==",
+      "deprecated": "Material UI v4 doesn't receive active development since September 2021. See the guide https://mui.com/material-ui/migration/migration-v4/ to upgrade to v5.",
+      "dependencies": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.3",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      },
+      "peerDependencies": {
+        "@material-ui/core": "^4.12.1",
         "@types/react": "^16.8.6 || ^17.0.0",
         "react": "^16.8.0 || ^17.0.0",
         "react-dom": "^16.8.0 || ^17.0.0"
@@ -37222,6 +37250,18 @@
       "integrity": "sha512-IKHlyx6LDh8n19vzwH5RtHIOHl9Tu90aAAxcbWME6kp4dmvODM3UvOHJeMIDzUbd4muuJKHmlNoBN+mDY4XkBA==",
       "requires": {
         "@babel/runtime": "^7.4.4"
+      }
+    },
+    "@material-ui/lab": {
+      "version": "4.0.0-alpha.61",
+      "resolved": "https://registry.npmjs.org/@material-ui/lab/-/lab-4.0.0-alpha.61.tgz",
+      "integrity": "sha512-rSzm+XKiNUjKegj8bzt5+pygZeckNLOr+IjykH8sYdVk7dE9y2ZuUSofiMV2bJk3qU+JHwexmw+q0RyNZB9ugg==",
+      "requires": {
+        "@babel/runtime": "^7.4.4",
+        "@material-ui/utils": "^4.11.3",
+        "clsx": "^1.0.4",
+        "prop-types": "^15.7.2",
+        "react-is": "^16.8.0 || ^17.0.0"
       }
     },
     "@material-ui/styles": {

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "react-virtualized-auto-sizer": "^1.0.2",
     "rollbar": "^2.14.4",
     "ttag": "^1.7.22",
+    "use-prosemirror": "^1.3.0",
     "y-prosemirror": "^1.2.1",
     "yjs": "^13.5.29"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@hocuspocus/provider": "^2.0.3",
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
+    "@material-ui/lab": "^4.0.0-alpha.61",
     "accepts": "^1.3.7",
     "apollo-boost": "^0.4.4",
     "apollo-link": "^1.2.13",


### PR DESCRIPTION
## Changes
- Add CollabHistory component to display history in modalview
  - Use [yjs-demos schema](https://github.com/yjs/yjs-demos/blob/main/prosemirror-versions/schema.js) for displaying `ychange`
- Refactor CollabEditor: use [use-prosemirror](https://github.com/ponymessenger/use-prosemirror) to create ProseMirror editor view
  - HocuspocusProvider connects server onTranscribe and destroys(disconnects) when `Editor` unmount
  - Make sure `Editor` and `CollabHistory` are created after provider synced, or ProseMirror editor may create with a wrong state
  - Update ydoc user mapping with a json string contains id and name
  - Note: there's another ProseMirror reactjs plugin [react-prosemirror](https://github.com/nytimes/react-prosemirror), but it require reactjs>=17
  - https://github.com/cofacts/rumors-api/pull/316
## Snapshot

![螢幕擷取畫面 2023-08-09 210930](https://github.com/cofacts/rumors-site/assets/6376572/949660db-f67d-4fed-a3a3-0c4df280ebb7)
