### PR TITLE
feat: auto resize search bar

### DIFF
--- a/components/SearchPageJumbotron.js
+++ b/components/SearchPageJumbotron.js
@@ -116,7 +116,7 @@ function SearchPageJumbotron() {
               name="search"
               className={classes.input}
               minRows={1}
-              onKeyDown={(e) => {
+              onKeyDown={e => {
                 // enter to trigger search, so disable default line breaking
                 if (e.key == 'Enter') {
                   e.preventDefault();

--- a/components/SearchPageJumbotron.js
+++ b/components/SearchPageJumbotron.js
@@ -2,7 +2,7 @@ import { useRef, useEffect, memo } from 'react';
 import { useRouter } from 'next/router';
 import { t } from 'ttag';
 import { makeStyles, withStyles } from '@material-ui/core/styles';
-import { Tabs, Tab, Box, Container } from '@material-ui/core';
+import { Tabs, Tab, Box, Container, TextareaAutosize } from '@material-ui/core';
 import SearchIcon from '@material-ui/icons/Search';
 
 const useStyles = makeStyles(theme => ({
@@ -10,6 +10,7 @@ const useStyles = makeStyles(theme => ({
     background: '#202020',
   },
   search: {
+    alignSelf: 'flex-start',
     color: theme.palette.common.white,
     paddingRight: theme.spacing(3),
   },
@@ -53,6 +54,7 @@ const useStyles = makeStyles(theme => ({
     outline: 'none',
     color: theme.palette.common.white,
     background: 'transparent',
+    paddingRight: theme.spacing(4),
   },
   submit: {
     display: 'none',
@@ -109,11 +111,11 @@ function SearchPageJumbotron() {
         <form onSubmit={onSearch} className={classes.form}>
           <h2 className={classes.search}>{t`Searching`}</h2>
           <Box flex={1} className={classes.inputArea}>
-            <textarea
+            <TextareaAutosize
               ref={textareaRef}
               name="search"
               className={classes.input}
-              rows={1}
+              minRows={1}
             />
             <button type="submit" className={classes.submit}>
               <SearchIcon />

--- a/components/SearchPageJumbotron.js
+++ b/components/SearchPageJumbotron.js
@@ -97,7 +97,7 @@ function SearchPageJumbotron() {
     });
   };
 
-  const { q } = query;
+  const { q = '' } = query;
   useEffect(() => {
     textareaRef.current.value = q;
   }, [q]);
@@ -116,6 +116,13 @@ function SearchPageJumbotron() {
               name="search"
               className={classes.input}
               minRows={1}
+              onKeyDown={(e) => {
+                // enter to trigger search, so disable default line breaking
+                if (e.key == 'Enter') {
+                  e.preventDefault();
+                  e.target.form.requestSubmit();
+                }
+              }}
             />
             <button type="submit" className={classes.submit}>
               <SearchIcon />


### PR DESCRIPTION
fix #281 

As per requirements from the issue description, I have used `TextAreaAutoResize` component from Material UI. I have also adjusted the styles of the textarea since the text inside is overlapping with search icon button.

Before:
![image](https://github.com/user-attachments/assets/d80acd8c-9981-4166-a5f2-ff0913536bf5)

After:
![image](https://github.com/user-attachments/assets/89c69fc4-a14a-41c6-b164-39e11b25cb90)

I noticed pressing enter key on the current site https://cofacts.org/search did not trigger search, but I have added it as per the issue description.

I also adjusted the `Searching` text to stick at the top of the flex area.