### PR TITLE
Feat/issue-456-adjust-reply-search

### DIFF
--- a/components/NewReplySection/ReplySearch/ReplySearch.js
+++ b/components/NewReplySection/ReplySearch/ReplySearch.js
@@ -20,6 +20,7 @@ const SEARCH = gql`
         node {
           id
           articleReplies {
+            status
             user {
               id
             }
@@ -39,6 +40,7 @@ const SEARCH = gql`
       edges {
         node {
           articleReplies {
+            status
             user {
               id
             }
@@ -89,7 +91,7 @@ function ReplySearch({
   ).concat(relatedArticleReplies);
 
   const validArticleReplies = allArticleReplies.filter(reply => {
-    return reply.articleId && reply.article?.id;
+    return reply.status === 'NORMAL';
   });
 
   const currentUserOnly = [FILTERS.MY_MESSAGES, FILTERS.MY_REPLIES].includes(

--- a/components/NewReplySection/ReplySearch/ReplySearch.js
+++ b/components/NewReplySection/ReplySearch/ReplySearch.js
@@ -88,15 +88,22 @@ function ReplySearch({
     existingReplyIds
   ).concat(relatedArticleReplies);
 
+  const validArticleReplies = allArticleReplies.filter(reply => {
+    return (
+      reply.articleId &&
+      reply.article?.id
+    );
+  });
+
   const currentUserOnly = [FILTERS.MY_MESSAGES, FILTERS.MY_REPLIES].includes(
     filter
   );
 
   const articleReplies = currentUserOnly
-    ? allArticleReplies.filter(
+    ? validArticleReplies.filter(
         ({ user }) => user && user.id === currentUser?.id
       )
-    : allArticleReplies;
+    : validArticleReplies;
 
   return (
     <>

--- a/components/NewReplySection/ReplySearch/ReplySearch.js
+++ b/components/NewReplySection/ReplySearch/ReplySearch.js
@@ -20,7 +20,6 @@ const SEARCH = gql`
         node {
           id
           articleReplies {
-            status
             user {
               id
             }

--- a/components/NewReplySection/ReplySearch/ReplySearch.js
+++ b/components/NewReplySection/ReplySearch/ReplySearch.js
@@ -89,10 +89,7 @@ function ReplySearch({
   ).concat(relatedArticleReplies);
 
   const validArticleReplies = allArticleReplies.filter(reply => {
-    return (
-      reply.articleId &&
-      reply.article?.id
-    );
+    return reply.articleId && reply.article?.id;
   });
 
   const currentUserOnly = [FILTERS.MY_MESSAGES, FILTERS.MY_REPLIES].includes(

--- a/components/RelatedReplies.js
+++ b/components/RelatedReplies.js
@@ -68,6 +68,7 @@ const RelatedArticleReplyData = gql`
   fragment RelatedArticleReplyData on ArticleReply {
     articleId
     replyId
+    status
     user {
       id
     }

--- a/i18n/zh_TW.po
+++ b/i18n/zh_TW.po
@@ -135,6 +135,7 @@ msgstr "刪除"
 msgid "Submit"
 msgstr "送出"
 
+#: components/AIReplySection/VoteButtons.tsx:214
 #: components/ArticleCategories/CategoryOption.js:364
 #: components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.js:238
 msgid "Thank you for the feedback."
@@ -202,7 +203,7 @@ msgid "someone"
 msgstr "有人"
 
 #: components/LandingPage/Stats.js:145
-#. we hold ~
+#. we hold ~ 
 msgid "a gathering of editors."
 msgstr "編輯小聚"
 
@@ -391,7 +392,7 @@ msgstr "訂閱本頁"
 msgid "See Reasons"
 msgstr "看理由"
 
-#: components/AIReplySection/VoteButtons.tsx:203
+#: components/AIReplySection/VoteButtons.tsx:207
 #: components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.js:231
 msgid "Send"
 msgstr "送出"
@@ -447,7 +448,7 @@ msgstr "可疑訊息"
 msgid "Do you have any thing to add?"
 msgstr "您有沒有什麼想補充的呢？"
 
-#: components/AIReplySection/VoteButtons.tsx:187
+#: components/AIReplySection/VoteButtons.tsx:190
 #: components/ArticleReplyFeedbackControl/ArticleReplyFeedbackControl.js:205
 msgid "Why do you think it is not useful?"
 msgstr "您認為沒有幫助的理由是什麼呢？"
@@ -2238,7 +2239,7 @@ msgstr "所附網址的網頁內容"
 
 #: components/ArticleReply/ArticleReply.js:110
 #: pages/article/[id].js:306
-#. t: terms subject
+#. t: terms subject 
 msgid "This info"
 msgstr "此資訊"
 
@@ -2585,7 +2586,7 @@ msgstr "Cofacts 開源專案開始於 2016 年。2023 年，Cofacts 工作小組
 msgid "Automated analysis from AI"
 msgstr "AI 自動分析"
 
-#: components/AIReplySection/VoteButtons.tsx:186
+#: components/AIReplySection/VoteButtons.tsx:189
 msgid "Do you have anything to add?"
 msgstr "針對這則回應，有沒有想補充的呢？"
 


### PR DESCRIPTION
## Issue
fix #456
When using "Use existing reply" feature, deleted replies were still being displayed in the list. While we cannot filter these replies directly from the API (since `articleReplies` are not stored in the reply object), we can filter them out at the UI level.

## Changes
- Added filtering logic in ReplySearch component to only show replies that have valid article connections

## To check
不確定這樣判斷 deleted replies 的商業邏輯是否正確