### PR TITLE
fix(ProfilePage): should see other users' profile page

### DIFF
--- a/components/ProfilePage/ProfilePage.js
+++ b/components/ProfilePage/ProfilePage.js
@@ -89,9 +89,9 @@ function ProfilePage({ id, slug }) {
   //
   const router = useRouter();
   const latestSlug = data?.GetUser?.slug; // slug may update after user edits
-  const userId = currentUser?.id;
+  const userId = data?.GetUser?.id;
   useEffect(() => {
-    if (latestSlug === undefined) return;
+    if (!latestSlug && latestSlug !== '') return;
     const targetPath = latestSlug
       ? `/user/${encodeURI(latestSlug)}`
       : `/user?id=${userId}`;


### PR DESCRIPTION
## explaination
I found that latestSlug returns null when the user hasn't set their slug yet. Therefore, I changed `latestSlug === undefined` to `!latestSlug && latestSlug !== ''`
Additionally, if the user resets their slug to an empty string, it will fail the condition. To address this, I changed the userId to ensure redirection leads to the user's page instead of "my" page.

## preview
<img width="1412" alt="截圖 2024-12-21 上午1 59 54" src="https://github.com/user-attachments/assets/68e6ae8e-4223-4d60-890b-e1498895d6e5" />
able to see other user's profile page



