### PR TITLE
Fix UI when adding categories to articles

### DIFF
--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -173,7 +173,7 @@ const LOAD_ARTICLE = gql`
       cooccurrences {
         ...CooccurrenceSectionData
       }
-      articleCategories(statuses: $articleCategoryStatuses) {
+      articleCategories(statuses: $articleCategoryStatuses) @connection(key: "articleCategories") {
         ...ArticleCategoryData
         ...AddCategoryDialogData
       }
@@ -221,7 +221,7 @@ const LOAD_ARTICLE_FOR_USER = gql`
       articleReplies(statuses: $articleReplyStatuses) {
         ...ArticleReplyForUser
       }
-      articleCategories(statuses: $articleCategoryStatuses) {
+      articleCategories(statuses: $articleCategoryStatuses) @connection(key: "articleCategories") {
         ...ArticleCategoryDataForUser
         ...AddCategoryDialogData
       }


### PR DESCRIPTION
Closes #481.

The reason the UI was not refreshed was a regression introduced by cf550a0ca17a8b6b44f7839454b1758704e701c0. Adding the argument "(statuses: $articleCategoryStatuses)" changes the key used by InMemoryCache from "articleCategories" to "articleCategories({"statuses":["NORMAL"]})". This results in cache.readFragment() (called in components/ArticleCategories/CategoryOption.js throwing this error:
```
Invariant Violation: Can't find field articleCategories on object {
  "id": ...,
  "text": ...
  ...
  "articleCategories({\"statuses\":[\"NORMAL\"]})": [
    {
      "type": "id",
      "generated": false,
      "id": "ArticleCategory:...__...",
      "typename": "ArticleCategory"
    }
  ],
  "stats": [
    ...
  ],
  "user": {
    ...
  }
}
```

This commits solves this issue by forcing the key to be "articleCategories".

The technique of using an `@connection` directive is documented here: https://www.apollographql.com/docs/react/data/directives/#connection