### PR TITLE
Add fallback when terms fail to load

### DIFF
--- a/components/AppLayout/AppFooter.js
+++ b/components/AppLayout/AppFooter.js
@@ -33,10 +33,13 @@ const useStyles = makeStyles(theme => ({
     },
   },
   container: {
-    width: 800,
+    width: '100%',
+    maxWidth: 800,
     color: theme.palette.text.primary,
+    gap: 20,
     margin: 60,
     display: 'flex',
+    flexWrap: 'wrap',
   },
   second: {
     display: 'flex',
@@ -49,7 +52,8 @@ const useStyles = makeStyles(theme => ({
     height: 'auto',
   },
   column: {
-    flex: '1 1',
+    flex: '1 1 auto',
+    minWidth: 'max-content', // distribute width using longest content in the column
   },
   linkTextWithIcon: {
     marginLeft: 12,
@@ -169,12 +173,11 @@ function AppFooter() {
   const isDesktop = useMediaQuery('(min-width:768px)');
 
   return (
-    // <Box component="footer" display={['block', 'block', 'block']}>
     <Box component="footer">
       <div className={classes.first}>
         <div className={classes.container}>
-          {isDesktop && <FactCheckSection classes={classes} />}
-          {isDesktop && <AboutSection classes={classes} />}
+          <FactCheckSection classes={classes} />
+          <AboutSection classes={classes} />
           <ContactSection classes={classes} isDesktop={isDesktop} />
         </div>
       </div>


### PR DESCRIPTION
# Terms page
- Loading page also link to Terms in case loading stuck
- When loading fails, provide link to Terms

https://github.com/cofacts/rumors-site/assets/108608/6258ad45-5386-42c8-807d-b26c8178b16d

# Footer adjustments
- Show all footer content on mobile so that terms of use is also available
- Distribute width of columns in footer using longest content

![image](https://github.com/cofacts/rumors-site/assets/108608/ace5659d-03a8-4254-9dec-fe0a36af5231)
![image](https://github.com/cofacts/rumors-site/assets/108608/eb4df310-9678-4f7f-ba90-86648f4f8c0a)



