### PR TITLE
Upgrade Hocuspocus provider v3 and yjs ecosystem

### DIFF
--- a/components/Collaborate/CollabEditor.js
+++ b/components/Collaborate/CollabEditor.js
@@ -4,6 +4,7 @@ import {
   ySyncPlugin,
   yCursorPlugin,
   yUndoPlugin,
+  initProseMirrorDoc,
   undo,
   redo,
 } from 'y-prosemirror';
@@ -102,10 +103,13 @@ const Editor = ({ provider, currentUser, className, innerRef, onUnmount }) => {
 
   const yXmlFragment = ydoc.get('prosemirror', Y.XmlFragment);
 
+  const { doc, mapping } = initProseMirrorDoc(yXmlFragment, schema);
+
   const [state, setState] = useProseMirror({
     schema,
+    doc,
     plugins: [
-      ySyncPlugin(yXmlFragment, { permanentUserData }),
+      ySyncPlugin(yXmlFragment, { permanentUserData, mapping }),
       yCursorPlugin(provider.awareness),
       yUndoPlugin(),
       keymap({

--- a/components/Collaborate/CollabHistory.js
+++ b/components/Collaborate/CollabHistory.js
@@ -1,6 +1,6 @@
 import { t } from 'ttag';
 import * as Y from 'yjs';
-import { ySyncPlugin, ySyncPluginKey } from 'y-prosemirror';
+import { ySyncPlugin, ySyncPluginKey, initProseMirrorDoc } from 'y-prosemirror';
 import { useProseMirror, ProseMirror } from 'use-prosemirror';
 import { schema } from './Schema';
 import { useState, useRef, useEffect, forwardRef, useCallback } from 'react';
@@ -164,11 +164,15 @@ const CustomModalContent = forwardRef(function CustomModalContent(
   });
   const versionList = getYdocData?.GetYdoc?.versions || [];
 
+  const { doc, mapping } = initProseMirrorDoc(yXmlFragment, schema);
+
   const [state, setState] = useProseMirror({
     schema,
+    doc,
     plugins: [
       ySyncPlugin(yXmlFragment, {
         permanentUserData,
+        mapping,
         onFirstRender,
       }),
     ],

--- a/next.config.js
+++ b/next.config.js
@@ -49,22 +49,9 @@ module.exports = {
         ],
       },
       {
-        // Langfuse SDK
-        test: /node_modules\/langfuse/,
+        // Langfuse SDK & yjs ecosystem use optional chaining & nullish coalescing
+        test: /node_modules[\\/](langfuse|yjs|y-prosemirror|y-protocols|lib0)/,
         type: 'javascript/auto', // https://stackoverflow.com/a/74957466/1582110
-        use: [
-          {
-            loader: 'babel-loader',
-            options: {
-              presets: ['@babel/preset-env'],
-            },
-          },
-        ],
-      },
-      {
-        // yjs ecosystem uses optional chaining & nullish coalescing
-        test: /node_modules\/(yjs|y-prosemirror|y-protocols|lib0)/,
-        type: 'javascript/auto',
         use: [
           {
             loader: 'babel-loader',

--- a/next.config.js
+++ b/next.config.js
@@ -60,6 +60,19 @@ module.exports = {
             },
           },
         ],
+      },
+      {
+        // yjs ecosystem uses optional chaining & nullish coalescing
+        test: /node_modules\/(yjs|y-prosemirror|y-protocols|lib0)/,
+        type: 'javascript/auto',
+        use: [
+          {
+            loader: 'babel-loader',
+            options: {
+              presets: ['@babel/preset-env'],
+            },
+          },
+        ],
       }
     );
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@apollo/react-hooks": "^3.0.1",
         "@apollo/react-ssr": "^3.0.1",
-        "@hocuspocus/provider": "^2.0.3",
+        "@hocuspocus/provider": "^3.4.4",
         "@material-ui/core": "^4.9.7",
         "@material-ui/icons": "^4.9.1",
         "@material-ui/lab": "^4.0.0-alpha.61",
@@ -54,8 +54,9 @@
         "rollbar": "^2.14.4",
         "ttag": "^1.7.22",
         "use-prosemirror": "^1.3.0",
-        "y-prosemirror": "^1.2.1",
-        "yjs": "^13.5.29"
+        "y-prosemirror": "^1.3.7",
+        "y-protocols": "^1.0.7",
+        "yjs": "^13.6.30"
       },
       "devDependencies": {
         "@apollo/react-testing": "^3.0.1",
@@ -3766,38 +3767,41 @@
       "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
     },
     "node_modules/@hocuspocus/common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-2.1.0.tgz",
-      "integrity": "sha512-K8f4TQfP5TJakGBKJR9bGg5EHM8QkM5zxjrT3iv0k/jvNF4M9gh0zFSJrCQgF55/tkLCvBCOSWMLPX9TSjlW5w==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-3.4.4.tgz",
+      "integrity": "sha512-RykIJ0tsHHMP4Xk+4UCbc7SO5LgGxGUSTdbh6anJEsaALAyqinf1Nn5HYuMjLPolAmsar1v++m9zufR09NLpXA==",
+      "license": "MIT",
       "dependencies": {
-        "lib0": "^0.2.47"
+        "lib0": "^0.2.87"
       }
     },
     "node_modules/@hocuspocus/provider": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/provider/-/provider-2.1.0.tgz",
-      "integrity": "sha512-Hg6OLlxt0RFrZ7pS6p2pnqWhxeqq4tRVcbyA34E8/Braj40S+q+H5+0UIYyXTLGknRrChcjIN/P51C8gGAA9sQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/provider/-/provider-3.4.4.tgz",
+      "integrity": "sha512-KbsMAfdYcIJD8eMU/5QnpXcSOvIWAcCNI33FSRSaKCIpYBFtAwkYIwWnZJmPZ8a1BMAtqQc+uvy9+UQf7GHnGQ==",
+      "license": "MIT",
       "dependencies": {
-        "@hocuspocus/common": "^2.1.0",
+        "@hocuspocus/common": "^3.4.4",
         "@lifeomic/attempt": "^3.0.2",
-        "lib0": "^0.2.47",
-        "ws": "^7.5.9"
+        "lib0": "^0.2.87",
+        "ws": "^8.17.1"
       },
       "peerDependencies": {
-        "y-protocols": "^1.0.5",
-        "yjs": "^13.5.29"
+        "y-protocols": "^1.0.6",
+        "yjs": "^13.6.8"
       }
     },
     "node_modules/@hocuspocus/provider/node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "license": "MIT",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -4486,20 +4490,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@jest/schemas": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.0.2.tgz",
-      "integrity": "sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@sinclair/typebox": "^0.23.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
       }
     },
     "node_modules/@jest/source-map": {
@@ -5611,14 +5601,6 @@
       "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
       "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
       "dev": true
-    },
-    "node_modules/@sinclair/typebox": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.4.tgz",
-      "integrity": "sha512-0/WqSvpVbCBAV1yPeko7eAczKbs78dNVAaX14quVlwOb2wxfKuXCx91h4NrEfkYK9zEnyVSW4JVI/trP3iS+Qg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
@@ -11706,14 +11688,6 @@
       "engines": {
         "node": ">=6.0"
       }
-    },
-    "node_modules/ci-info": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "node_modules/cipher-base": {
       "version": "1.0.4",
@@ -18964,6 +18938,7 @@
       "version": "0.2.5",
       "resolved": "https://registry.npmjs.org/isomorphic.js/-/isomorphic.js-0.2.5.tgz",
       "integrity": "sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==",
+      "license": "MIT",
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
@@ -20095,17 +20070,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-get-type": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
-      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
     "node_modules/jest-haste-map": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
@@ -20447,28 +20411,6 @@
         "node": ">= 10.14.2"
       }
     },
-    "node_modules/jest-resolve": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.0.2.tgz",
-      "integrity": "sha512-4smZQ+Z4bzRNAXmj2HSrDYOAVar/SBDClUWxDJrz3BHbw+URXGAPenziWIShmybBlcRnX0lVCs43UiB7+Fh+lg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.0.2",
-        "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^28.0.2",
-        "jest-validate": "^28.0.2",
-        "resolve": "^1.20.0",
-        "resolve.exports": "^1.1.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
     "node_modules/jest-resolve-dependencies": {
       "version": "26.6.3",
       "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-26.6.3.tgz",
@@ -20481,153 +20423,6 @@
       },
       "engines": {
         "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/@jest/types": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz",
-      "integrity": "sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jest/schemas": "^28.0.2",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/@types/yargs": {
-      "version": "17.0.10",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
-      "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/jest-haste-map": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.0.2.tgz",
-      "integrity": "sha512-EokdL7l5uk4TqWGawwrIt8w3tZNcbeiRxmKGEURf42pl+/rWJy3sCJlon5HBhJXZTW978jk6600BLQOI7i25Ig==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "^28.0.2",
-        "@types/graceful-fs": "^4.1.3",
-        "@types/node": "*",
-        "anymatch": "^3.0.3",
-        "fb-watchman": "^2.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-regex-util": "^28.0.2",
-        "jest-util": "^28.0.2",
-        "jest-worker": "^28.0.2",
-        "micromatch": "^4.0.4",
-        "walker": "^1.0.7"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      },
-      "optionalDependencies": {
-        "fsevents": "^2.3.2"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/jest-regex-util": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
-      "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/jest-util": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.0.2.tgz",
-      "integrity": "sha512-EVdpIRCC8lzqhp9A0u0aAKlsFIzufK6xKxNK7awsnebTdOP4hpyQW5o6Ox2qPl8gbeUKYF+POLyItaND53kpGA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "^28.0.2",
-        "@types/node": "*",
-        "chalk": "^4.0.0",
-        "ci-info": "^3.2.0",
-        "graceful-fs": "^4.2.9",
-        "picomatch": "^2.2.3"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/jest-runner": {
@@ -21280,168 +21075,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-validate": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.0.2.tgz",
-      "integrity": "sha512-nr0UOvCTtxP0YPdsk01Gk7e7c0xIiEe2nncAe3pj0wBfUvAykTVrMrdeASlAJnlEQCBuwN/GF4hKoCzbkGNCNw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jest/types": "^28.0.2",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^28.0.2",
-        "leven": "^3.1.0",
-        "pretty-format": "^28.0.2"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/@jest/types": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz",
-      "integrity": "sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jest/schemas": "^28.0.2",
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^17.0.8",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/@types/yargs": {
-      "version": "17.0.10",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
-      "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/yargs-parser": "*"
-      }
-    },
-    "node_modules/jest-validate/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-validate/node_modules/camelcase": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/jest-validate/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/jest-validate/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-validate/node_modules/pretty-format": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.0.2.tgz",
-      "integrity": "sha512-UmGZ1IERwS3yY35LDMTaBUYI1w4udZDdJGGT/DqQeKG9ZLDn7/K2Jf/JtYSRiHCCKMHvUA+zsEGSmHdpaVp1yw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@jest/schemas": "^28.0.2",
-        "ansi-regex": "^5.0.1",
-        "ansi-styles": "^5.0.0",
-        "react-is": "^18.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/jest-validate/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/jest-validate/node_modules/react-is": {
-      "version": "18.1.0",
-      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
-      "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/jest-validate/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-watcher": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
@@ -21510,50 +21143,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/jest-worker": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.0.2.tgz",
-      "integrity": "sha512-pijNxfjxT0tGAx+8+OzZ+eayVPCwy/rsZFhebmC0F4YnXu1EHPEPxg7utL3m5uX3EaFH1/jwDxGa1EbjJCST2g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "engines": {
-        "node": "^12.13.0 || ^14.15.0 || ^16.10.0 || >=17.0.0"
-      }
-    },
-    "node_modules/jest-worker/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-worker/node_modules/supports-color": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/js-cookie": {
@@ -22153,13 +21742,15 @@
       }
     },
     "node_modules/lib0": {
-      "version": "0.2.78",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.78.tgz",
-      "integrity": "sha512-SV2nU43/6eaYnGH3l0lg2wg1ziB/TH3sAd2E8quXPGwrqo+aX98SNT2ZKucpUr5B8A52jD7ZMjAl+r87Fa/bLQ==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
+      "license": "MIT",
       "dependencies": {
         "isomorphic.js": "^0.2.4"
       },
       "bin": {
+        "0ecdsa-generate-keypair": "bin/0ecdsa-generate-keypair.js",
         "0gentesthtml": "bin/gentesthtml.js",
         "0serve": "bin/0serve.js"
       },
@@ -28265,17 +27856,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/resolve.exports": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
-      "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -32396,7 +31976,6 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "deprecated": "fsevents 1 will break on node v14+ and could be using insecure binaries. Upgrade to fsevents 2.",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -33331,11 +32910,16 @@
       }
     },
     "node_modules/y-prosemirror": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.1.tgz",
-      "integrity": "sha512-czMBfB1eL2awqmOSxQM8cS/fsUOGE6fjvyPLInrh4crPxFiw67wDpwIW+EGBYKRa04sYbS0ScGj7ZgvWuDrmBQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.7.tgz",
+      "integrity": "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==",
+      "license": "MIT",
       "dependencies": {
-        "lib0": "^0.2.42"
+        "lib0": "^0.2.109"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
@@ -33350,16 +32934,23 @@
       }
     },
     "node_modules/y-protocols": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.5.tgz",
-      "integrity": "sha512-Wil92b7cGk712lRHDqS4T90IczF6RkcvCwAD0A2OPg+adKmOe+nOiT/N2hvpQIWS3zfjmtL4CPaH5sIW1Hkm/A==",
-      "peer": true,
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
+      "license": "MIT",
       "dependencies": {
-        "lib0": "^0.2.42"
+        "lib0": "^0.2.85"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=8.0.0"
       },
       "funding": {
         "type": "GitHub Sponsors ❤",
         "url": "https://github.com/sponsors/dmonad"
+      },
+      "peerDependencies": {
+        "yjs": "^13.0.0"
       }
     },
     "node_modules/y18n": {
@@ -33556,11 +33147,12 @@
       }
     },
     "node_modules/yjs": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.2.tgz",
-      "integrity": "sha512-shFc4JI8Hr3NqKYlS09xX6lyQwU3LvQlOXEkHK2aBa1T/luNLf0qHtoujgb9pRPxhIK0uevobHhDw0+AET1Vkw==",
+      "version": "13.6.30",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.30.tgz",
+      "integrity": "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==",
+      "license": "MIT",
       "dependencies": {
-        "lib0": "^0.2.74"
+        "lib0": "^0.2.99"
       },
       "engines": {
         "node": ">=16.0.0",
@@ -36428,28 +36020,28 @@
       "integrity": "sha512-gfta+H8aziZsm8pZa0vj04KO6biEiisppNgA1kbJvFrrWu9Vm7eaUEy76DIxsuTaWvti5fkJVhllWc6ZTE+Mdw=="
     },
     "@hocuspocus/common": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-2.1.0.tgz",
-      "integrity": "sha512-K8f4TQfP5TJakGBKJR9bGg5EHM8QkM5zxjrT3iv0k/jvNF4M9gh0zFSJrCQgF55/tkLCvBCOSWMLPX9TSjlW5w==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/common/-/common-3.4.4.tgz",
+      "integrity": "sha512-RykIJ0tsHHMP4Xk+4UCbc7SO5LgGxGUSTdbh6anJEsaALAyqinf1Nn5HYuMjLPolAmsar1v++m9zufR09NLpXA==",
       "requires": {
-        "lib0": "^0.2.47"
+        "lib0": "^0.2.87"
       }
     },
     "@hocuspocus/provider": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@hocuspocus/provider/-/provider-2.1.0.tgz",
-      "integrity": "sha512-Hg6OLlxt0RFrZ7pS6p2pnqWhxeqq4tRVcbyA34E8/Braj40S+q+H5+0UIYyXTLGknRrChcjIN/P51C8gGAA9sQ==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/@hocuspocus/provider/-/provider-3.4.4.tgz",
+      "integrity": "sha512-KbsMAfdYcIJD8eMU/5QnpXcSOvIWAcCNI33FSRSaKCIpYBFtAwkYIwWnZJmPZ8a1BMAtqQc+uvy9+UQf7GHnGQ==",
       "requires": {
-        "@hocuspocus/common": "^2.1.0",
+        "@hocuspocus/common": "^3.4.4",
         "@lifeomic/attempt": "^3.0.2",
-        "lib0": "^0.2.47",
-        "ws": "^7.5.9"
+        "lib0": "^0.2.87",
+        "ws": "^8.17.1"
       },
       "dependencies": {
         "ws": {
-          "version": "7.5.9",
-          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+          "version": "8.20.0",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+          "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
           "requires": {}
         }
       }
@@ -36980,17 +36572,6 @@
             }
           }
         }
-      }
-    },
-    "@jest/schemas": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.0.2.tgz",
-      "integrity": "sha512-YVDJZjd4izeTDkij00vHHAymNXQ6WWsdChFRK86qck6Jpr3DCL5W3Is3vslviRlP+bLuMYRLbdp98amMvqudhA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@sinclair/typebox": "^0.23.3"
       }
     },
     "@jest/source-map": {
@@ -37791,14 +37372,6 @@
       "resolved": "https://registry.npmjs.org/@repeaterjs/repeater/-/repeater-3.0.4.tgz",
       "integrity": "sha512-AW8PKd6iX3vAZ0vA43nOUOnbq/X5ihgU+mSXXqunMkeQADGiqw/PY0JNeYtD5sr0PAy51YPgAPbDoeapv9r8WA==",
       "dev": true
-    },
-    "@sinclair/typebox": {
-      "version": "0.23.4",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.23.4.tgz",
-      "integrity": "sha512-0/WqSvpVbCBAV1yPeko7eAczKbs78dNVAaX14quVlwOb2wxfKuXCx91h4NrEfkYK9zEnyVSW4JVI/trP3iS+Qg==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "@sinonjs/commons": {
       "version": "1.8.3",
@@ -42503,14 +42076,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.3.tgz",
       "integrity": "sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg=="
-    },
-    "ci-info": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.3.0.tgz",
-      "integrity": "sha512-riT/3vI5YpVH6/qomlDnJow6TBee2PBKSEpx3O32EGPYbWGIRsIlGRms3Sm74wYE1JMo8RnO04Hb12+v1J5ICw==",
-      "dev": true,
-      "optional": true,
-      "peer": true
     },
     "cipher-base": {
       "version": "1.0.4",
@@ -49090,14 +48655,6 @@
         }
       }
     },
-    "jest-get-type": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
-      "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "jest-haste-map": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-26.6.2.tgz",
@@ -49356,142 +48913,6 @@
       "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-26.0.0.tgz",
       "integrity": "sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==",
       "dev": true
-    },
-    "jest-resolve": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-28.0.2.tgz",
-      "integrity": "sha512-4smZQ+Z4bzRNAXmj2HSrDYOAVar/SBDClUWxDJrz3BHbw+URXGAPenziWIShmybBlcRnX0lVCs43UiB7+Fh+lg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "chalk": "^4.0.0",
-        "graceful-fs": "^4.2.9",
-        "jest-haste-map": "^28.0.2",
-        "jest-pnp-resolver": "^1.2.2",
-        "jest-util": "^28.0.2",
-        "jest-validate": "^28.0.2",
-        "resolve": "^1.20.0",
-        "resolve.exports": "^1.1.0",
-        "slash": "^3.0.0"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz",
-          "integrity": "sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jest/schemas": "^28.0.2",
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^17.0.8",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "17.0.10",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
-          "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "jest-haste-map": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-28.0.2.tgz",
-          "integrity": "sha512-EokdL7l5uk4TqWGawwrIt8w3tZNcbeiRxmKGEURf42pl+/rWJy3sCJlon5HBhJXZTW978jk6600BLQOI7i25Ig==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jest/types": "^28.0.2",
-            "@types/graceful-fs": "^4.1.3",
-            "@types/node": "*",
-            "anymatch": "^3.0.3",
-            "fb-watchman": "^2.0.0",
-            "fsevents": "^2.3.2",
-            "graceful-fs": "^4.2.9",
-            "jest-regex-util": "^28.0.2",
-            "jest-util": "^28.0.2",
-            "jest-worker": "^28.0.2",
-            "micromatch": "^4.0.4",
-            "walker": "^1.0.7"
-          }
-        },
-        "jest-regex-util": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-28.0.2.tgz",
-          "integrity": "sha512-4s0IgyNIy0y9FK+cjoVYoxamT7Zeo7MhzqRGx7YDYmaQn1wucY9rotiGkBzzcMXTtjrCAP/f7f+E0F7+fxPNdw==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "jest-util": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.0.2.tgz",
-          "integrity": "sha512-EVdpIRCC8lzqhp9A0u0aAKlsFIzufK6xKxNK7awsnebTdOP4hpyQW5o6Ox2qPl8gbeUKYF+POLyItaND53kpGA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jest/types": "^28.0.2",
-            "@types/node": "*",
-            "chalk": "^4.0.0",
-            "ci-info": "^3.2.0",
-            "graceful-fs": "^4.2.9",
-            "picomatch": "^2.2.3"
-          }
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
     },
     "jest-resolve-dependencies": {
       "version": "26.6.3",
@@ -50009,133 +49430,6 @@
         }
       }
     },
-    "jest-validate": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-28.0.2.tgz",
-      "integrity": "sha512-nr0UOvCTtxP0YPdsk01Gk7e7c0xIiEe2nncAe3pj0wBfUvAykTVrMrdeASlAJnlEQCBuwN/GF4hKoCzbkGNCNw==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@jest/types": "^28.0.2",
-        "camelcase": "^6.2.0",
-        "chalk": "^4.0.0",
-        "jest-get-type": "^28.0.2",
-        "leven": "^3.1.0",
-        "pretty-format": "^28.0.2"
-      },
-      "dependencies": {
-        "@jest/types": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.0.2.tgz",
-          "integrity": "sha512-hi3jUdm9iht7I2yrV5C4s3ucCJHUP8Eh3W6rQ1s4n/Qw9rQgsda4eqCt+r3BKRi7klVmZfQlMx1nGlzNMP2d8A==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jest/schemas": "^28.0.2",
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^17.0.8",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/yargs": {
-          "version": "17.0.10",
-          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.10.tgz",
-          "integrity": "sha512-gmEaFwpj/7f/ROdtIlci1R1VYU1J4j95m8T+Tj3iBgiBFKg1foE/PSl93bBd5T9LDXNPo8UlNN6W0qwD8O5OaA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@types/yargs-parser": "*"
-          }
-        },
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "camelcase": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "pretty-format": {
-          "version": "28.0.2",
-          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.0.2.tgz",
-          "integrity": "sha512-UmGZ1IERwS3yY35LDMTaBUYI1w4udZDdJGGT/DqQeKG9ZLDn7/K2Jf/JtYSRiHCCKMHvUA+zsEGSmHdpaVp1yw==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "@jest/schemas": "^28.0.2",
-            "ansi-regex": "^5.0.1",
-            "ansi-styles": "^5.0.0",
-            "react-is": "^18.0.0"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-              "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-              "dev": true,
-              "optional": true,
-              "peer": true
-            }
-          }
-        },
-        "react-is": {
-          "version": "18.1.0",
-          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
-          "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
     "jest-watcher": {
       "version": "26.6.2",
       "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-26.6.2.tgz",
@@ -50181,40 +49475,6 @@
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
-          }
-        }
-      }
-    },
-    "jest-worker": {
-      "version": "28.0.2",
-      "resolved": "https://registry.npmjs.org/jest-worker/-/jest-worker-28.0.2.tgz",
-      "integrity": "sha512-pijNxfjxT0tGAx+8+OzZ+eayVPCwy/rsZFhebmC0F4YnXu1EHPEPxg7utL3m5uX3EaFH1/jwDxGa1EbjJCST2g==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "requires": {
-        "@types/node": "*",
-        "merge-stream": "^2.0.0",
-        "supports-color": "^8.0.0"
-      },
-      "dependencies": {
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true,
-          "optional": true,
-          "peer": true
-        },
-        "supports-color": {
-          "version": "8.1.1",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
-          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -50714,9 +49974,9 @@
       }
     },
     "lib0": {
-      "version": "0.2.78",
-      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.78.tgz",
-      "integrity": "sha512-SV2nU43/6eaYnGH3l0lg2wg1ziB/TH3sAd2E8quXPGwrqo+aX98SNT2ZKucpUr5B8A52jD7ZMjAl+r87Fa/bLQ==",
+      "version": "0.2.117",
+      "resolved": "https://registry.npmjs.org/lib0/-/lib0-0.2.117.tgz",
+      "integrity": "sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==",
       "requires": {
         "isomorphic.js": "^0.2.4"
       }
@@ -55534,14 +54794,6 @@
         }
       }
     },
-    "resolve.exports": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
-      "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
-      "dev": true,
-      "optional": true,
-      "peer": true
-    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -58826,7 +58078,6 @@
           "version": "1.2.13",
           "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
           "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
-          "dev": true,
           "optional": true,
           "requires": {
             "bindings": "^1.5.0",
@@ -59582,20 +58833,19 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     },
     "y-prosemirror": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.2.1.tgz",
-      "integrity": "sha512-czMBfB1eL2awqmOSxQM8cS/fsUOGE6fjvyPLInrh4crPxFiw67wDpwIW+EGBYKRa04sYbS0ScGj7ZgvWuDrmBQ==",
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/y-prosemirror/-/y-prosemirror-1.3.7.tgz",
+      "integrity": "sha512-NpM99WSdD4Fx4if5xOMDpPtU3oAmTSjlzh5U4353ABbRHl1HtAFUx6HlebLZfyFxXN9jzKMDkVbcRjqOZVkYQg==",
       "requires": {
-        "lib0": "^0.2.42"
+        "lib0": "^0.2.109"
       }
     },
     "y-protocols": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.5.tgz",
-      "integrity": "sha512-Wil92b7cGk712lRHDqS4T90IczF6RkcvCwAD0A2OPg+adKmOe+nOiT/N2hvpQIWS3zfjmtL4CPaH5sIW1Hkm/A==",
-      "peer": true,
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/y-protocols/-/y-protocols-1.0.7.tgz",
+      "integrity": "sha512-YSVsLoXxO67J6eE/nV4AtFtT3QEotZf5sK5BHxFBXso7VDUT3Tx07IfA6hsu5Q5OmBdMkQVmFZ9QOA7fikWvnw==",
       "requires": {
-        "lib0": "^0.2.42"
+        "lib0": "^0.2.85"
       }
     },
     "y18n": {
@@ -59748,11 +58998,11 @@
       "dev": true
     },
     "yjs": {
-      "version": "13.6.2",
-      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.2.tgz",
-      "integrity": "sha512-shFc4JI8Hr3NqKYlS09xX6lyQwU3LvQlOXEkHK2aBa1T/luNLf0qHtoujgb9pRPxhIK0uevobHhDw0+AET1Vkw==",
+      "version": "13.6.30",
+      "resolved": "https://registry.npmjs.org/yjs/-/yjs-13.6.30.tgz",
+      "integrity": "sha512-vv/9h42eCMC81ZHDFswuu/MKzkl/vyq1BhaNGfHyOonwlG4CJbQF4oiBBJPvfdeCt/PlVDWh7Nov9D34YY09uQ==",
       "requires": {
-        "lib0": "^0.2.74"
+        "lib0": "^0.2.99"
       }
     },
     "ylru": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "@apollo/react-hooks": "^3.0.1",
     "@apollo/react-ssr": "^3.0.1",
-    "@hocuspocus/provider": "^2.0.3",
+    "@hocuspocus/provider": "^3.4.4",
     "@material-ui/core": "^4.9.7",
     "@material-ui/icons": "^4.9.1",
     "@material-ui/lab": "^4.0.0-alpha.61",
@@ -66,8 +66,9 @@
     "rollbar": "^2.14.4",
     "ttag": "^1.7.22",
     "use-prosemirror": "^1.3.0",
-    "y-prosemirror": "^1.2.1",
-    "yjs": "^13.5.29"
+    "y-prosemirror": "^1.3.7",
+    "y-protocols": "^1.0.7",
+    "yjs": "^13.6.30"
   },
   "devDependencies": {
     "@apollo/react-testing": "^3.0.1",


### PR DESCRIPTION
## Summary
- Upgrade @hocuspocus/provider from v2 to v3.4.4
- Upgrade y-prosemirror (1.2.1 → 1.3.7), yjs (13.5.29 → 13.6.30), add y-protocols 1.0.7
- Fix Y.js data not rendering in ProseMirror by using `initProseMirrorDoc`

## Changes
### Dependencies
- `@hocuspocus/provider`: ^2.0.3 → ^3.4.4
- `y-prosemirror`: ^1.2.1 → ^1.3.7
- `yjs`: ^13.5.29 → ^13.6.30
- Added `y-protocols`: ^1.0.7

### ProseMirror initialization fix
- Use `initProseMirrorDoc(yXmlFragment, schema)` to get initial `doc` and `mapping`
- Pass `doc` to `useProseMirror` and `mapping` to `ySyncPlugin`
- Fixes issue where Y.js collaborative data was not rendering in ProseMirror editor

### Build config
- Add babel-loader rule for yjs ecosystem packages (`yjs`, `y-prosemirror`, `y-protocols`, `lib0`) that use optional chaining & nullish coalescing