### PR TITLE
feat(Profile page): show join date

### DIFF
--- a/components/ProfilePage/ProfilePage.js
+++ b/components/ProfilePage/ProfilePage.js
@@ -44,6 +44,7 @@ const LOAD_USER = gql`
   query LoadProfilePage($id: String, $slug: String) {
     GetUser(id: $id, slug: $slug) {
       id
+      createdAt
       ...UserHeaderData
       contributions {
         date

--- a/components/ProfilePage/UserPageHeader.js
+++ b/components/ProfilePage/UserPageHeader.js
@@ -15,6 +15,7 @@ import Ribbon from 'components/Ribbon';
 import LevelIcon from 'components/LevelIcon';
 import LevelProgressBar from 'components/AppLayout/Widgets/LevelProgressBar';
 import Avatar from 'components/AppLayout/Widgets/Avatar';
+import TimeInfo from 'components/Infos/TimeInfo';
 import Stats from './Stats';
 import EditIcon from '@material-ui/icons/Edit';
 import EditProfileDialog from './EditProfileDialog';
@@ -250,6 +251,9 @@ function UserPageHeader({ user, isSelf, stats }) {
               {editButtonElem}
             </Hidden>
           </div>
+          <TimeInfo time={user.createdAt}>
+            {timeAgo => t`Join date : ${timeAgo}`}
+          </TimeInfo>
           <div className={classes.progress}>
             <LevelProgressBar user={user} />
             <Typography variant="caption">

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -966,6 +966,11 @@ msgid "Cofacts chatbot"
 msgstr "Cofacts 真的假的聊天機器人"
 
 #: components/ProfilePage/UserPageHeader.js:256
+#, javascript-format
+msgid "Join date : ${ timeAgo }"
+msgstr "註冊日期 : ${ timeAgo }"
+
+#: components/ProfilePage/UserPageHeader.js:256
 msgid "EXP"
 msgstr "公道值"
 


### PR DESCRIPTION
Display join date of a user on their profile page #412 

In English
<img width="1419" alt="截圖 2024-12-18 上午12 26 06" src="https://github.com/user-attachments/assets/89f9ffee-552c-4b41-b124-94b51cff90bc" />

In Mandarin
<img width="1409" alt="截圖 2024-12-18 上午12 27 54" src="https://github.com/user-attachments/assets/bf3827a0-9c47-4767-ac2d-0b554146bf03" />

Not sure whether putting JoinDate in that place is optimal for UI