### PR TITLE
fix: disable PM2 log files to prevent disk exhaustion

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -5,7 +5,8 @@ module.exports = {
       script: 'server.js',
       instances: process.env.WEB_CONCURRENCY ? +process.env.WEB_CONCURRENCY : 1,
       exec_mode: 'cluster',
-      log_date_format: 'YYYY-MM-DD HH:mm Z',
+      out_file: '/dev/null',
+      error_file: '/dev/null',
     },
   ],
 };


### PR DESCRIPTION
## 問題

PM2 預設行為是把 app 的 stdout/stderr 同時寫到兩個地方：
1. Docker stdout → GCP Cloud Logging（正確）
2. `/root/.pm2/logs/` 檔案（重複，且沒有 size limit）

這導致 production GCE 上的 PM2 log 無限累積，造成磁碟爆滿：

| Container | PM2 log 佔用 |
|-----------|-------------|
| `site-en` | **3.5 GB** |
| `site-ja` | **1.3 GB** |

兩個 error log 都是相同的 warning 每 30 分鐘重複一次（PM2 定期重啟）：
```
Warning: fragment with name ArticleWithCategories already exists.
Langfuse public key not passed to constructor ...
Yjs was already imported ...
```

發現時 GCE 磁碟使用率已達 **91%**（44 GB / 48 GB）。

## 修法

在 `ecosystem.config.js` 加上 `out_file: '/dev/null'` 和 `error_file: '/dev/null'`，讓 PM2 只走 Docker stdout，不再寫本地檔案。

這與 `rumors-api` 和 `rumors-line-bot` 已採用的[作法](https://github.com/cofacts/rumors-api/blob/master/ecosystem.config.js#L11-L12)相同。

🤖 Generated with [Claude Code](https://claude.com/claude-code)