### PR TITLE
feat: send upvote / downvote without reason

### DIFF
--- a/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.js
+++ b/components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.js
@@ -136,6 +136,13 @@ function ArticleReplyFeedbackControl({ articleReply, className }) {
   const openVotePopover = (event, value) => {
     setVotePopoverAnchorEl(event.currentTarget);
     setVote(value);
+    createReplyFeedback({
+      variables: {
+        articleId: articleReply.articleId,
+        replyId: articleReply.replyId,
+        vote: value,
+      },
+    });
   };
 
   const closeVotePopover = () => {
@@ -228,7 +235,7 @@ function ArticleReplyFeedbackControl({ articleReply, className }) {
               });
             }}
           >
-            {t`Send`}
+            {reason ? t`Send` : t`Close`}
           </Button>
         </div>
       </Popover>


### PR DESCRIPTION
fix #294

As in the issue description, I have changed to submit the feedback on every upvote / downvote click. The reason dialog stays the same, and it shows `Close` when there is no input text, `Send` otherwise.