### PR TITLE
fix(ProfilePage): redirect to new user profile URL after user changin…

### DIFF
--- a/components/ProfilePage/ProfilePage.js
+++ b/components/ProfilePage/ProfilePage.js
@@ -88,13 +88,16 @@ function ProfilePage({ id, slug }) {
   //
   const router = useRouter();
   const latestSlug = data?.GetUser?.slug; // slug may update after user edits
+  const userId = currentUser?.id;
   useEffect(() => {
-    if (!latestSlug) return;
-    const targetPath = `/user/${encodeURI(latestSlug)}`;
-    if (window.location.pathname !== targetPath) {
+    if (latestSlug === undefined) return;
+    const targetPath = latestSlug
+      ? `/user/${encodeURI(latestSlug)}`
+      : `/user?id=${userId}`;
+    if (router.asPath !== targetPath) {
       router.replace(targetPath);
     }
-  }, [latestSlug, router]);
+  }, [latestSlug, userId, router]);
 
   if (loading) {
     return (


### PR DESCRIPTION
Did a few adjustments
1. Changed the condition `!latestSlug` to `latestSlug === undefined` since slug might be cleared.
2. Redirect to `/user?id={yourId}` when `latestSlug` is null or empty.
3. Replaced `window.location.pathname` with `router.asPath` because `window.location.pathname` cannot capture query parameters.