### PR TITLE
Updated README to specify node v16 is required since node v21 had a number of errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ For production via [rumors-deploy](http://github.com/cofacts/rumors-deploy), do 
 
 ## Development
 
-This project uses NodeJS 16+.
+This project uses NodeJS 16. Use a node version manager like `nvm` to install version 16 (ex. `nvm install 16`)
 
 ``` bash
 $ npm install


### PR DESCRIPTION
Updated README to specify node v16 is required since node v21 had a number of errors

One error was:
- Had to fix an ERR_OSSL_EVP_UNSUPPORTED error with running ` npm run dev ` by doing `export NODE_OPTIONS=--openssl-legacy-provider ` as per this stackoverflow article: https://stackoverflow.com/questions/69394632/webpack-build-failing-with-err-ossl-evp-unsupported

Another error occurred when trying to accessing localhost:3000
``` ./node_modules/date-fns/locale/pt-BR/index.js.flow 4:7
Module parse failed: Unexpected token (4:7)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
| // This file is generated automatically by `scripts/build/typings.js`. Please, don't change it.
|
> export type Locale = {
|   code?: string,
|   formatDistance?: (...args: Array<any>) => any,
```