### PR TITLE
Reply detail and article detail revamp for blocked content

### DIFF
--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -382,7 +382,10 @@ function ArticlePage() {
     <AppLayout>
       <Head>
         <title>
-          {ellipsis(article.text, { wordCount: 100 })} | {t`Cofacts`}
+          {article.status === 'BLOCKED'
+            ? t`Cofacts`
+            : ellipsis(article.text, { wordCount: 100 })}{' '}
+          | {t`Cofacts`}
         </title>
         {/* Don't let search engines index blocked spam */ article.status ===
           'BLOCKED' && <meta name="robots" content="noindex, nofollow" />}

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -378,14 +378,47 @@ function ArticlePage() {
     element => element.user && currentUser && element.user.id === currentUser.id
   );
 
+  const headerElem = (
+    <header className={classes.textHeader}>
+      <Ribbon className={classes.title}>
+        {ngettext(
+          msgid`${replyRequestCount} person report this message`,
+          `${replyRequestCount} people report this message`,
+          replyRequestCount
+        )}
+      </Ribbon>
+      <Infos>
+        <TimeInfo time={article.createdAt}>
+          {timeAgo => t`First reported ${timeAgo}`}
+        </TimeInfo>
+      </Infos>
+    </header>
+  );
+
+  if (article.status === 'BLOCKED' && !currentUser) {
+    return (
+      <AppLayout>
+        <Head>
+          <title>{t`Cofacts`}</title>
+          <meta name="robots" content="noindex, nofollow" />
+        </Head>
+        <div className={classes.root}>
+          <div className={classes.main}>
+            <Card>
+              {headerElem}
+              <CardContent>{t`Log in to view content`}</CardContent>
+            </Card>
+          </div>
+        </div>
+      </AppLayout>
+    );
+  }
+
   return (
     <AppLayout>
       <Head>
         <title>
-          {article.status === 'BLOCKED'
-            ? t`Cofacts`
-            : `${ellipsis(article.text, { wordCount: 100 })}
-          | ${t`Cofacts`}`}
+          {ellipsis(article.text, { wordCount: 100 })} | {t`Cofacts`}
         </title>
         {/* Don't let search engines index blocked spam */ article.status ===
           'BLOCKED' && <meta name="robots" content="noindex, nofollow" />}
@@ -393,85 +426,66 @@ function ArticlePage() {
       <div className={classes.root}>
         <div className={classes.main}>
           <Card>
-            <header className={classes.textHeader}>
-              <Ribbon className={classes.title}>
-                {ngettext(
-                  msgid`${replyRequestCount} person report this message`,
-                  `${replyRequestCount} people report this message`,
-                  replyRequestCount
-                )}
-              </Ribbon>
-              <Infos>
-                <TimeInfo time={article.createdAt}>
-                  {timeAgo => t`First reported ${timeAgo}`}
-                </TimeInfo>
-              </Infos>
-            </header>
+            {headerElem}
             <CardContent>
-              {article.status === 'BLOCKED' && !currentUser ? (
-                t`Log in to view content`
-              ) : (
-                <>
-                  {(() => {
-                    switch (articleType) {
-                      case 'IMAGE':
-                        return !originalAttachmentUrl ? (
-                          <img
-                            className={classes.attachment}
-                            src={attachmentUrl}
-                            alt="image"
-                          />
-                        ) : (
-                          <a
-                            href={originalAttachmentUrl}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            <img
-                              className={classes.attachment}
-                              src={attachmentUrl}
-                              alt="image"
-                            />
-                          </a>
-                        );
-                      case 'VIDEO':
-                        return !originalAttachmentUrl ? (
-                          t`Log in to view video content`
-                        ) : (
-                          <video
-                            className={classes.attachment}
-                            src={originalAttachmentUrl}
-                            controls
-                          />
-                        );
-                      case 'AUDIO':
-                        return !originalAttachmentUrl ? (
-                          t`Log in to view audio content`
-                        ) : (
-                          <audio src={originalAttachmentUrl} controls />
-                        );
-                      default:
-                        return (
-                          <>
-                            {text &&
-                              nl2br(
-                                linkify(text, {
-                                  props: {
-                                    target: '_blank',
-                                    rel: 'ugc nofollow',
-                                  },
-                                })
-                              )}
-                            <Hyperlinks
-                              hyperlinks={hyperlinks}
-                              rel="ugc nofollow"
-                            />
-                          </>
-                        );
-                    }
-                  })()}
-                </>
-              )}
+              {(() => {
+                switch (articleType) {
+                  case 'IMAGE':
+                    return !originalAttachmentUrl ? (
+                      <img
+                        className={classes.attachment}
+                        src={attachmentUrl}
+                        alt="image"
+                      />
+                    ) : (
+                      <a
+                        href={originalAttachmentUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <img
+                          className={classes.attachment}
+                          src={attachmentUrl}
+                          alt="image"
+                        />
+                      </a>
+                    );
+                  case 'VIDEO':
+                    return !originalAttachmentUrl ? (
+                      t`Log in to view video content`
+                    ) : (
+                      <video
+                        className={classes.attachment}
+                        src={originalAttachmentUrl}
+                        controls
+                      />
+                    );
+                  case 'AUDIO':
+                    return !originalAttachmentUrl ? (
+                      t`Log in to view audio content`
+                    ) : (
+                      <audio src={originalAttachmentUrl} controls />
+                    );
+                  default:
+                    return (
+                      <>
+                        {text &&
+                          nl2br(
+                            linkify(text, {
+                              props: {
+                                target: '_blank',
+                                rel: 'ugc nofollow',
+                              },
+                            })
+                          )}
+                        <Hyperlinks
+                          hyperlinks={hyperlinks}
+                          rel="ugc nofollow"
+                        />
+                      </>
+                    );
+                }
+              })()}
               {articleType !== 'TEXT' ? (
                 <CollabEditor article={article} />
               ) : null}

--- a/pages/article/[id].js
+++ b/pages/article/[id].js
@@ -384,8 +384,8 @@ function ArticlePage() {
         <title>
           {article.status === 'BLOCKED'
             ? t`Cofacts`
-            : ellipsis(article.text, { wordCount: 100 })}{' '}
-          | {t`Cofacts`}
+            : `${ellipsis(article.text, { wordCount: 100 })}
+          | ${t`Cofacts`}`}
         </title>
         {/* Don't let search engines index blocked spam */ article.status ===
           'BLOCKED' && <meta name="robots" content="noindex, nofollow" />}

--- a/pages/reply/[id].js
+++ b/pages/reply/[id].js
@@ -206,15 +206,15 @@ function ReplyPage() {
     return (
       <AppLayout>
         <Head>
-          <title>
-            {ellipsis(reply.text, { wordCount: 100 })} | {t`Cofacts`}
-          </title>
+          <title>{t`Cofacts`}</title>
           <meta name="robots" content="noindex" />
         </Head>
         <div className={classes.root}>
           <Card>
             <CardHeader>{t`This reply`}</CardHeader>
-            <CardContent>{reply.text}</CardContent>
+            <CardContent>
+              {!currentUser ? t`Log in to view content` : reply.text}
+            </CardContent>
           </Card>
         </div>
       </AppLayout>


### PR DESCRIPTION
Fixes #577 as well as #570. In the end, `status` field is not required at all for replies; merely by looking at the status of original article reply, we can judge if the reply is blocked or not.

# Spam article

Not logged in: cannot see everything else
![圖片](https://github.com/user-attachments/assets/1cbcd7ce-469b-4902-94a2-7837a7b80f60)

Logged in: can see and interact everything
![圖片](https://github.com/user-attachments/assets/e5b3faa2-3b68-48af-8606-e4ec1d589469)

# Spam reply
Not logged in
![圖片](https://github.com/user-attachments/assets/d489c552-e554-40c3-a8aa-c61e709e4a37)

Logged in
![圖片](https://github.com/user-attachments/assets/4b64c1ab-7eb5-44da-9387-baca986275d7)

