### PR TITLE
feat: Show URL title in article list

### DIFF
--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -165,7 +165,7 @@ function Hyperlink({ hyperlink, rel = '' }) {
           </p>
         )}
         {topImageUrl && <figure className='image' />}
-        {error && <p className='error'>{getErrorText(error)}</p>}
+        {error && <p className={classes.error}>{getErrorText(error)}</p>}
       </div>
       <span className={classes.url}>
         <HyperlinkIcon />

--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -17,6 +17,7 @@ const useStyles = makeStyles(theme => ({
     margin: '0 8px 8px 0',
     background: theme.palette.secondary[50],
     borderRadius: 8,
+    width: '100%',
     maxWidth: '100%',
     '& h1': {
       overflow: 'hidden',

--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -157,11 +157,13 @@ function Hyperlink({ hyperlink, rel = '' }) {
 
   return (
     <article className={classes.linkcard}>
-      <h1 title={title}>{title}</h1>
+      {title && <h1 title={title}>{title}</h1>}
       <div className={classes.preview}>
-        <p className='summary' title={summary}>
-          {summary}
-        </p>
+        {summary && (
+          <p className='summary' title={summary}>
+            {summary}
+          </p>
+        )}
         {topImageUrl && <figure className='image' />}
         {error && <p className='error'>{getErrorText(error)}</p>}
       </div>

--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -1,12 +1,12 @@
-import gql from 'graphql-tag'
-import { t } from 'ttag'
-import { Box, CircularProgress } from '@material-ui/core'
-import { makeStyles } from '@material-ui/core/styles'
-import { useQuery } from '@apollo/react-hooks'
+import gql from 'graphql-tag';
+import { t } from 'ttag';
+import { Box, CircularProgress } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+import { useQuery } from '@apollo/react-hooks';
 
-import { HyperlinkIcon } from 'components/icons'
+import { HyperlinkIcon } from 'components/icons';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(theme => ({
   root: {
     display: 'flex',
     flexFlow: 'row',
@@ -89,7 +89,7 @@ const useStyles = makeStyles((theme) => ({
     color: 'firebrick',
     fontStyle: 'italic',
   },
-}))
+}));
 
 const HyperlinkData = gql`
   fragment HyperlinkData on Hyperlink {
@@ -99,7 +99,7 @@ const HyperlinkData = gql`
     topImageUrl
     error
   }
-`
+`;
 
 export const POLLING_QUERY = {
   articles: gql`
@@ -124,7 +124,7 @@ export const POLLING_QUERY = {
     }
     ${HyperlinkData}
   `,
-}
+};
 
 /**
  * @param {string} error - One of ResolveError https://github.com/cofacts/url-resolver/blob/master/src/typeDefs/ResolveError.graphql
@@ -132,16 +132,16 @@ export const POLLING_QUERY = {
 function getErrorText(error) {
   switch (error) {
     case 'NAME_NOT_RESOLVED':
-      return t`Domain name cannot be resolved`
+      return t`Domain name cannot be resolved`;
     case 'UNSUPPORTED':
     case 'INVALID_URL':
-      return t`URL is malformed or not supported`
+      return t`URL is malformed or not supported`;
     case 'NOT_REACHABLE':
-      return t`Cannot get data from URL`
+      return t`Cannot get data from URL`;
     case 'HTTPS_ERROR':
-      return t`Target site contains HTTPS error`
+      return t`Target site contains HTTPS error`;
     default:
-      return t`Unknown error`
+      return t`Unknown error`;
   }
 }
 
@@ -150,31 +150,31 @@ function getErrorText(error) {
  * @param {string} props.rel - rel prop for the hyperlink (other than noopener and noreferrer)
  */
 function Hyperlink({ hyperlink, rel = '' }) {
-  const { title, topImageUrl, error, url } = hyperlink
-  const summary = (hyperlink.summary || '').slice(0, 200)
+  const { title, topImageUrl, error, url } = hyperlink;
+  const summary = (hyperlink.summary || '').slice(0, 200);
 
-  const classes = useStyles({ topImageUrl })
+  const classes = useStyles({ topImageUrl });
 
   return (
     <article className={classes.linkcard}>
       {title && <h1 title={title}>{title}</h1>}
       <div className={classes.preview}>
         {summary && (
-          <p className='summary' title={summary}>
+          <p className="summary" title={summary}>
             {summary}
           </p>
         )}
-        {topImageUrl && <figure className='image' />}
+        {topImageUrl && <figure className="image" />}
         {error && <p className={classes.error}>{getErrorText(error)}</p>}
       </div>
       <span className={classes.url}>
         <HyperlinkIcon />
-        <a href={url} target='_blank' rel={`noopener noreferrer ${rel}`}>
+        <a href={url} target="_blank" rel={`noopener noreferrer ${rel}`}>
           {url}
         </a>
       </span>
     </article>
-  )
+  );
 }
 
 function PollingHyperlink({ pollingType, pollingId }) {
@@ -187,9 +187,9 @@ function PollingHyperlink({ pollingType, pollingId }) {
   useQuery(POLLING_QUERY[pollingType], {
     variables: { id: pollingId },
     pollInterval: 2000,
-  })
+  });
 
-  return <CircularProgress />
+  return <CircularProgress />;
 }
 
 /**
@@ -199,19 +199,19 @@ function PollingHyperlink({ pollingType, pollingId }) {
  * @param {string?} props.rel - rel prop for the hyperlink (other than noopener and noreferrer)
  */
 function Hyperlinks({ hyperlinks, pollingType, pollingId, rel }) {
-  const classes = useStyles()
+  const classes = useStyles();
   if (!((pollingId && pollingType) || (!pollingId && !pollingType))) {
-    throw new Error('pollingType and pollingId must be specified together')
+    throw new Error('pollingType and pollingId must be specified together');
   }
 
-  if (hyperlinks && hyperlinks.length === 0) return null
+  if (hyperlinks && hyperlinks.length === 0) return null;
 
-  let className = `${classes.root}`
+  let className = `${classes.root}`;
   if (hyperlinks && hyperlinks.length > 1) {
-    className += ` ${classes.multilink}`
+    className += ` ${classes.multilink}`;
   }
   return (
-    <Box className={className} component='section' mt={2} mb={1}>
+    <Box className={className} component="section" mt={2} mb={1}>
       {(hyperlinks || []).map((hyperlink, idx) => (
         <Hyperlink key={idx} hyperlink={hyperlink} rel={rel} />
       ))}
@@ -219,11 +219,11 @@ function Hyperlinks({ hyperlinks, pollingType, pollingId, rel }) {
         <PollingHyperlink pollingId={pollingId} pollingType={pollingType} />
       )}
     </Box>
-  )
+  );
 }
 
 Hyperlinks.fragments = {
   HyperlinkData,
-}
+};
 
-export default Hyperlinks
+export default Hyperlinks;

--- a/components/Hyperlinks.js
+++ b/components/Hyperlinks.js
@@ -1,12 +1,12 @@
-import gql from 'graphql-tag';
-import { t } from 'ttag';
-import { Box, CircularProgress } from '@material-ui/core';
-import { makeStyles } from '@material-ui/core/styles';
-import { useQuery } from '@apollo/react-hooks';
+import gql from 'graphql-tag'
+import { t } from 'ttag'
+import { Box, CircularProgress } from '@material-ui/core'
+import { makeStyles } from '@material-ui/core/styles'
+import { useQuery } from '@apollo/react-hooks'
 
-import { HyperlinkIcon } from 'components/icons';
+import { HyperlinkIcon } from 'components/icons'
 
-const useStyles = makeStyles(theme => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     display: 'flex',
     flexFlow: 'row',
@@ -68,7 +68,7 @@ const useStyles = makeStyles(theme => ({
     '& .summary': {
       color: theme.palette.secondary[500],
       overflow: 'hidden',
-      margin: 0,
+      margin: '1px 0',
       display: '-webkit-box',
       boxOrient: 'vertical',
       textOverflow: 'ellipsis',
@@ -89,7 +89,7 @@ const useStyles = makeStyles(theme => ({
     color: 'firebrick',
     fontStyle: 'italic',
   },
-}));
+}))
 
 const HyperlinkData = gql`
   fragment HyperlinkData on Hyperlink {
@@ -99,7 +99,7 @@ const HyperlinkData = gql`
     topImageUrl
     error
   }
-`;
+`
 
 export const POLLING_QUERY = {
   articles: gql`
@@ -124,7 +124,7 @@ export const POLLING_QUERY = {
     }
     ${HyperlinkData}
   `,
-};
+}
 
 /**
  * @param {string} error - One of ResolveError https://github.com/cofacts/url-resolver/blob/master/src/typeDefs/ResolveError.graphql
@@ -132,16 +132,16 @@ export const POLLING_QUERY = {
 function getErrorText(error) {
   switch (error) {
     case 'NAME_NOT_RESOLVED':
-      return t`Domain name cannot be resolved`;
+      return t`Domain name cannot be resolved`
     case 'UNSUPPORTED':
     case 'INVALID_URL':
-      return t`URL is malformed or not supported`;
+      return t`URL is malformed or not supported`
     case 'NOT_REACHABLE':
-      return t`Cannot get data from URL`;
+      return t`Cannot get data from URL`
     case 'HTTPS_ERROR':
-      return t`Target site contains HTTPS error`;
+      return t`Target site contains HTTPS error`
     default:
-      return t`Unknown error`;
+      return t`Unknown error`
   }
 }
 
@@ -150,29 +150,29 @@ function getErrorText(error) {
  * @param {string} props.rel - rel prop for the hyperlink (other than noopener and noreferrer)
  */
 function Hyperlink({ hyperlink, rel = '' }) {
-  const { title, topImageUrl, error, url } = hyperlink;
-  const summary = (hyperlink.summary || '').slice(0, 200);
+  const { title, topImageUrl, error, url } = hyperlink
+  const summary = (hyperlink.summary || '').slice(0, 200)
 
-  const classes = useStyles({ topImageUrl });
+  const classes = useStyles({ topImageUrl })
 
   return (
     <article className={classes.linkcard}>
       <h1 title={title}>{title}</h1>
       <div className={classes.preview}>
-        <p className="summary" title={summary}>
+        <p className='summary' title={summary}>
           {summary}
         </p>
-        {topImageUrl && <figure className="image" />}
-        {error && <p className="error">{getErrorText(error)}</p>}
+        {topImageUrl && <figure className='image' />}
+        {error && <p className='error'>{getErrorText(error)}</p>}
       </div>
       <span className={classes.url}>
         <HyperlinkIcon />
-        <a href={url} target="_blank" rel={`noopener noreferrer ${rel}`}>
+        <a href={url} target='_blank' rel={`noopener noreferrer ${rel}`}>
           {url}
         </a>
       </span>
     </article>
-  );
+  )
 }
 
 function PollingHyperlink({ pollingType, pollingId }) {
@@ -185,9 +185,9 @@ function PollingHyperlink({ pollingType, pollingId }) {
   useQuery(POLLING_QUERY[pollingType], {
     variables: { id: pollingId },
     pollInterval: 2000,
-  });
+  })
 
-  return <CircularProgress />;
+  return <CircularProgress />
 }
 
 /**
@@ -197,19 +197,19 @@ function PollingHyperlink({ pollingType, pollingId }) {
  * @param {string?} props.rel - rel prop for the hyperlink (other than noopener and noreferrer)
  */
 function Hyperlinks({ hyperlinks, pollingType, pollingId, rel }) {
-  const classes = useStyles();
+  const classes = useStyles()
   if (!((pollingId && pollingType) || (!pollingId && !pollingType))) {
-    throw new Error('pollingType and pollingId must be specified together');
+    throw new Error('pollingType and pollingId must be specified together')
   }
 
-  if (hyperlinks && hyperlinks.length === 0) return null;
+  if (hyperlinks && hyperlinks.length === 0) return null
 
-  let className = `${classes.root}`;
+  let className = `${classes.root}`
   if (hyperlinks && hyperlinks.length > 1) {
-    className += ` ${classes.multilink}`;
+    className += ` ${classes.multilink}`
   }
   return (
-    <Box className={className} component="section" mt={2} mb={1}>
+    <Box className={className} component='section' mt={2} mb={1}>
       {(hyperlinks || []).map((hyperlink, idx) => (
         <Hyperlink key={idx} hyperlink={hyperlink} rel={rel} />
       ))}
@@ -217,11 +217,11 @@ function Hyperlinks({ hyperlinks, pollingType, pollingId, rel }) {
         <PollingHyperlink pollingId={pollingId} pollingType={pollingType} />
       )}
     </Box>
-  );
+  )
 }
 
 Hyperlinks.fragments = {
   HyperlinkData,
-};
+}
 
-export default Hyperlinks;
+export default Hyperlinks

--- a/components/ListPageDisplays/ArticleCard.js
+++ b/components/ListPageDisplays/ArticleCard.js
@@ -9,6 +9,7 @@ import ListPageCard from './ListPageCard';
 import { highlightSections, HighlightFields } from 'lib/text';
 import { useHighlightStyles } from './utils';
 import cx from 'clsx';
+import Hyperlinks from 'components/Hyperlinks';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -99,7 +100,14 @@ const useStyles = makeStyles(theme => ({
  * @param {Highlights?} props.highlight - If given, display search snippet instead of reply text
  */
 function ArticleCard({ article, highlight = '' }) {
-  const { id, text, replyCount, replyRequestCount, createdAt } = article;
+  const {
+    id,
+    text,
+    replyCount,
+    replyRequestCount,
+    createdAt,
+    hyperlinks,
+  } = article;
   const classes = useStyles();
   const highlightClasses = useHighlightStyles();
 
@@ -124,13 +132,16 @@ function ArticleCard({ article, highlight = '' }) {
               </div>
             </div>
             <Thumbnail article={article} className={classes.attachment} />
-            {(text || highlight) && (
-              <ExpandableText className={classes.content} lineClamp={3}>
-                {highlight
-                  ? highlightSections(highlight, highlightClasses)
-                  : text}
-              </ExpandableText>
-            )}
+            <div className={classes.content}>
+              {(text || highlight) && (
+                <ExpandableText lineClamp={3}>
+                  {highlight
+                    ? highlightSections(highlight, highlightClasses)
+                    : text}
+                </ExpandableText>
+              )}
+              <Hyperlinks hyperlinks={hyperlinks} />
+            </div>
           </div>
         </ListPageCard>
       </a>
@@ -146,9 +157,13 @@ ArticleCard.fragments = {
       replyCount
       replyRequestCount
       createdAt
+      hyperlinks {
+        ...HyperlinkData
+      }
       ...ThumbnailArticleData
     }
     ${Thumbnail.fragments.ThumbnailArticleData}
+    ${Hyperlinks.fragments.HyperlinkData}
   `,
   Highlight: HighlightFields,
 };

--- a/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
+++ b/components/ListPageDisplays/__snapshots__/ListPageCards.stories.storyshot
@@ -96,25 +96,31 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                   }
                   className="makeStyles-attachment"
                 />
-                <ExpandableText
+                <div
                   className="makeStyles-content"
-                  lineClamp={3}
                 >
-                  <div
-                    className="makeStyles-content"
+                  <ExpandableText
+                    lineClamp={3}
                   >
-                    <div
-                      className="makeStyles-root"
-                      style={
-                        Object {
-                          "maxHeight": 42,
+                    <div>
+                      <div
+                        className="makeStyles-root"
+                        style={
+                          Object {
+                            "maxHeight": 42,
+                          }
                         }
-                      }
-                    >
-                      Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                      >
+                        Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                      </div>
                     </div>
-                  </div>
-                </ExpandableText>
+                  </ExpandableText>
+                  <Hyperlinks>
+                    <section
+                      className="MuiBox-root MuiBox-root makeStyles-root"
+                    />
+                  </Hyperlinks>
+                </div>
               </div>
             </article>
           </ListPageCard>
@@ -223,38 +229,20 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                   }
                   className="makeStyles-attachment"
                 />
-                <ExpandableText
+                <div
                   className="makeStyles-content"
-                  lineClamp={3}
                 >
-                  <div
-                    className="makeStyles-content"
+                  <ExpandableText
+                    lineClamp={3}
                   >
-                    <div
-                      className="makeStyles-root"
-                      style={
-                        Object {
-                          "maxHeight": 42,
+                    <div>
+                      <div
+                        className="makeStyles-root"
+                        style={
+                          Object {
+                            "maxHeight": 42,
+                          }
                         }
-                      }
-                    >
-                      <mark
-                        className="makeStyles-highlight"
-                        key="highlight-0"
-                      >
-                        Lorem ipsum
-                      </mark>
-                       dolor sit amet, consectetur adipiscing elit. 
-                      <mark
-                        className="makeStyles-highlight"
-                        key="highlight-1"
-                      >
-                        Mauris eu ex augue
-                      </mark>
-                      . Etiam posuere sagittis iaculis. Vestibulum sollicitudin nec felis a mollis. Phasellus ut est velit. Proin fermentum arcu ornare quam vulputate, vel eleifend velit ultrices. Fusce tincidunt vel urna at luctus.
-                      <section
-                        className="makeStyles-hyperlinks"
-                        key="hyperlink-section-0"
                       >
                         <mark
                           className="makeStyles-highlight"
@@ -262,18 +250,42 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                         >
                           Lorem ipsum
                         </mark>
-                         dolor sit amet 
+                         dolor sit amet, consectetur adipiscing elit. 
                         <mark
                           className="makeStyles-highlight"
                           key="highlight-1"
                         >
                           Mauris eu ex augue
                         </mark>
-                        . Etiam posuere sagittis iaculis.
-                      </section>
+                        . Etiam posuere sagittis iaculis. Vestibulum sollicitudin nec felis a mollis. Phasellus ut est velit. Proin fermentum arcu ornare quam vulputate, vel eleifend velit ultrices. Fusce tincidunt vel urna at luctus.
+                        <section
+                          className="makeStyles-hyperlinks"
+                          key="hyperlink-section-0"
+                        >
+                          <mark
+                            className="makeStyles-highlight"
+                            key="highlight-0"
+                          >
+                            Lorem ipsum
+                          </mark>
+                           dolor sit amet 
+                          <mark
+                            className="makeStyles-highlight"
+                            key="highlight-1"
+                          >
+                            Mauris eu ex augue
+                          </mark>
+                          . Etiam posuere sagittis iaculis.
+                        </section>
+                      </div>
                     </div>
-                  </div>
-                </ExpandableText>
+                  </ExpandableText>
+                  <Hyperlinks>
+                    <section
+                      className="MuiBox-root MuiBox-root makeStyles-root"
+                    />
+                  </Hyperlinks>
+                </div>
               </div>
             </article>
           </ListPageCard>
@@ -377,6 +389,15 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     src="https://placekitten.com/512/1000"
                   />
                 </Thumbnail>
+                <div
+                  className="makeStyles-content"
+                >
+                  <Hyperlinks>
+                    <section
+                      className="MuiBox-root MuiBox-root makeStyles-root"
+                    />
+                  </Hyperlinks>
+                </div>
               </div>
             </article>
           </ListPageCard>
@@ -480,6 +501,15 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     src="https://placekitten.com/2000/150"
                   />
                 </Thumbnail>
+                <div
+                  className="makeStyles-content"
+                >
+                  <Hyperlinks>
+                    <section
+                      className="MuiBox-root MuiBox-root makeStyles-root"
+                    />
+                  </Hyperlinks>
+                </div>
               </div>
             </article>
           </ListPageCard>
@@ -579,6 +609,15 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                 >
                   A video (Preview not supported yet)
                 </Thumbnail>
+                <div
+                  className="makeStyles-content"
+                >
+                  <Hyperlinks>
+                    <section
+                      className="MuiBox-root MuiBox-root makeStyles-root"
+                    />
+                  </Hyperlinks>
+                </div>
               </div>
             </article>
           </ListPageCard>
@@ -685,6 +724,15 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     src="https://drive.google.com/uc?id=1SQ9lc1-ghzw-SL6Dyb_UMN6hAPBAckvK&confirm=t"
                   />
                 </Thumbnail>
+                <div
+                  className="makeStyles-content"
+                >
+                  <Hyperlinks>
+                    <section
+                      className="MuiBox-root MuiBox-root makeStyles-root"
+                    />
+                  </Hyperlinks>
+                </div>
               </div>
             </article>
           </ListPageCard>
@@ -791,6 +839,15 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     src="https://drive.google.com/uc?id=1DczThMYTmGV3GvDCAU2EPnhsBwVcoFQi&confirm=t"
                   />
                 </Thumbnail>
+                <div
+                  className="makeStyles-content"
+                >
+                  <Hyperlinks>
+                    <section
+                      className="MuiBox-root MuiBox-root makeStyles-root"
+                    />
+                  </Hyperlinks>
+                </div>
               </div>
             </article>
           </ListPageCard>
@@ -893,6 +950,15 @@ exports[`Storyshots ListPageDisplays/ListPageCards Article Cards 1`] = `
                     src="https://drive.google.com/uc?id=1D-K8hVcOw7UNbu80uJkAYMJd1HilAFOp&confirm=t"
                   />
                 </Thumbnail>
+                <div
+                  className="makeStyles-content"
+                >
+                  <Hyperlinks>
+                    <section
+                      className="MuiBox-root MuiBox-root makeStyles-root"
+                    />
+                  </Hyperlinks>
+                </div>
               </div>
             </article>
           </ListPageCard>

--- a/components/ReportPage/__snapshots__/ActionButton.stories.storyshot
+++ b/components/ReportPage/__snapshots__/ActionButton.stories.storyshot
@@ -9,7 +9,7 @@ exports[`Storyshots ReportPage/ActionButton Default 1`] = `
   }
 >
   <button
-    className="MuiButtonBase-root-321 MuiButton-root-294 MuiButton-outlined-299 makeStyles-button"
+    className="MuiButtonBase-root-343 MuiButton-root-316 MuiButton-outlined-321 makeStyles-button"
     disabled={false}
     onBlur={[Function]}
     onDragLeave={[Function]}
@@ -31,13 +31,13 @@ exports[`Storyshots ReportPage/ActionButton Default 1`] = `
     type="button"
   >
     <span
-      className="MuiButton-label-295"
+      className="MuiButton-label-317"
     >
       Action button text
       <Arrow>
         <svg
           aria-hidden={true}
-          className="MuiSvgIcon-root-322"
+          className="MuiSvgIcon-root-344"
           focusable="false"
           viewBox="0 0 14 27"
         >
@@ -51,7 +51,7 @@ exports[`Storyshots ReportPage/ActionButton Default 1`] = `
       </Arrow>
     </span>
     <span
-      className="MuiTouchRipple-root-331"
+      className="MuiTouchRipple-root-353"
     >
       <TransitionGroup
         childFactory={[Function]}

--- a/components/__snapshots__/Hyperlinks.stories.storyshot
+++ b/components/__snapshots__/Hyperlinks.stories.storyshot
@@ -155,16 +155,11 @@ exports[`Storyshots Hyperlinks All Variants 1`] = `
         <article
           className="makeStyles-linkcard"
         >
-          <h1 />
           <div
             className="makeStyles-preview makeStyles-preview"
           >
             <p
-              className="summary"
-              title=""
-            />
-            <p
-              className="error"
+              className="makeStyles-error"
             >
               Cannot get data from URL
             </p>


### PR DESCRIPTION
# Issue

Closes #308: Show URL title in article list

<img width="415" alt="image" src="https://github.com/user-attachments/assets/7ab9f3b1-b4d5-4e76-b556-db279f64d42d" />

# Changes

- Add predefined `<Hyperlinks>` component to article list
- Modified `<Hyperlink>` to check `summary` and `title`'s existence before rendering it, which also make the error message align to the left when there's no summary available
- Use predefined styling for error message

(Before)
<img width="415" alt="image" src="https://github.com/user-attachments/assets/d81645db-bcc7-47c0-a237-bc4fe460a98a" />

(After)
<img width="415" alt="image" src="https://github.com/user-attachments/assets/14217ff3-fb3d-47f5-8c99-9811e42a0e05" />