### PR TITLE
fix: router redirect when no id and no slug

### DIFF
--- a/components/ProfilePage/ProfilePage.js
+++ b/components/ProfilePage/ProfilePage.js
@@ -110,6 +110,12 @@ function ProfilePage({ id, slug }) {
   }
 
   if (!data || !data.GetUser) {
+    const userId = currentUser?.id;
+    if (!id && !slug && userId) {
+      router.replace(`/user?id=${userId}`);
+      return null;
+    }
+
     return (
       <AppLayout container={false}>
         <Head>


### PR DESCRIPTION
When entering user page without id and without slug (`/user/`), it will redirect to `/user?id={userId}`